### PR TITLE
Refact/internal changes/Fixes/Improvements in subfile records creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 out
 .DS_Store
 *.vsix
+.vscode-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,10 +112,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Fixed
 - Fixed an issue when sorting items in a record that had hidden fields. These fields now appear first in the sort order.
 
-### [0.7.1] - 2025-09-15
+### [0.7.1] - 2025-09-19
 ## Refactored
 - Internal refactoring and code cleanup.
 ## Fixed
+- 3-digit rows/columns were not being parsed correctly.
 - Improved subfile record creation (both regular and window subfiles):
   - Every subfile is created with a control record (header), and the subfile record (detail).
   - The control record is created with: SFLSIZ, SFLPAG, OVERLAY, RTNCSRLOC, SFLCSRRRN, SFLDSP, SFLDSPCTL,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,3 +111,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   If copying a field, you must provide a new name if one with the same name already exists in the destination record.
 ## Fixed
 - Fixed an issue when sorting items in a record that had hidden fields. These fields now appear first in the sort order.
+
+### [0.7.1] - 2025-09-14
+## Refactored
+- Internal refactoring and code cleanup.
+## Fixed
+- Improved subfile record creation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,4 +121,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - The control record is created with: SFLSIZ, SFLPAG, OVERLAY, RTNCSRLOC, SFLCSRRRN, SFLDSP, SFLDSPCTL,
     SFLCLR and SFLEND. SFLDSP, SFLDSPCTL, SLFEND with N80 indicator, and SFLCLR with 80 indicator.
     Also some hidden fields are added: NRR, NBR, WSRECNAM, WSFLDNAM, and WSFLRRN.
-    (all this will be configurable in future versions). 
+    (all this will be configurable in future versions).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,8 +112,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## Fixed
 - Fixed an issue when sorting items in a record that had hidden fields. These fields now appear first in the sort order.
 
-### [0.7.1] - 2025-09-14
+### [0.7.1] - 2025-09-15
 ## Refactored
 - Internal refactoring and code cleanup.
 ## Fixed
-- Improved subfile record creation.
+- Improved subfile record creation (both regular and window subfiles):
+  - Every subfile is created with a control record (header), and the subfile record (detail).
+  - The control record is created with: SFLSIZ, SFLPAG, OVERLAY, RTNCSRLOC, SFLCSRRRN, SFLDSP, SFLDSPCTL,
+    SFLCLR and SFLEND. SFLDSP, SFLDSPCTL, SLFEND with N80 indicator, and SFLCLR with 80 indicator.
+    Also some hidden fields are added: NRR, NBR, WSRECNAM, WSFLDNAM, and WSFLRRN.
+    (all this will be configurable in future versions). 

--- a/README.md
+++ b/README.md
@@ -99,9 +99,15 @@ Some features may not work as expected. Please leave an issue if something is no
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**0.7.1** - 2025-09-14
+**0.7.1** - 2025-09-15
 - Refactored: Internal refactoring and code cleanup.
-- Changed: Improved subfile record creation.
+- Changed: Improved subfile record creation (both regular and window subfiles):
+  - Every subfile is created with a control record (header), and the subfile record (detail).
+  - The control record is created with: SFLSIZ, SFLPAG, OVERLAY, RTNCSRLOC, SFLCSRRRN, SFLDSP, SFLDSPCTL,
+    SFLCLR and SFLEND. SFLDSP, SFLDSPCTL, SLFEND with N80 indicator, and SFLCLR with 80 indicator.
+    Also some hidden fields are added: NRR, NBR, WSRECNAM, WSFLDNAM, and WSFLRRN.
+    (all this will be configurable in future versions). 
+    
 ---
 
 💬 **Feedback is welcome!** Please leave a comment, open an issue, and enjoy using DSPF-edit.

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ Some features may not work as expected. Please leave an issue if something is no
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**0.7.1** - 2025-09-15
+**0.7.1** - 2025-09-19
 - Refactored: Internal refactoring and code cleanup.
+- Fixed: 3-digit rows/columns were not being parsed correctly.
 - Changed: Improved subfile record creation (both regular and window subfiles):
   - Every subfile is created with a control record (header), and the subfile record (detail).
   - The control record is created with: SFLSIZ, SFLPAG, OVERLAY, RTNCSRLOC, SFLCSRRRN, SFLDSP, SFLDSPCTL,

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ See the full changelog [here](./CHANGELOG.md).
   - The control record is created with: SFLSIZ, SFLPAG, OVERLAY, RTNCSRLOC, SFLCSRRRN, SFLDSP, SFLDSPCTL,
     SFLCLR and SFLEND. SFLDSP, SFLDSPCTL, SLFEND with N80 indicator, and SFLCLR with 80 indicator.
     Also some hidden fields are added: NRR, NBR, WSRECNAM, WSFLDNAM, and WSFLRRN.
-    (all this will be configurable in future versions). 
+    (all this will be configurable in future versions).
     
 ---
 

--- a/README.md
+++ b/README.md
@@ -99,11 +99,9 @@ Some features may not work as expected. Please leave an issue if something is no
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**0.7.0** - 2025-09-14
-- Added: Ability to copy a Field/Constant to a different record or to a different position within the same record.  
-  If copying a field, you must provide a new name if one with the same name already exists in the destination record.
-- Fixed: There were an issue when sorting items in a record that had hidden fields. These fields now appear first in the sort order.
-
+**0.7.1** - 2025-09-14
+- Refactored: Internal refactoring and code cleanup.
+- Changed: Improved subfile record creation.
 ---
 
 💬 **Feedback is welcome!** Please leave a comment, open an issue, and enjoy using DSPF-edit.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"

