### PR TITLE
Add workflow to publish extension on GitHub release

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,7 +3,11 @@ name: Build Extension
 on:
   workflow_dispatch:
 
+  push:
+    branches: ["main"]
+
   pull_request:
+    branches: ["main"]
 
 jobs:
   build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+name: Release Extension
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  release:
+    name: Release
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20.x]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install Extension Dependencies
+        run: |
+          npm install
+          npm install -g vsce
+
+      - name: Build Extension
+        run: vsce package
+
+      - name: Publish to Marketplace
+        run: vsce publish -p $PUBLISHER_TOKEN
+        env:
+          PUBLISHER_TOKEN: ${{ secrets.PUBLISHER_TOKEN }}


### PR DESCRIPTION
@christianlarsen Glad to see the other PR got in. As requested, here is a simple release workflow to automate the publishing of the extension. With this workflow, all you need to do is bump the `version` number in the `package.json` and then create a GitHub release. This will trigger the workflow and publish to the marketplace!

**To use this workflow, you will need to setup a GitHub secret in your repository settings called `PUBLISHER_TOKEN`.**

I also updated the workflow triggers for the other PR workflow so that it is run when changes are pushed to main. Although it is recommended to use PRs, in case you do push directly to `main` (which I also tend to do sometimes as well) this will help you know whether what is on `main` passes the build.