### PR TITLE
v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,3 +141,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### [0.9.0] - 2025-09-28
 ## Added
 - Ability to remove a constant or field attribute from the DDS.
+
+### [0.9.1] - 2025-10-03
+## Fixed
+- The extension no longer validates whether a constant fits on the screen. Constants that don’t fit can now be viewed by resizing the window.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The extension provides a **navigable schema view** of the DDS source file that i
   - Right-click options:
     - Edit field.
     - Copy field (to the same or different record).
+    - Remove field.
     - Center field on screen.
     - Change position (absolute position/relative to existing constant/field).
     - Apply colors/attributes.
@@ -64,6 +65,7 @@ The extension provides a **navigable schema view** of the DDS source file that i
 
 - **Attributes**
     - Add / Remove / Change indicators.
+    - Remove attribute.
 
 ---
 
@@ -101,8 +103,8 @@ Some features may not work as expected. Please leave an issue if something is no
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**0.9.0** - 2025-09-28
-- Added: Ability to remove a constant or field attribute from the DDS.
+**0.9.1** - 2025-10-03
+- Fixed: The extension no longer validates whether a constant fits on the screen. Constants that don’t fit can now be viewed by resizing the window.
 
 ---
 

--- a/src/dspf-edit.commands/dspf-edit.edit-constant.ts
+++ b/src/dspf-edit.commands/dspf-edit.edit-constant.ts
@@ -153,7 +153,7 @@ async function getConstantTextFromUser(
     const newText = await vscode.window.showInputBox({
         title: title,
         value: defaultValue,
-        validateInput: value => validateConstantText(value, column)
+        validateInput: value => validateConstantText(value)
     });
 
     return newText || null;
@@ -470,16 +470,9 @@ function parseConstantFromLine(lineText: string, lineIndex: number): ExistingCon
  * @param column - Optional column position for length validation
  * @returns Error message or null if valid
  */
-function validateConstantText(value: string, column?: number): string | null {
+function validateConstantText(value: string): string | null {
     if (value === '') {
         return "The constant text cannot be empty.";
-    };
-
-    if (column) {
-        const totalLength = value.length + 2; // +2 for quotes
-        if (column + totalLength - 1 > fileSizeAttributes.maxCol1) {
-            return "Text too long for the specified position.";
-        };
     };
 
     return null;


### PR DESCRIPTION
### [0.9.1] - 2025-10-03
## Fixed
- The extension no longer validates whether a constant fits on the screen. Constants that don’t fit can now be viewed by resizing the window.