### PR TITLE
Feat:extension in activity bar w/icon // extension can be used together with IBMi Renderer // Fixes: problems adding new fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,3 +78,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [0.4.3] - 2025-09-04
 ### Fixes
 - Now only the field length is requested when the type requires it.
+
+## [0.5.0] - 2025-09-06
+### Added
+- The extension can be launched from a separate icon in the activity bar.
+- The extension remembers the last opened DDS display file source and allows you to use other extensions simultaneously (for example, you can use IBM i Renderer without losing the DDS structure on the screen).
+### Fixes
+- Problems adding a new field.

--- a/README.md
+++ b/README.md
@@ -94,8 +94,10 @@ Some features may not work as expected. Please leave an issue if something is no
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**0.4.3** - 2025-09-04
-- Fixes: Now only the field length is requested when the type requires it.
+**0.5.0** - 2025-09-06
+- New: The extension can be launched from a separate icon in the activity bar.
+- New: The extension remembers the last opened DDS display file source and allows you to use other extensions simultaneously (for example, you can use IBM i Renderer without losing the DDS structure on the screen).
+- Fixes: Problems adding new fields.
 
 ---
 

--- a/assets/dds_extension_icon_activity.svg
+++ b/assets/dds_extension_icon_activity.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <!-- Hexagon outline -->
+  <path d="M12 2 L20 6.5 L20 17.5 L12 22 L4 17.5 L4 6.5 Z" 
+        stroke="currentColor" 
+        stroke-width="1.5" 
+        fill="none"/>
+  
+  <!-- DDS Text -->
+  <text x="12" 
+        y="13.5" 
+        font-family="Arial, sans-serif" 
+        font-size="7" 
+        font-weight="bold" 
+        text-anchor="middle" 
+        fill="currentColor">DDS</text>
+</svg>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"
@@ -41,11 +41,22 @@
   "main": "./out/extension.js",
   "preview": true,
   "contributes": {
-    "views": {
-      "explorer": [
+    "viewsContainers": {
+      "activitybar": [
         {
-          "id": "ddsStructureView",
-          "name": "DSPF Structure"
+          "id" : "dspf-edit",
+          "title" : "DSPF Structure",
+          "icon" : "assets/dds_extension_icon_activity.svg",
+          "when" : "true"
+        }
+      ]
+    },
+    "views": {
+      "dspf-edit" : [
+        {
+          "id" : "dspf-edit.schema-view",
+          "name" : "Definition",
+          "when" : "true"
         }
       ]
     },
@@ -139,107 +150,107 @@
       "view/item/context": [
         {
           "command": "dspf-edit.edit-constant",
-          "when": "view == ddsStructureView && viewItem == constant",
+          "when": "view == dspf-edit.schema-view && viewItem == constant",
           "group": "fields_constants_navigation1@1"
         },
         {
           "command": "dspf-edit.edit-field",
-          "when": "view == ddsStructureView && viewItem == field",
+          "when": "view == dspf-edit.schema-view && viewItem == field",
           "group": "fields_constants_navigation1@1"
         },
         {
           "command": "dspf-edit.center",
-          "when": "view == ddsStructureView && (viewItem == constant || viewItem == field)",
+          "when": "view == dspf-edit.schema-view && (viewItem == constant || viewItem == field)",
           "group": "fields_constants_navigation2@2"
         },
         {
           "command": "dspf-edit.change-position",
-          "when": "view == ddsStructureView && (viewItem == constant || viewItem == field)",
+          "when": "view == dspf-edit.schema-view && (viewItem == constant || viewItem == field)",
           "group": "fields_constants_navigation2@3"
         },
         {
           "command": "dspf-edit.add-color",
-          "when": "view == ddsStructureView && (viewItem == constant || viewItem == field)",
+          "when": "view == dspf-edit.schema-view && (viewItem == constant || viewItem == field)",
           "group": "fields_constants_navigation3@1"
         },
         {
           "command": "dspf-edit.add-attribute",
-          "when": "view == ddsStructureView && (viewItem == constant || viewItem == field)",
+          "when": "view == dspf-edit.schema-view && (viewItem == constant || viewItem == field)",
           "group": "fields_constants_navigation3@2"
         },
         {
           "command": "dspf-edit.add-validity-check",
-          "when": "view == ddsStructureView && viewItem == field",
+          "when": "view == dspf-edit.schema-view && viewItem == field",
           "group": "fields_constants_navigation3@3"
         },
         {
           "command": "dspf-edit.add-editing-keywords",
-          "when": "view == ddsStructureView && viewItem == field",
+          "when": "view == dspf-edit.schema-view && viewItem == field",
           "group": "fields_constants_navigation3@4"
         },
         {
           "command": "dspf-edit.add-error-message",
-          "when": "view == ddsStructureView && viewItem == field",
+          "when": "view == dspf-edit.schema-view && viewItem == field",
           "group": "fields_constants_navigation3@5"
         },
         {
           "command": "dspf-edit.add-indicators",
-          "when": "view == ddsStructureView && (viewItem == constant || viewItem == field)",
+          "when": "view == dspf-edit.schema-view && (viewItem == constant || viewItem == field)",
           "group": "fields_constants_navigation3@6"
         },
         {
           "command": "dspf-edit.add-indicators",
-          "when": "view == ddsStructureView && (viewItem == constantAttribute || viewItem === fieldAttribute)",
+          "when": "view == dspf-edit.schema-view && (viewItem == constantAttribute || viewItem === fieldAttribute)",
           "group": "attributes_navigation0@1"
         },
         {
           "command": "dspf-edit.window-resize",
-          "when": "view == ddsStructureView && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem == record",
           "group": "records_navigation1@0"
         },
         {
           "command": "dspf-edit.copy-record",
-          "when": "view == ddsStructureView && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem == record",
           "group": "records_navigation1@1"
         },
         {
           "command": "dspf-edit.delete-record",
-          "when": "view == ddsStructureView && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem == record",
           "group": "records_navigation1@2"
         },
         {
           "command": "dspf-edit.add-buttons",
-          "when": "view == ddsStructureView && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem == record",
           "group": "records_navigation2@1"
         },
         {
           "command": "dspf-edit.add-key",
-          "when": "view == ddsStructureView && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem == record",
           "group": "records_navigation3@1"
         },
         {
           "command": "dspf-edit.new-record",
-          "when": "view == ddsStructureView && (viewItem == file || viewItem == group)",
+          "when": "view == dspf-edit.schema-view && (viewItem == file || viewItem == group)",
           "group": "file_navigation1@1"
         },
         {
           "command": "dspf-edit.add-constant",
-          "when": "view == ddsStructureView && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem == record",
           "group": "records_navigation0@1"
         },
         {
           "command": "dspf-edit.add-field",
-          "when": "view == ddsStructureView && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem == record",
           "group": "records_navigation0@2"
         },
         {
           "command": "dspf-edit.add-key",
-          "when": "view == ddsStructureView && viewItem == file",
+          "when": "view == dspf-edit.schema-view && viewItem == file",
           "group": "file_navigation2@1"
         },
         {
           "command": "dspf-edit.fill-constant",
-          "when": "view == ddsStructureView && viewItem == constant",
+          "when": "view == dspf-edit.schema-view && viewItem == constant",
           "group": "fields_constants_navigation4@0"
         }
       ]

--- a/src/dspf-edit.add-buttons.ts
+++ b/src/dspf-edit.add-buttons.ts
@@ -7,6 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from './dspf-edit.providers';
 import { getRecordSize, fieldsPerRecords, DdsSize, getDefaultSize } from './dspf-edit.model';
+import { lastDdsDocument, lastDdsEditor } from './extension';
 
 // COMMAND REGISTRATION
 
@@ -32,12 +33,13 @@ export function addButtons(context: vscode.ExtensionContext): void {
  */
 async function handleAddButtonsCommand(node: DdsNode): Promise<void> {
     try {
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            vscode.window.showErrorMessage('No active editor found.');
+        const editor = lastDdsEditor;
+        const document = editor?.document ?? lastDdsDocument;
+        if (!document || !editor) {
+            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
-
+        
         // Validate that the node is a record
         if (node.ddsElement.kind !== 'record') {
             vscode.window.showWarningMessage('Buttons can only be added to records.');

--- a/src/dspf-edit.add-editing-keywords.ts
+++ b/src/dspf-edit.add-editing-keywords.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import { DdsNode } from './dspf-edit.providers';
 import { fieldsPerRecords } from './dspf-edit.model';
 import { isAttributeLine, findElementInsertionPoint } from './dspf-edit.helper';
+import { lastDdsDocument, lastDdsEditor } from './extension';
 
 // INTERFACES AND TYPES
 
@@ -49,9 +50,10 @@ export function editingKeywords(context: vscode.ExtensionContext): void {
  */
 async function handleEditingKeywordsCommand(node: DdsNode): Promise<void> {
     try {
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            vscode.window.showErrorMessage('No active editor found.');
+        const editor = lastDdsEditor;
+        const document = editor?.document ?? lastDdsDocument;
+        if (!document || !editor) {
+            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.add-error-messages.ts
+++ b/src/dspf-edit.add-error-messages.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import { DdsNode } from './dspf-edit.providers';
 import { fieldsPerRecords } from './dspf-edit.model';
 import { isAttributeLine, findElementInsertionPointRecordFirstLine } from './dspf-edit.helper';
+import { lastDdsDocument, lastDdsEditor } from './extension';
 
 // INTERFACES AND TYPES
 
@@ -42,9 +43,10 @@ export function addErrorMessage(context: vscode.ExtensionContext): void {
  */
 async function handleAddErrorMessageCommand(node: DdsNode): Promise<void> {
     try {
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            vscode.window.showErrorMessage('No active editor found.');
+        const editor = lastDdsEditor;
+        const document = editor?.document ?? lastDdsDocument;
+        if (!document || !editor) {
+            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.add-indicators.ts
+++ b/src/dspf-edit.add-indicators.ts
@@ -6,6 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from './dspf-edit.providers';
+import { lastDdsDocument, lastDdsEditor } from './extension';
 
 // INTERFACES AND TYPES
 
@@ -48,9 +49,10 @@ export function addIndicators(context: vscode.ExtensionContext): void {
  */
 async function handleAddIndicatorsCommand(node: DdsNode): Promise<void> {
     try {
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            vscode.window.showErrorMessage('No active editor found.');
+        const editor = lastDdsEditor;
+        const document = editor?.document ?? lastDdsDocument;
+        if (!document || !editor) {
+            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.add-keys.ts
+++ b/src/dspf-edit.add-keys.ts
@@ -11,6 +11,7 @@ import {
     isAttributeLine, findElementInsertionPointRecordFirstLine, findElementInsertionPointFileFirstLine,
     handleDspsizWorkflow, DspsizConfig
 } from './dspf-edit.helper';
+import { lastDdsDocument, lastDdsEditor } from './extension';
 
 // INTERFACES AND TYPES
 
@@ -45,9 +46,10 @@ export function addKeyCommand(context: vscode.ExtensionContext): void {
  */
 async function handleAddKeyCommandCommand(node: DdsNode): Promise<void> {
     try {
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            vscode.window.showErrorMessage('No active editor found.');
+        const editor = lastDdsEditor;
+        const document = editor?.document ?? lastDdsDocument;
+        if (!document || !editor) {
+            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.add-validity-check.ts
+++ b/src/dspf-edit.add-validity-check.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import { DdsNode } from './dspf-edit.providers';
 import { fieldsPerRecords } from './dspf-edit.model';
 import { isAttributeLine, findElementInsertionPoint } from './dspf-edit.helper';
+import { lastDdsDocument, lastDdsEditor } from './extension';
 
 // INTERFACES AND TYPES
 
@@ -45,9 +46,10 @@ export function addValidityCheck(context: vscode.ExtensionContext): void {
  */
 async function handleAddValidityCheckCommand(node: DdsNode): Promise<void> {
     try {
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            vscode.window.showErrorMessage('No active editor found.');
+        const editor = lastDdsEditor;
+        const document = editor?.document ?? lastDdsDocument;
+        if (!document || !editor) {
+            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.center.ts
+++ b/src/dspf-edit.center.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from './dspf-edit.providers';
 import { getRecordSize, DdsRecord } from './dspf-edit.model';
-import { describeDdsRecord } from './dspf-edit.helper';
+import { lastDdsDocument, lastDdsEditor } from './extension';
 
 // POSITION CENTERING FUNCTIONALITY
 
@@ -42,10 +42,10 @@ async function handleCenterCommand(node: DdsNode): Promise<void> {
             return;
         };
 
-        // Get active editor
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            vscode.window.showWarningMessage("No active editor found.");
+        const editor = lastDdsEditor;
+        const document = editor?.document ?? lastDdsDocument;
+        if (!document || !editor) {
+            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.change-position.ts
+++ b/src/dspf-edit.change-position.ts
@@ -7,6 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from './dspf-edit.providers';
 import { fileSizeAttributes } from './dspf-edit.model';
+import { lastDdsDocument, lastDdsEditor } from './extension';
 
 // INTERFACES AND TYPES
 
@@ -58,9 +59,10 @@ async function handleChangePositionCommand(node: DdsNode): Promise<void> {
             return;
         };
 
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            vscode.window.showErrorMessage("No active editor found.");
+        const editor = lastDdsEditor;
+        const document = editor?.document ?? lastDdsDocument;
+        if (!document || !editor) {
+            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.copy-record.ts
+++ b/src/dspf-edit.copy-record.ts
@@ -7,6 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from './dspf-edit.providers';
 import { recordExists } from './dspf-edit.helper';
+import { lastDdsDocument, lastDdsEditor } from './extension';
 
 // INTERFACES AND TYPES
 
@@ -61,12 +62,13 @@ async function handleCopyRecordCommand(node: DdsNode): Promise<void> {
             return;
         };
 
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            vscode.window.showErrorMessage("No active editor found.");
+        const editor = lastDdsEditor;
+        const document = editor?.document ?? lastDdsDocument;
+        if (!document || !editor) {
+            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
-
+        
         // Detect record boundaries
         const recordBoundary = detectRecordBoundaries(editor, element);
         if (recordBoundary.totalLines === 0) {

--- a/src/dspf-edit.delete-record.ts
+++ b/src/dspf-edit.delete-record.ts
@@ -6,6 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from './dspf-edit.providers';
+import { lastDdsDocument, lastDdsEditor } from './extension';
 
 // COMMAND REGISTRATION
 
@@ -39,9 +40,10 @@ async function handleDeleteRecordCommand(node: DdsNode): Promise<void> {
             return;
         };
 
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            vscode.window.showErrorMessage("No active editor found.");
+        const editor = lastDdsEditor;
+        const document = editor?.document ?? lastDdsDocument;
+        if (!document || !editor) {
+            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.fill-constant.ts
+++ b/src/dspf-edit.fill-constant.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import { DdsNode } from './dspf-edit.providers';
 import { DdsConstant } from './dspf-edit.model';
 import { updateExistingConstant } from './dspf-edit.edit-constant';
+import { lastDdsDocument, lastDdsEditor } from './extension';
 
 // INTERFACES AND TYPES
 
@@ -47,9 +48,10 @@ export function fillConstant(context: vscode.ExtensionContext): void {
  */
 async function handleFillConstantCommand(node: DdsNode): Promise<void> {
     try {
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            vscode.window.showErrorMessage('No active editor found.');
+        const editor = lastDdsEditor;
+        const document = editor?.document ?? lastDdsDocument;
+        if (!document || !editor) {
+            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.generate-structure.ts
+++ b/src/dspf-edit.generate-structure.ts
@@ -4,14 +4,20 @@
 	dspf-edit.generate-structure.ts
 */
 
-import * as vscode from 'vscode';
 import { DdsTreeProvider } from './dspf-edit.providers';
 import { isDdsFile } from './dspf-edit.helper';
 import { parseDocument } from './dspf-edit.parser';
+import { lastDdsDocument, lastDdsEditor } from './extension';
 
 export function generateStructure(treeProvider: DdsTreeProvider) {
-
-	const editor = vscode.window.activeTextEditor;
+	const editor = lastDdsEditor;
+	const document = editor?.document ?? lastDdsDocument;
+	if (!document || !editor) {
+		treeProvider.setElements([]);
+		treeProvider.refresh();
+		return;
+	};
+	
 	if (editor && isDdsFile(editor.document)) {
 		const text = editor.document.getText();
 		treeProvider.setElements(parseDocument(text));
@@ -20,5 +26,4 @@ export function generateStructure(treeProvider: DdsTreeProvider) {
         treeProvider.setElements([]);
         treeProvider.refresh();
     };
-
 };

--- a/src/dspf-edit.goto-line.ts
+++ b/src/dspf-edit.goto-line.ts
@@ -5,20 +5,29 @@
 */
 
 import * as vscode from 'vscode';
+import { lastDdsDocument, lastDdsEditor } from './extension';
 
 export function goToLineHandler(context: vscode.ExtensionContext): void {
-	const disposable = vscode.commands.registerCommand('ddsEdit.goToLine', (lineNumber: number) => {
-		const editor = vscode.window.activeTextEditor;
-		
-        if (!editor) {
-            vscode.window.showWarningMessage("No active editor found.");
-            return;
-        };
+  const disposable = vscode.commands.registerCommand('ddsEdit.goToLine', (lineNumber: number) => {
 
-		const position = new vscode.Position(lineNumber - 1, 0);
-		editor.selection = new vscode.Selection(position, position);
-		editor.revealRange(new vscode.Range(position, position), vscode.TextEditorRevealType.InCenter);
-	});
+    const editor = lastDdsEditor;
 
-	context.subscriptions.push(disposable);
+    if (!editor) {
+      vscode.window.showWarningMessage("No DDS editor available.");
+      return;
+    };
+
+    if (vscode.window.activeTextEditor !== editor) {
+      vscode.window.showTextDocument(editor.document, { viewColumn: editor.viewColumn });
+    };
+
+    const position = new vscode.Position(lineNumber - 1, 0);
+    const range = new vscode.Range(position, position);
+
+    editor.selection = new vscode.Selection(range.start, range.end);
+    editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+
+  });
+
+  context.subscriptions.push(disposable);
 };

--- a/src/dspf-edit.new-record.ts
+++ b/src/dspf-edit.new-record.ts
@@ -9,6 +9,7 @@ import { DdsNode } from './dspf-edit.providers';
 import { recordExists, DspsizConfig,
     checkIfDspsizNeeded, collectDspsizConfiguration, generateDspsizLines } from './dspf-edit.helper';
 import { fileSizeAttributes } from './dspf-edit.model';
+import { lastDdsDocument, lastDdsEditor } from './extension';
 
 // INTERFACES AND TYPES
 
@@ -100,9 +101,10 @@ async function handleNewRecordCommand(node: DdsNode): Promise<void> {
             return;
         };
 
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            vscode.window.showErrorMessage("No active editor found.");
+        const editor = lastDdsEditor;
+        const document = editor?.document ?? lastDdsDocument;
+        if (!document || !editor) {
+            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.parser.ts
+++ b/src/dspf-edit.parser.ts
@@ -692,6 +692,7 @@ function updateFileSizeAttributes(sizes: Array<{ row: number; col: number; name:
         fileSizeAttributes.maxCol2 = sizes[1].col;
         fileSizeAttributes.nameDsply2 = sizes[1].name;
     };
+
 };
 
 /**

--- a/src/dspf-edit.providers.ts
+++ b/src/dspf-edit.providers.ts
@@ -7,8 +7,8 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
 import { DdsElement, DdsGroup } from './dspf-edit.model';
-import { describeDdsField, describeDdsConstant, describeDdsRecord, describeDdsFile, formatDdsIndicators, goToLine } from './dspf-edit.helper';
-
+import { describeDdsField, describeDdsConstant, describeDdsRecord, describeDdsFile, formatDdsIndicators } from './dspf-edit.helper';
+import { lastDdsEditor } from './extension';
 
 // DDS TREE PROVIDER CLASS
 
@@ -94,7 +94,7 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 	 */
 	private getRootChildren(elements: DdsElement[]): Thenable<DdsNode[]> {
 		const file = elements.find(e => e.kind === 'file');
-		const editor = vscode.window.activeTextEditor;
+		const editor = lastDdsEditor || vscode.window.activeTextEditor;
 		const fileName = editor ? path.basename(editor.document.fileName) : 'Unknown';
 		let fileNode: DdsNode | undefined;
 

--- a/src/dspf-edit.view-structure.ts
+++ b/src/dspf-edit.view-structure.ts
@@ -8,13 +8,19 @@ import * as vscode from 'vscode';
 import { DdsTreeProvider } from './dspf-edit.providers';
 import { isDdsFile } from './dspf-edit.helper';
 import { parseDocument } from './dspf-edit.parser';
+import { lastDdsDocument, lastDdsEditor } from './extension';
 
 export function viewStructure(context: vscode.ExtensionContext, treeProvider: DdsTreeProvider) {
 
     context.subscriptions.push(
 		vscode.commands.registerCommand('dds-aid.view-structure', () => {
-			const editor = vscode.window.activeTextEditor;
-			const document = editor?.document;
+			const editor = lastDdsEditor;
+			const document = editor?.document ?? lastDdsDocument;
+			if (!document || !editor) {
+				vscode.window.showErrorMessage('No DDS editor found.');
+				return;
+			};
+			
 			if (editor && document && isDdsFile(document)) {
 				const text = editor.document.getText();
 				treeProvider.setElements(parseDocument(text));

--- a/src/dspf-edit.window-resize.ts
+++ b/src/dspf-edit.window-resize.ts
@@ -7,6 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from './dspf-edit.providers';
 import { fileSizeAttributes, fieldsPerRecords } from './dspf-edit.model';
+import { lastDdsDocument, lastDdsEditor } from './extension';
 
 // INTERFACES AND TYPES
 
@@ -88,9 +89,10 @@ async function handleWindowResizeCommand(node: DdsNode): Promise<void> {
             return;
         };
 
-        const editor = vscode.window.activeTextEditor;
-        if (!editor) {
-            vscode.window.showErrorMessage("No active editor found.");
+        const editor = lastDdsEditor;
+        const document = editor?.document ?? lastDdsDocument;
+        if (!document || !editor) {
+            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 


### PR DESCRIPTION
## [0.5.0] - 2025-09-06
### Added
- The extension can be launched from a separate icon in the activity bar.
- The extension remembers the last opened DDS display file source and allows you to use other extensions simultaneously (for example, you can use IBM i Renderer without losing the DDS structure on the screen).
### Fixes
- Problems adding a new field.