--- a/src/dspf-edit.commands/dspf-edit.add-attribute.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-attribute.ts
@@ -6,8 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from './../dspf-edit.providers/dspf-edit.providers';
-import { isAttributeLine, findElementInsertionPoint } from './../dspf-edit.utils/dspf-edit.helper'
-import { ExtensionState } from './../dspf-edit.states/state';
+import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, parseIndicatorsFromLine, groupConsecutiveLines } from './../dspf-edit.utils/dspf-edit.helper'
 import { fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
  
 // INTERFACES AND TYPES
@@ -43,10 +42,9 @@ export function addAttribute(context: vscode.ExtensionContext): void {
  */
 async function handleAddAttributeCommand(node: DdsNode): Promise<void> {
     try {
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
         if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 
@@ -552,74 +550,4 @@ function calculateAttributeDeletionRanges(
     };
     
     return ranges;
-};
-
-/**
- * Groups consecutive line numbers together for more efficient batch deletion.
- * @param lines - Array of line indices (should be sorted)
- * @returns Array of arrays, where each sub-array contains consecutive line numbers
- */
-function groupConsecutiveLines(lines: number[]): number[][] {
-    if (lines.length === 0) return [];
-    
-    // Ensure lines are sorted
-    const sortedLines = [...lines].sort((a, b) => a - b);
-    const groups: number[][] = [];
-    let currentGroup: number[] = [sortedLines[0]];
-    
-    for (let i = 1; i < sortedLines.length; i++) {
-        const currentLine = sortedLines[i];
-        const previousLine = sortedLines[i - 1];
-        
-        if (currentLine === previousLine + 1) {
-            // Consecutive line - add to current group
-            currentGroup.push(currentLine);
-        } else {
-            // Non-consecutive line - start new group
-            groups.push(currentGroup);
-            currentGroup = [currentLine];
-        };
-    };
-    
-    // Don't forget the last group
-    groups.push(currentGroup);
-    
-    return groups;
-};
-
-// LINE CREATION AND DETECTION FUNCTIONS
-
-/**
- * Finds existing attribute lines for an element.
- * This function is kept for backward compatibility but the logic has been moved to getCurrentAttributesForElement.
- * @param editor - The active text editor
- * @param element - The DDS element
- * @returns Array of line indices containing attributes
- */
-function findExistingAttributeLines(editor: vscode.TextEditor, element: any): number[] {
-    const attributes = getCurrentAttributesForElement(editor, element);
-    return attributes.map(attr => attr.lineIndex!);
-};
-
-/**
- * Parses indicators from a DDS line at positions 7-9, 10-12, 13-15.
- * @param lineText - The DDS line text
- * @returns Array of indicator codes found
- */
-function parseIndicatorsFromLine(lineText: string): string[] {
-    const indicators: string[] = [];
-
-    // Check positions 7-9, 10-12, 13-15 (0-based: 6-8, 9-11, 12-14)
-    const positions = [6, 9, 12];
-
-    for (const pos of positions) {
-        if (lineText.length > pos + 2) {
-            const indicator = lineText.substring(pos, pos + 3).trim();
-            if (indicator && /^N?[0-9]{1,2}$/.test(indicator)) {
-                indicators.push(indicator);
-            };
-        };
-    };
-
-    return indicators;
 };

--- a/src/dspf-edit.commands/dspf-edit.add-attribute.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-attribute.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from './../dspf-edit.providers/dspf-edit.providers';
-import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, parseIndicatorsFromLine, groupConsecutiveLines } from './../dspf-edit.utils/dspf-edit.helper'
+import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, parseIndicatorsFromLine, groupConsecutiveLines } from './../dspf-edit.utils/dspf-edit.helper';
 import { fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
  
 // INTERFACES AND TYPES

--- a/src/dspf-edit.commands/dspf-edit.add-buttons.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-buttons.ts
@@ -7,7 +7,40 @@
 import * as vscode from 'vscode';
 import { DdsNode } from './../dspf-edit.providers/dspf-edit.providers';
 import { getRecordSize, fieldsPerRecords, DdsSize, getDefaultSize } from '../dspf-edit.model/dspf-edit.model';
-import { ExtensionState } from './../dspf-edit.states/state';
+import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
+
+// TYPE DEFINITIONS
+
+/**
+ * Represents a button definition with function key and label.
+ */
+interface ButtonDefinition {
+    key: string;    // Function key (e.g., "F1", "F12")
+    label: string;  // Button label text
+};
+
+/**
+ * Contains comprehensive information about a record needed for button placement.
+ */
+interface RecordInformation {
+    name: string;
+    size: any;              // Record size information
+    info: any;              // Additional record information
+    endLineIndex: number;   // Line index where the record ends
+    visibleStart: number;   // Starting row for visible area
+    maxColumns: number;     // Maximum columns available
+    isWindow : boolean;     // True is it is a window
+};
+
+/**
+ * Contains layout information for button placement.
+ */
+interface ButtonLayout {
+    startRow: number;       // Starting row for first button
+    startCol: number;       // Starting column for buttons
+    rowsNeeded: number;     // Total rows needed for all buttons
+    spacing: number;        // Space between buttons
+};
 
 // COMMAND REGISTRATION
 
@@ -33,10 +66,9 @@ export function addButtons(context: vscode.ExtensionContext): void {
  */
 async function handleAddButtonsCommand(node: DdsNode): Promise<void> {
     try {
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
         if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
         
@@ -401,38 +433,5 @@ function sortButtonsByFKeyOrder(buttons: ButtonDefinition[]): ButtonDefinition[]
 export function findRecordInsertionPoint(recordName: string): number | null {
     const recordInfo = fieldsPerRecords.find(r => r.record === recordName);
     return recordInfo ? recordInfo.endIndex + 1 : null;
-};
-
-// TYPE DEFINITIONS
-
-/**
- * Represents a button definition with function key and label.
- */
-interface ButtonDefinition {
-    key: string;    // Function key (e.g., "F1", "F12")
-    label: string;  // Button label text
-};
-
-/**
- * Contains comprehensive information about a record needed for button placement.
- */
-interface RecordInformation {
-    name: string;
-    size: any;              // Record size information
-    info: any;              // Additional record information
-    endLineIndex: number;   // Line index where the record ends
-    visibleStart: number;   // Starting row for visible area
-    maxColumns: number;     // Maximum columns available
-    isWindow : boolean;     // True is it is a window
-};
-
-/**
- * Contains layout information for button placement.
- */
-interface ButtonLayout {
-    startRow: number;       // Starting row for first button
-    startCol: number;       // Starting column for buttons
-    rowsNeeded: number;     // Total rows needed for all buttons
-    spacing: number;        // Space between buttons
 };
 

--- a/src/dspf-edit.commands/dspf-edit.add-color.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-color.ts
@@ -6,8 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { isAttributeLine, findElementInsertionPoint } from '../dspf-edit.utils/dspf-edit.helper';
-import { ExtensionState } from '../dspf-edit.states/state';
+import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, parseIndicatorsFromLine, groupConsecutiveLines } from '../dspf-edit.utils/dspf-edit.helper';
 import { fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
 
 // INTERFACES AND TYPES
@@ -43,10 +42,9 @@ export function addColor(context: vscode.ExtensionContext): void {
  */
 async function handleAddColorCommand(node: DdsNode): Promise<void> {
     try {
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
         if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 
@@ -514,74 +512,4 @@ function calculateColorDeletionRanges(
     };
     
     return ranges;
-};
-
-/**
- * Groups consecutive line numbers together for more efficient batch deletion.
- * @param lines - Array of line indices (should be sorted)
- * @returns Array of arrays, where each sub-array contains consecutive line numbers
- */
-function groupConsecutiveLines(lines: number[]): number[][] {
-    if (lines.length === 0) return [];
-    
-    // Ensure lines are sorted
-    const sortedLines = [...lines].sort((a, b) => a - b);
-    const groups: number[][] = [];
-    let currentGroup: number[] = [sortedLines[0]];
-    
-    for (let i = 1; i < sortedLines.length; i++) {
-        const currentLine = sortedLines[i];
-        const previousLine = sortedLines[i - 1];
-        
-        if (currentLine === previousLine + 1) {
-            // Consecutive line - add to current group
-            currentGroup.push(currentLine);
-        } else {
-            // Non-consecutive line - start new group
-            groups.push(currentGroup);
-            currentGroup = [currentLine];
-        };
-    };
-    
-    // Don't forget the last group
-    groups.push(currentGroup);
-    
-    return groups;
-};
-
-// LINE CREATION AND DETECTION FUNCTIONS
-
-/**
- * Finds existing color attribute lines for an element.
- * This function is kept for backward compatibility but the logic has been moved to getCurrentColorsForElement.
- * @param editor - The active text editor
- * @param element - The DDS element
- * @returns Array of line indices containing color attributes
- */
-function findExistingColorLines(editor: vscode.TextEditor, element: any): number[] {
-    const colors = getCurrentColorsForElement(editor, element);
-    return colors.map(color => color.lineIndex!);
-};
-
-/**
- * Parses indicators from a DDS line at positions 7-9, 10-12, 13-15.
- * @param lineText - The DDS line text
- * @returns Array of indicator codes found
- */
-function parseIndicatorsFromLine(lineText: string): string[] {
-    const indicators: string[] = [];
-
-    // Check positions 7-9, 10-12, 13-15 (0-based: 6-8, 9-11, 12-14)
-    const positions = [6, 9, 12];
-
-    for (const pos of positions) {
-        if (lineText.length > pos + 2) {
-            const indicator = lineText.substring(pos, pos + 3).trim();
-            if (indicator && /^N?[0-9]{1,2}$/.test(indicator)) {
-                indicators.push(indicator);
-            };
-        };
-    };
-
-    return indicators;
 };

--- a/src/dspf-edit.commands/dspf-edit.add-editing-keywords.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-editing-keywords.ts
@@ -7,8 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { isAttributeLine, findElementInsertionPoint } from '../dspf-edit.utils/dspf-edit.helper';
-import { ExtensionState } from '../dspf-edit.states/state';
+import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, groupConsecutiveLines } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
@@ -50,10 +49,9 @@ export function editingKeywords(context: vscode.ExtensionContext): void {
  */
 async function handleEditingKeywordsCommand(node: DdsNode): Promise<void> {
     try {
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
         if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 
@@ -806,34 +804,6 @@ function calculateEditingDeletionRanges(
     };
     
     return ranges;
-};
-
-/**
- * Groups consecutive line numbers together for more efficient batch deletion.
- * @param lines - Array of line indices (should be sorted)
- * @returns Array of arrays, where each sub-array contains consecutive line numbers
- */
-function groupConsecutiveLines(lines: number[]): number[][] {
-    if (lines.length === 0) return [];
-    
-    const sortedLines = [...lines].sort((a, b) => a - b);
-    const groups: number[][] = [];
-    let currentGroup: number[] = [sortedLines[0]];
-    
-    for (let i = 1; i < sortedLines.length; i++) {
-        const currentLine = sortedLines[i];
-        const previousLine = sortedLines[i - 1];
-        
-        if (currentLine === previousLine + 1) {
-            currentGroup.push(currentLine);
-        } else {
-            groups.push(currentGroup);
-            currentGroup = [currentLine];
-        };
-    };
-    
-    groups.push(currentGroup);
-    return groups;
 };
 
 // LINE DETECTION FUNCTIONS

--- a/src/dspf-edit.commands/dspf-edit.add-error-messages.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-error-messages.ts
@@ -7,8 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { isAttributeLine, findElementInsertionPointRecordFirstLine } from '../dspf-edit.utils/dspf-edit.helper';
-import { ExtensionState } from '../dspf-edit.states/state';
+import { isAttributeLine, findElementInsertionPointRecordFirstLine, checkForEditorAndDocument, groupConsecutiveLines } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
@@ -43,10 +42,9 @@ export function addErrorMessage(context: vscode.ExtensionContext): void {
  */
 async function handleAddErrorMessageCommand(node: DdsNode): Promise<void> {
     try {
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
         if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 
@@ -577,32 +575,4 @@ function calculateErrorMessageDeletionRanges(
     };
 
     return ranges;
-};
-
-/**
- * Groups consecutive line numbers for efficient batch deletion.
- * @param lines - Array of line indices (should be sorted)
- * @returns Array of arrays containing consecutive line numbers
- */
-function groupConsecutiveLines(lines: number[]): number[][] {
-    if (lines.length === 0) return [];
-
-    const sortedLines = [...lines].sort((a, b) => a - b);
-    const groups: number[][] = [];
-    let currentGroup: number[] = [sortedLines[0]];
-
-    for (let i = 1; i < sortedLines.length; i++) {
-        const currentLine = sortedLines[i];
-        const previousLine = sortedLines[i - 1];
-
-        if (currentLine === previousLine + 1) {
-            currentGroup.push(currentLine);
-        } else {
-            groups.push(currentGroup);
-            currentGroup = [currentLine];
-        };
-    };
-
-    groups.push(currentGroup);
-    return groups;
 };

--- a/src/dspf-edit.commands/dspf-edit.add-indicators.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-indicators.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { ExtensionState } from '../dspf-edit.states/state';
+import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
@@ -49,10 +49,9 @@ export function addIndicators(context: vscode.ExtensionContext): void {
  */
 async function handleAddIndicatorsCommand(node: DdsNode): Promise<void> {
     try {
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
         if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 
@@ -583,19 +582,4 @@ function parseIndicatorsFromLine(lineText: string): IndicatorAssignment[] {
     };
 
     return indicators;
-};
-
-// HELPER FUNCTIONS
-
-/**
- * Checks if a DDS line has available space for indicator conditioning.
- * @param lineText - The DDS line text
- * @returns True if there's space for indicators
- */
-function hasAvailableIndicatorSpace(lineText: string): boolean {
-    if (lineText.length < 17) return true;
-    
-    // Check if positions 7-16 are empty or contain only spaces (0-based: 6-15)
-    const conditionArea = lineText.substring(6, 16);
-    return conditionArea.trim() === '';
 };

--- a/src/dspf-edit.commands/dspf-edit.add-keys.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-keys.ts
@@ -9,9 +9,10 @@ import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { attributesFileLevel, fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
 import {
     isAttributeLine, findElementInsertionPointRecordFirstLine, findElementInsertionPointFileFirstLine,
-    handleDspsizWorkflow, DspsizConfig
+    handleDspsizWorkflow, DspsizConfig,
+    checkForEditorAndDocument,
+    groupConsecutiveLines
 } from '../dspf-edit.utils/dspf-edit.helper';
-import { ExtensionState } from '../dspf-edit.states/state';
 
 // INTERFACES AND TYPES
 
@@ -46,10 +47,9 @@ export function addKeyCommand(context: vscode.ExtensionContext): void {
  */
 async function handleAddKeyCommandCommand(node: DdsNode): Promise<void> {
     try {
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
         if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 
@@ -630,39 +630,6 @@ function calculateKeyCommandDeletionRanges(
     return ranges;
 };
 
-/**
- * Groups consecutive line numbers together for more efficient batch deletion.
- * @param lines - Array of line indices (should be sorted)
- * @returns Array of arrays, where each sub-array contains consecutive line numbers
- */
-function groupConsecutiveLines(lines: number[]): number[][] {
-    if (lines.length === 0) return [];
-
-    // Ensure lines are sorted
-    const sortedLines = [...lines].sort((a, b) => a - b);
-    const groups: number[][] = [];
-    let currentGroup: number[] = [sortedLines[0]];
-
-    for (let i = 1; i < sortedLines.length; i++) {
-        const currentLine = sortedLines[i];
-        const previousLine = sortedLines[i - 1];
-
-        if (currentLine === previousLine + 1) {
-            // Consecutive line - add to current group
-            currentGroup.push(currentLine);
-        } else {
-            // Non-consecutive line - start new group
-            groups.push(currentGroup);
-            currentGroup = [currentLine];
-        };
-    };
-
-    // Don't forget the last group
-    groups.push(currentGroup);
-
-    return groups;
-};
-
 // LINE CREATION AND DETECTION FUNCTIONS
 
 /**
@@ -748,27 +715,4 @@ function findExistingKeyCommandLinesInFile(editor: vscode.TextEditor): number[] 
     };
 
     return keyCommandLines;
-};
-
-/**
- * Parses indicators from a DDS line at positions 7-9, 10-12, 13-15.
- * @param lineText - The DDS line text
- * @returns Array of indicator codes found
- */
-function parseIndicatorsFromLine(lineText: string): string[] {
-    const indicators: string[] = [];
-
-    // Check positions 7-9, 10-12, 13-15 (0-based: 6-8, 9-11, 12-14)
-    const positions = [6, 9, 12];
-
-    for (const pos of positions) {
-        if (lineText.length > pos + 2) {
-            const indicator = lineText.substring(pos, pos + 3).trim();
-            if (indicator && /^N?[0-9]{1,2}$/.test(indicator)) {
-                indicators.push(indicator);
-            };
-        };
-    };
-
-    return indicators;
 };

--- a/src/dspf-edit.commands/dspf-edit.add-validity-check.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-validity-check.ts
@@ -7,8 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { isAttributeLine, findElementInsertionPoint } from '../dspf-edit.utils/dspf-edit.helper';
-import { ExtensionState } from '../dspf-edit.states/state';
+import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, groupConsecutiveLines } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
@@ -46,10 +45,9 @@ export function addValidityCheck(context: vscode.ExtensionContext): void {
  */
 async function handleAddValidityCheckCommand(node: DdsNode): Promise<void> {
     try {
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
         if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 
@@ -503,39 +501,6 @@ function calculateValidityCheckDeletionRanges(
     };
     
     return ranges;
-};
-
-/**
- * Groups consecutive line numbers together for more efficient batch deletion.
- * @param lines - Array of line indices (should be sorted)
- * @returns Array of arrays, where each sub-array contains consecutive line numbers
- */
-function groupConsecutiveLines(lines: number[]): number[][] {
-    if (lines.length === 0) return [];
-    
-    // Ensure lines are sorted
-    const sortedLines = [...lines].sort((a, b) => a - b);
-    const groups: number[][] = [];
-    let currentGroup: number[] = [sortedLines[0]];
-    
-    for (let i = 1; i < sortedLines.length; i++) {
-        const currentLine = sortedLines[i];
-        const previousLine = sortedLines[i - 1];
-        
-        if (currentLine === previousLine + 1) {
-            // Consecutive line - add to current group
-            currentGroup.push(currentLine);
-        } else {
-            // Non-consecutive line - start new group
-            groups.push(currentGroup);
-            currentGroup = [currentLine];
-        };
-    };
-    
-    // Don't forget the last group
-    groups.push(currentGroup);
-    
-    return groups;
 };
 
 // LINE CREATION AND DETECTION FUNCTIONS

--- a/src/dspf-edit.commands/dspf-edit.center.ts
+++ b/src/dspf-edit.commands/dspf-edit.center.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { getRecordSize } from '../dspf-edit.model/dspf-edit.model';
-import { ExtensionState } from '../dspf-edit.states/state';
+import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
 
 // POSITION CENTERING FUNCTIONALITY
 
@@ -33,19 +33,17 @@ export function centerPosition(context: vscode.ExtensionContext): void {
  */
 async function handleCenterCommand(node: DdsNode): Promise<void> {
     try {
-        const element = node.ddsElement;
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
+        if (!document || !editor) {
+            return;
+        };
 
+        const element = node.ddsElement;
         // Validate element type and properties
         const validationResult = validateElementForCentering(element);
         if (!validationResult.isValid) {
             vscode.window.showWarningMessage(validationResult.message);
-            return;
-        };
-
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
-        if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.commands/dspf-edit.change-position.ts
+++ b/src/dspf-edit.commands/dspf-edit.change-position.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fileSizeAttributes } from '../dspf-edit.model/dspf-edit.model';
-import { ExtensionState } from '../dspf-edit.states/state';
+import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
@@ -51,18 +51,17 @@ export function changePosition(context: vscode.ExtensionContext): void {
  */
 async function handleChangePositionCommand(node: DdsNode): Promise<void> {
     try {
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
+        if (!document || !editor) {
+            return;
+        };
+
         const element = node.ddsElement;
 
         // Validate element type
         if (element.kind !== "field" && element.kind !== "constant") {
             vscode.window.showWarningMessage("Position can only be changed for fields and constants.");
-            return;
-        };
-
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
-        if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.commands/dspf-edit.copy-constant.ts
+++ b/src/dspf-edit.commands/dspf-edit.copy-constant.ts
@@ -6,8 +6,8 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { fieldsPerRecords, ConstantInfo, FieldsPerRecord, DdsConstant, AttributeWithIndicators } from '../dspf-edit.model/dspf-edit.model';
-import { ExtensionState } from '../dspf-edit.states/state';
+import { fieldsPerRecords, ConstantInfo, DdsConstant, AttributeWithIndicators } from '../dspf-edit.model/dspf-edit.model';
+import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
 
 /**
  * Interface for constant copy configuration
@@ -85,17 +85,16 @@ export function copyConstant(context: vscode.ExtensionContext): void {
  */
 async function handleCopyConstantCommand(node: DdsNode): Promise<void> {
     try {
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
+        if (!document || !editor) {
+            return;
+        };
+
         // Validate the selected node
         const validationResult = validateNodeForCopy(node);
         if (!validationResult.isValid) {
             vscode.window.showWarningMessage(validationResult.errorMessage!);
-            return;
-        };
-
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
-        if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.commands/dspf-edit.copy-field.ts
+++ b/src/dspf-edit.commands/dspf-edit.copy-field.ts
@@ -6,8 +6,8 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { fieldsPerRecords, FieldInfo, FieldsPerRecord, DdsField } from '../dspf-edit.model/dspf-edit.model';
-import { ExtensionState } from '../dspf-edit.states/state';
+import { fieldsPerRecords, FieldInfo, DdsField } from '../dspf-edit.model/dspf-edit.model';
+import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
 
 /**
  * Interface for field copy configuration
@@ -100,18 +100,16 @@ export function copyField(context: vscode.ExtensionContext): void {
  */
 async function handleCopyFieldCommand(node: DdsNode): Promise<void> {
     try {
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
+        if (!document || !editor) {
+            return;
+        };
+
         // Validate the selected node
         const validationResult = validateNodeForCopy(node);
         if (!validationResult.isValid) {
             vscode.window.showWarningMessage(validationResult.errorMessage!);
-            return;
-        };
-
-        // Get the active editor and document
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
-        if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.commands/dspf-edit.copy-record.ts
+++ b/src/dspf-edit.commands/dspf-edit.copy-record.ts
@@ -6,8 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { recordExists } from '../dspf-edit.utils/dspf-edit.helper';
-import { ExtensionState } from '../dspf-edit.states/state';
+import { checkForEditorAndDocument, recordExists } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
@@ -54,6 +53,12 @@ export function copyRecord(context: vscode.ExtensionContext): void {
  */
 async function handleCopyRecordCommand(node: DdsNode): Promise<void> {
     try {
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
+        if (!document || !editor) {
+            return;
+        };
+
         const element = node.ddsElement;
 
         // Validate element type
@@ -62,13 +67,6 @@ async function handleCopyRecordCommand(node: DdsNode): Promise<void> {
             return;
         };
 
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
-        if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
-            return;
-        };
-        
         // Detect record boundaries
         const recordBoundary = detectRecordBoundaries(editor, element);
         if (recordBoundary.totalLines === 0) {

--- a/src/dspf-edit.commands/dspf-edit.delete-record.ts
+++ b/src/dspf-edit.commands/dspf-edit.delete-record.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { ExtensionState } from '../dspf-edit.states/state';
+import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
 
 // COMMAND REGISTRATION
 
@@ -32,18 +32,17 @@ export function deleteRecord(context: vscode.ExtensionContext): void {
  */
 async function handleDeleteRecordCommand(node: DdsNode): Promise<void> {
     try {
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
+        if (!document || !editor) {
+            return;
+        };
+
         const element = node.ddsElement;
 
         // Validate element type
         if (element.kind !== "record") {
             vscode.window.showWarningMessage("Only records can be deleted.");
-            return;
-        };
-
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
-        if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.commands/dspf-edit.edit-constant.ts
+++ b/src/dspf-edit.commands/dspf-edit.edit-constant.ts
@@ -7,8 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fileSizeAttributes, fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { findEndLineIndex } from '../dspf-edit.utils/dspf-edit.helper';
-import { ExtensionState } from '../dspf-edit.states/state';
+import { checkForEditorAndDocument, findEndLineIndex } from '../dspf-edit.utils/dspf-edit.helper';
 
 // TYPE DEFINITIONS
 
@@ -77,18 +76,17 @@ export function addConstant(context: vscode.ExtensionContext): void {
  */
 async function handleEditConstantCommand(node: DdsNode): Promise<void> {
     try {
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
+        if (!document || !editor) {
+            return;
+        };
+
         const element = node.ddsElement;
 
         // Validate that the element is a constant
         if (element.kind !== "constant") {
             vscode.window.showWarningMessage("Only constants can be edited.");
-            return;
-        };
-
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
-        if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 
@@ -119,10 +117,9 @@ async function handleEditConstantCommand(node: DdsNode): Promise<void> {
  */
 async function handleAddConstantCommand(node?: DdsNode): Promise<void> {
     try {
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
         if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.commands/dspf-edit.edit-field.ts
+++ b/src/dspf-edit.commands/dspf-edit.edit-field.ts
@@ -7,8 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fileSizeAttributes, fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { parseSize } from '../dspf-edit.utils/dspf-edit.helper';
-import { ExtensionState } from '../dspf-edit.states/state';
+import { checkForEditorAndDocument, parseSize } from '../dspf-edit.utils/dspf-edit.helper';
 
 /**
  * Interface defining the structure of a field's size properties
@@ -180,17 +179,16 @@ export function editField(context: vscode.ExtensionContext): void {
  */
 async function handleEditFieldCommand(node: DdsNode): Promise<void> {
     try {
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
+        if (!document || !editor) {
+            return;
+        };
+
         // Validate the selected node
         const validationResult = validateNodeForEdit(node);
         if (!validationResult.isValid) {
             vscode.window.showWarningMessage(validationResult.errorMessage!);
-            return;
-        };
-
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
-        if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 
@@ -234,17 +232,16 @@ async function handleEditFieldCommand(node: DdsNode): Promise<void> {
  */
 async function handleAddFieldCommand(node: DdsNode): Promise<void> {
     try {
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
+        if (!document || !editor) {
+            return;
+        };
+
         // Validate the selected node
         const validationResult = validateNodeForAdd(node);
         if (!validationResult.isValid) {
             vscode.window.showWarningMessage(validationResult.errorMessage!);
-            return;
-        };
-
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
-        if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.commands/dspf-edit.edit-field.ts
+++ b/src/dspf-edit.commands/dspf-edit.edit-field.ts
@@ -1269,7 +1269,7 @@ function buildUpdatedLine(originalLine: string, newName: string, newSize: FieldS
     const typeCharacter = line.substring(FIELD_CONSTANTS.TYPE_COLUMN, FIELD_CONSTANTS.TYPE_COLUMN + 1);
     const isNumericField = FIELD_CONSTANTS.NUMERIC_TYPES.includes(typeCharacter as any);
     
-    if (isNumericField && newSize.decimals != undefined) {
+    if (isNumericField && newSize.decimals !== undefined) {
         const decimalString = newSize.decimals.toString().padStart(2, ' ').substring(0, 2);
         line = line.substring(0, FIELD_CONSTANTS.DECIMAL_COLUMN_START) + 
                decimalString + 

--- a/src/dspf-edit.commands/dspf-edit.fill-constant.ts
+++ b/src/dspf-edit.commands/dspf-edit.fill-constant.ts
@@ -8,7 +8,7 @@ import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { DdsConstant } from '../dspf-edit.model/dspf-edit.model';
 import { updateExistingConstant } from './dspf-edit.edit-constant';
-import { ExtensionState } from '../dspf-edit.states/state';
+import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
@@ -48,10 +48,9 @@ export function fillConstant(context: vscode.ExtensionContext): void {
  */
 async function handleFillConstantCommand(node: DdsNode): Promise<void> {
     try {
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
         if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.commands/dspf-edit.generate-structure.ts
+++ b/src/dspf-edit.commands/dspf-edit.generate-structure.ts
@@ -5,13 +5,15 @@
 */
 
 import { DdsTreeProvider } from '../dspf-edit.providers/dspf-edit.providers';
-import { isDdsFile } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, isDdsFile } from '../dspf-edit.utils/dspf-edit.helper';
 import { parseDocument } from '../dspf-edit.parser/dspf-edit.parser';
-import { ExtensionState } from '../dspf-edit.states/state';
 
 export function generateStructure(treeProvider: DdsTreeProvider) {
-	const editor = ExtensionState.lastDdsEditor;
-	const document = editor?.document ?? ExtensionState.lastDdsDocument;
+    // Check for editor and document
+    const { editor, document } = checkForEditorAndDocument();
+    if (!document || !editor) {
+        return;
+    };
 	if (!document || !editor) {
 		treeProvider.setElements([]);
 		treeProvider.refresh();

--- a/src/dspf-edit.commands/dspf-edit.goto-line.ts
+++ b/src/dspf-edit.commands/dspf-edit.goto-line.ts
@@ -5,18 +5,17 @@
 */
 
 import * as vscode from 'vscode';
-import { ExtensionState } from '../dspf-edit.states/state';
+import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
 
 export function goToLineHandler(context: vscode.ExtensionContext): void {
   const disposable = vscode.commands.registerCommand('ddsEdit.goToLine', (lineNumber: number) => {
 
-    const editor = ExtensionState.lastDdsEditor;
-
-    if (!editor) {
-      vscode.window.showWarningMessage("No DDS editor available.");
-      return;
+    // Check for editor and document
+    const { editor, document } = checkForEditorAndDocument();
+    if (!document || !editor) {
+        return;
     };
-
+    
     if (vscode.window.activeTextEditor !== editor) {
       vscode.window.showTextDocument(editor.document, { viewColumn: editor.viewColumn });
     };

--- a/src/dspf-edit.commands/dspf-edit.new-record.ts
+++ b/src/dspf-edit.commands/dspf-edit.new-record.ts
@@ -186,7 +186,7 @@ async function collectRecordName(): Promise<string | null> {
     const stepNumber = '1/4'; // Will be adjusted based on whether DSPSIZ is needed
     const recordName = await vscode.window.showInputBox({
         title: `Create New Record - Step ${stepNumber}`,
-        prompt: 'Enter the new record name',
+        prompt: 'Enter the new record name (In case of subfile, this is the subfile detail record name)',
         placeHolder: 'RECORD',
         validateInput: validateRecordName
     });
@@ -457,7 +457,7 @@ function validateWindowTitle(value: string, maxLength: number): string | null {
 async function collectSubfileConfiguration(): Promise<SubfileConfig | null> {
     const controlRecordName = await vscode.window.showInputBox({
         title: 'Subfile Configuration - Control Record',
-        prompt: 'Enter the subfile control record name',
+        prompt: 'Enter the subfile control record name (This is the subfile header record name)',
         placeHolder: 'SFLCTL',
         validateInput: validateRecordName
     });
@@ -546,6 +546,9 @@ function generateRecordLines(config: NewRecordConfig): string[] {
         case 'SFL':
             if (config.subfileConfig) {
                 lines.push(generateSubfileControlLine(config.name, config.subfileConfig));
+                lines.push(generateSubfileSizeLine(config.subfileConfig.size));
+                lines.push(generateSubfilePageLine(config.subfileConfig.page));
+                lines.push(...generateSubfileOtherLines());
             }
             break;
 
@@ -693,6 +696,7 @@ function generateSubfilePageLine(page: number): string {
 function generateSubfileOtherLines(): string[] {
     let lines : string[] = [];
     const lineStart = ' '.repeat(5) + 'A' + ' '.repeat(38);
+    const lineStartField = ' '.repeat(5) + 'A' + ' '.repeat(12);
 
     // Define lines
     lines[0] = lineStart + 'OVERLAY';
@@ -707,6 +711,12 @@ function generateSubfileOtherLines(): string[] {
     lines[4] = lines[4].substring(0, 7) + 'N80' + lines[4].substring(10);
     lines[6] = lines[6].substring(0, 7) + 'N80' + lines[6].substring(10);
     lines[5] = lines[5].substring(0, 8) + '80' + lines[5].substring(10);
+    // Add lines with hidden fields
+    lines[7] = lineStartField + 'NRR' + ' '.repeat(12) + '4S 0H';
+    lines[8] = lineStartField + 'NBR' + ' '.repeat(12) + '4S 0H';
+    lines[9] = lineStartField + 'WSRECNAM' + ' '.repeat(6) + '10A  H';
+    lines[10] = lineStartField + 'WSFLDNAM' + ' '.repeat(6) + '10A  H';
+    lines[11] = lineStartField + 'WSFLRRN' + ' '.repeat(8) + '5S 0 H';
 
     return lines;
 };

--- a/src/dspf-edit.commands/dspf-edit.new-record.ts
+++ b/src/dspf-edit.commands/dspf-edit.new-record.ts
@@ -559,6 +559,7 @@ function generateRecordLines(config: NewRecordConfig): string[] {
                 lines.push(...generateWindowBorderLines());
                 lines.push(generateSubfileSizeLine(config.subfileConfig.size));
                 lines.push(generateSubfilePageLine(config.subfileConfig.page));
+                lines.push(...generateSubfileOtherLines());
             }
             break;
     };
@@ -651,10 +652,9 @@ function generateWindowTitleLines(title: string): string[] {
  * @returns Array of formatted window border lines
  */
 function generateWindowBorderLines(): string[] {
-    return [
-        '     A                                      WDWBORDER((*COLOR BLU) (*DSPATR RI)-',
-        "     A                                       (*CHAR '        ')) "
-    ];
+    const baseLine = ' '.repeat(5) + 'A' + ' '.repeat(38) + 'WDWBORDER((*COLOR BLU) (*DSPATR RI)-';
+    const continuationLine = ' '.repeat(5) + 'A' + ' '.repeat(39) + "(*CHAR '" + ' '.repeat(8) + "')) ";
+    return [baseLine, continuationLine];
 };
 
 /**
@@ -684,6 +684,31 @@ function generateSubfileSizeLine(size: number): string {
  */
 function generateSubfilePageLine(page: number): string {
     return ' '.repeat(5) + 'A' + ' '.repeat(38) + 'SFLPAG(' + String(page).padStart(4, '0') + ')';
+};
+
+/**
+ * Generates rest of subfile control lines.
+ * @returns Formatted lines with RTVCSRLOC, OVERLAY, SFLCSRRRN, SFLDSP, SFLDSPCTL, SFLCLR, SLFEND(*MORE)
+ */
+function generateSubfileOtherLines(): string[] {
+    let lines : string[] = [];
+    const lineStart = ' '.repeat(5) + 'A' + ' '.repeat(38);
+
+    // Define lines
+    lines[0] = lineStart + 'OVERLAY';
+    lines[1] = lineStart + 'RTNCSRLOC(&WSRECNAM &WSFLDNAM)';
+    lines[2] = lineStart + 'SFLCSRRRN(&WSFLRRN)';
+    lines[3] = lineStart + 'SFLDSP';
+    lines[4] = lineStart + 'SFLDSPCTL';
+    lines[5] = lineStart + 'SFLCLR';
+    lines[6] = lineStart + 'SFLEND(*MORE)';
+    // Add indicators to SFLDSP, SFLDSPCTL, SFLCLR, SFLEND
+    lines[3] = lines[3].substring(0, 7) + 'N80' + lines[3].substring(10);
+    lines[4] = lines[4].substring(0, 7) + 'N80' + lines[4].substring(10);
+    lines[6] = lines[6].substring(0, 7) + 'N80' + lines[6].substring(10);
+    lines[5] = lines[5].substring(0, 8) + '80' + lines[5].substring(10);
+
+    return lines;
 };
 
 // DOCUMENT INSERTION FUNCTIONS

--- a/src/dspf-edit.commands/dspf-edit.new-record.ts
+++ b/src/dspf-edit.commands/dspf-edit.new-record.ts
@@ -7,9 +7,9 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { recordExists, DspsizConfig,
-    checkIfDspsizNeeded, collectDspsizConfiguration, generateDspsizLines } from '../dspf-edit.utils/dspf-edit.helper';
+    checkIfDspsizNeeded, collectDspsizConfiguration, generateDspsizLines, 
+    checkForEditorAndDocument} from '../dspf-edit.utils/dspf-edit.helper';
 import { fileSizeAttributes } from '../dspf-edit.model/dspf-edit.model';
-import { ExtensionState } from '../dspf-edit.states/state';
 
 // INTERFACES AND TYPES
 
@@ -93,15 +93,12 @@ export function newRecord(context: vscode.ExtensionContext): void {
  */
 async function handleNewRecordCommand(node: DdsNode): Promise<void> {
     try {
-        const element = node.ddsElement;
-
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
         if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
-
+        
         // Check if DSPSIZ needs to be defined
         const needsDspsiz = await checkIfDspsizNeeded(editor);
 

--- a/src/dspf-edit.commands/dspf-edit.sort-elements.ts
+++ b/src/dspf-edit.commands/dspf-edit.sort-elements.ts
@@ -6,8 +6,8 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { ExtensionState } from '../dspf-edit.states/state';
 import { fieldsPerRecords, FieldInfo, ConstantInfo, DdsRecord } from '../dspf-edit.model/dspf-edit.model';
+import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
@@ -52,10 +52,9 @@ export function sortElements(context: vscode.ExtensionContext): void {
  */
 async function handleSortElementsCommand(node: DdsNode): Promise<void> {
     try {
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
         if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.commands/dspf-edit.view-structure.ts
+++ b/src/dspf-edit.commands/dspf-edit.view-structure.ts
@@ -6,21 +6,19 @@
 
 import * as vscode from 'vscode';
 import { DdsTreeProvider } from '../dspf-edit.providers/dspf-edit.providers';
-import { isDdsFile } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, isDdsFile } from '../dspf-edit.utils/dspf-edit.helper';
 import { parseDocument } from '../dspf-edit.parser/dspf-edit.parser';
-import { ExtensionState } from '../dspf-edit.states/state';
 
 export function viewStructure(context: vscode.ExtensionContext, treeProvider: DdsTreeProvider) {
 
     context.subscriptions.push(
 		vscode.commands.registerCommand('dds-aid.view-structure', () => {
-			const editor = ExtensionState.lastDdsEditor;
-			const document = editor?.document ?? ExtensionState.lastDdsDocument;
+			// Check for editor and document
+			const { editor, document } = checkForEditorAndDocument();
 			if (!document || !editor) {
-				vscode.window.showErrorMessage('No DDS editor found.');
 				return;
-			};
-			
+			};		
+
 			if (editor && document && isDdsFile(document)) {
 				const text = editor.document.getText();
 				treeProvider.setElements(parseDocument(text));

--- a/src/dspf-edit.commands/dspf-edit.window-resize.ts
+++ b/src/dspf-edit.commands/dspf-edit.window-resize.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fileSizeAttributes, fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { ExtensionState } from '../dspf-edit.states/state';
+import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
@@ -82,18 +82,17 @@ export function windowResize(context: vscode.ExtensionContext): void {
  */
 async function handleWindowResizeCommand(node: DdsNode): Promise<void> {
     try {
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
+        if (!document || !editor) {
+            return;
+        };
+        
         const element = node.ddsElement;
 
         // Validate element type - only records can have windows
         if (element.kind !== "record") {
             vscode.window.showWarningMessage("Window resize can only be applied to record formats.");
-            return;
-        };
-
-        const editor = ExtensionState.lastDdsEditor;
-        const document = editor?.document ?? ExtensionState.lastDdsDocument;
-        if (!document || !editor) {
-            vscode.window.showErrorMessage('No DDS editor found.');
             return;
         };
 

--- a/src/dspf-edit.parser/dspf-edit.parser.ts
+++ b/src/dspf-edit.parser/dspf-edit.parser.ts
@@ -157,7 +157,7 @@ function parseSingleDdsLine(
 function extractLineComponents(trimmedLine: string) {
     const indicators = parseDdsIndicators(trimmedLine.substring(2, 11));
     const fieldName = trimmedLine.substring(13, 23).trim();
-    const rowText = trimmedLine.substring(34, 37).trim();
+    const rowText = trimmedLine.substring(33, 36).trim();
     const colText = trimmedLine.substring(36, 39).trim();
     const row = rowText ? Number(rowText) : undefined;
     const col = colText ? Number(colText) : undefined;

--- a/src/dspf-edit.providers/dspf-edit.providers.ts
+++ b/src/dspf-edit.providers/dspf-edit.providers.ts
@@ -507,7 +507,7 @@ export class DdsNode extends vscode.TreeItem {
 		this.description = this.getDescription(ddsElement);
 		
 		if (label === '📂 Records') {
-			this.contextValue = 'group:records' 
+			this.contextValue = 'group:records'; 
 		} else {
 			this.contextValue = ddsElement.kind;
 		};

--- a/src/dspf-edit.utils/dspf-edit.helper.ts
+++ b/src/dspf-edit.utils/dspf-edit.helper.ts
@@ -250,7 +250,7 @@ export function isAttributeLine(line: string): boolean {
     };
     // If there is a field, returns false    
     const fieldName = line.substring(18, 27).trim();
-    if (fieldName != '') {
+    if (fieldName !== '') {
         return false;
     };
 


### PR DESCRIPTION
- Refactored: Internal refactoring and code cleanup.
- Fixed: 3-digit rows/columns were not being parsed correctly.
- Changed: Improved subfile record creation (both regular and window subfiles):
  - Every subfile is created with a control record (header), and the subfile record (detail).
  - The control record is created with: SFLSIZ, SFLPAG, OVERLAY, RTNCSRLOC, SFLCSRRRN, SFLDSP, SFLDSPCTL,
    SFLCLR and SFLEND. SFLDSP, SFLDSPCTL, SLFEND with N80 indicator, and SFLCLR with 80 indicator.
    Also some hidden fields are added: NRR, NBR, WSRECNAM, WSFLDNAM, and WSFLRRN.
    (all this will be configurable in future versions).
    