### PR TITLE
feat: add cursor movement for constants/fields. changes in filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
+## [0.12.0] - 2025-11-28
+### Added
+- Now you can move a constant or field, one or five positions to the right or left using a button directly from the schema view.
+### Fixed
+- Changes to the filter button. It now maintains the filter by file (you can have a different filter applied to another file while they remain open).
+
 ## [0.11.0] - 2025-11-15
 ### Added
 - Now you can filter the records you want to work with using the filter button. Also you can select if you want to see the constants or fields, or both.

--- a/README.md
+++ b/README.md
@@ -103,8 +103,9 @@ Some features may not work as expected. Please leave an issue if something is no
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**0.11.0** - 2025-11-15
-- New feature: Now, you can filter the records you want to work with, using the icon. Also you can select if you want to see only constants or fields, in those records.
+**0.12.0** - 2025-11-28
+- New feature: Now you can move a constant or field, one or five positions to the right or left using a button directly from the schema view.
+- Fixed: Changes to the filter button. It now maintains the filter by file (you can have a different filter applied to another file while they remain open).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"
@@ -178,25 +178,65 @@
         "icon": "$(edit)"
       },
       {
-        "command": "ddsEdit.filterTreeView",
+        "command": "dspf-edit.filterTreeView",
         "title": "Filter Elements",
         "icon": "$(filter)"
       },
       {
-        "command": "ddsEdit.showAllElements",
+        "command": "dspf-edit.showAllElements",
         "title": "Show All Elements",
         "icon": "$(eye)"
+      },
+      {
+        "command": "dspf-edit.moveConstantLeft1",
+        "title": "Move Constant Left(1)",
+        "icon": "$(arrow-left)"
+      },
+      {
+        "command": "dspf-edit.moveConstantRight1",
+        "title": "Move Constant Right(1)",
+        "icon": "$(arrow-right)"
+      },
+      {
+        "command": "dspf-edit.moveConstantLeft5",
+        "title": "Move Constant Left(5)",
+        "icon": "$(chevron-left)"
+      },
+      {
+        "command": "dspf-edit.moveConstantRight5",
+        "title": "Move Constant Right(5)",
+        "icon": "$(chevron-right)"
+      },
+      {
+        "command": "dspf-edit.moveFieldLeft1",
+        "title": "Move Field Left(1)",
+        "icon": "$(arrow-left)"
+      },
+      {
+        "command": "dspf-edit.moveFieldRight1",
+        "title": "Move Field Right(1)",
+        "icon": "$(arrow-right)"
+      },
+      {
+        "command": "dspf-edit.moveFieldLeft5",
+        "title": "Move Field Left(5)",
+        "icon": "$(chevron-left)"
+      },
+      {
+        "command": "dspf-edit.moveFieldRight5",
+        "title": "Move Field Right(5)",
+        "icon": "$(chevron-right)"
       }
     ],
     "menus": {
       "view/title": [
         {
-          "command": "ddsEdit.filterTreeView",
+          "command": "dspf-edit.filterTreeView",
           "when": "view == dspf-edit.schema-view",
           "group": "navigation@1"
         },
         {
-          "command": "ddsEdit.showAllElements",
+          "command": "dspf-edit.showAllElements",
           "when": "view == dspf-edit.schema-view",
           "group": "navigation@2"
         }
@@ -345,22 +385,63 @@
         {
           "command" : "dspf-edit.remove-element",
           "when" : "view == dspf-edit.schema-view && (viewItem == constant || viewItem == field)",
-          "group" : "inline"
+          "group" : "inline@99"
         },
         {
           "command" : "dspf-edit.remove-attribute",
           "when" : "view == dspf-edit.schema-view && (viewItem == constantAttribute || viewItem == fieldAttribute)",
-          "group" : "inline"
+          "group" : "inline@99"
         },
         {
           "command" : "dspf-edit.rename-record",
           "when" : "view == dspf-edit.schema-view && viewItem == record",
-          "group" : "inline"
+          "group" : "inline@99"
         },
         {
           "command" : "dspf-edit.rename-field",
           "when" : "view == dspf-edit.schema-view && viewItem == field",
-          "group" : "inline"
+          "group" : "inline@99"
+        },
+        {
+          "command": "dspf-edit.moveConstantLeft5",
+          "when": "view == dspf-edit.schema-view && viewItem == constant",
+          "group": "inline@1"
+        },
+        {
+          "command": "dspf-edit.moveConstantLeft1",
+          "when": "view == dspf-edit.schema-view && viewItem == constant",
+          "group": "inline@2"
+        },
+        {
+          "command": "dspf-edit.moveConstantRight1",
+          "when": "view == dspf-edit.schema-view && viewItem == constant",
+          "group": "inline@3"
+        },
+        {
+          "command": "dspf-edit.moveConstantRight5",
+          "when": "view == dspf-edit.schema-view && viewItem == constant",
+          "group": "inline@4"
+        },
+
+        {
+          "command": "dspf-edit.moveFieldLeft5",
+          "when": "view == dspf-edit.schema-view && viewItem == field",
+          "group": "inline@1"
+        },
+        {
+          "command": "dspf-edit.moveFieldLeft1",
+          "when": "view == dspf-edit.schema-view && viewItem == field",
+          "group": "inline@2"
+        },
+        {
+          "command": "dspf-edit.moveFieldRight1",
+          "when": "view == dspf-edit.schema-view && viewItem == field",
+          "group": "inline@3"
+        },
+        {
+          "command": "dspf-edit.moveFieldRight5",
+          "when": "view == dspf-edit.schema-view && viewItem == field",
+          "group": "inline@4"
         }
       ]
     }

--- a/src/dspf-edit.commands/dspf-edit.add-attribute.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-attribute.ts
@@ -99,6 +99,8 @@ async function handleAddAttributeCommand(node: DdsNode): Promise<void> {
 
         // Apply the selected attributes to the element
         await addAttributesToElement(editor, node.ddsElement, selectedAttributes);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
 
         const attributesSummary = selectedAttributes.map(a =>
             `${a.attribute}${a.indicators.length > 0 ? `(${a.indicators.join(',')})` : ''}`

--- a/src/dspf-edit.commands/dspf-edit.add-buttons.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-buttons.ts
@@ -391,6 +391,9 @@ async function applyButtonsToRecord(
     };
 
     await vscode.workspace.applyEdit(edit);
+    await vscode.commands.executeCommand('cursorRight');
+    await vscode.commands.executeCommand('cursorLeft');
+    
     vscode.window.showInformationMessage(`Added ${buttons.length} buttons to record ${recordInfo.name}.`);
 };
 

--- a/src/dspf-edit.commands/dspf-edit.add-color.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-color.ts
@@ -99,6 +99,9 @@ async function handleAddColorCommand(node: DdsNode): Promise<void> {
 
         // Apply the selected colors to the element
         await addColorsToElement(editor, node.ddsElement, selectedColors);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
+        
         
         const colorsSummary = selectedColors.map(c => 
             `${c.color}${c.indicators.length > 0 ? `(${c.indicators.join(',')})` : ''}`

--- a/src/dspf-edit.commands/dspf-edit.add-editing-keywords.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-editing-keywords.ts
@@ -174,6 +174,9 @@ async function handleEditingKeywordsCommand(node: DdsNode): Promise<void> {
 
         // Apply the selected editing to the field
         await addEditingToField(editor, node.ddsElement, selectedEditing);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
+        
 
         const editingSummary = selectedEditing.map(edit =>
             `${edit.type}(${edit.value}${edit.modifier ? ' ' + edit.modifier : ''})`
@@ -755,6 +758,8 @@ async function removeEditingFromField(editor: vscode.TextEditor, element: any): 
     };
 
     await vscode.workspace.applyEdit(workspaceEdit);
+    await vscode.commands.executeCommand('cursorRight');
+    await vscode.commands.executeCommand('cursorLeft');
 
     vscode.window.showInformationMessage(`Removed field editing from ${element.name}.`);
 };

--- a/src/dspf-edit.commands/dspf-edit.add-error-messages.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-error-messages.ts
@@ -85,6 +85,9 @@ async function handleAddErrorMessageCommand(node: DdsNode): Promise<void> {
 
             if (action === 'Remove all error messages') {
                 await removeErrorMessagesFromField(editor, field);
+                await vscode.commands.executeCommand('cursorRight');
+                await vscode.commands.executeCommand('cursorLeft');
+                
                 vscode.window.showInformationMessage(`Removed all error messages from field '${field.name}'.`);
                 return;
             };
@@ -105,6 +108,8 @@ async function handleAddErrorMessageCommand(node: DdsNode): Promise<void> {
 
         // Apply the selected error messages to the field
         await addErrorMessagesToField(editor, field, selectedErrorMessages);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
 
         const messagesSummary = selectedErrorMessages.map(msg =>
             `${msg.indicator}: "${msg.messageText}"`

--- a/src/dspf-edit.commands/dspf-edit.add-indicators.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-indicators.ts
@@ -91,6 +91,9 @@ async function handleAddIndicatorsCommand(node: DdsNode): Promise<void> {
 
             if (action === 'Remove all indicators') {
                 await removeIndicatorsFromElement(editor, node.ddsElement);
+                await vscode.commands.executeCommand('cursorRight');
+                await vscode.commands.executeCommand('cursorLeft');
+                
                 (node.ddsElement.kind === 'constant' || node.ddsElement.kind === 'field') ?
                 vscode.window.showInformationMessage(`Removed all indicators from ${node.ddsElement.name}.`) :
                 vscode.window.showInformationMessage(`Removed all indicators from attribute.`);
@@ -99,11 +102,17 @@ async function handleAddIndicatorsCommand(node: DdsNode): Promise<void> {
 
             if (action === 'Replace all indicators') {
                 await removeIndicatorsFromElement(editor, node.ddsElement);
+                await vscode.commands.executeCommand('cursorRight');
+                await vscode.commands.executeCommand('cursorLeft');
+                
                 // Continue to add new indicators
             };
 
             if (action === 'Modify existing indicators') {
                 await modifyExistingIndicators(editor, node.ddsElement, currentIndicators);
+                await vscode.commands.executeCommand('cursorRight');
+                await vscode.commands.executeCommand('cursorLeft');
+                
                 return;
             };
 
@@ -127,6 +136,8 @@ async function handleAddIndicatorsCommand(node: DdsNode): Promise<void> {
 
         // Apply the selected indicators to the element
         await setIndicatorsForElement(editor, node.ddsElement, allIndicators);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
 
         const indicatorsSummary = formatIndicatorsSummary(allIndicators);
         const actionText = action === 'Add more indicators' ? 'Added' : 'Set';

--- a/src/dspf-edit.commands/dspf-edit.add-keys.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-keys.ts
@@ -148,6 +148,8 @@ async function handleAddKeyCommandCommand(node: DdsNode): Promise<void> {
                 await addKeyCommandsToFile(editor, selectedKeyCommands);
                 break;
         };
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
 
         const commandsSummary = selectedKeyCommands.map(k =>
             `${k.type}${k.keyNumber}${k.indicators.length > 0 ? `(${k.indicators.join(',')})` : ''}`

--- a/src/dspf-edit.commands/dspf-edit.add-validity-check.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-validity-check.ts
@@ -111,6 +111,8 @@ async function handleAddValidityCheckCommand(node: DdsNode): Promise<void> {
 
         // Apply the selected validity checks to the field
         await addValidityChecksToField(editor, node.ddsElement, selectedValidityChecks);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
 
         const checksSummary = selectedValidityChecks.map(vc =>
             `${vc.type}(${vc.parameters.join(' ')})`

--- a/src/dspf-edit.commands/dspf-edit.center.ts
+++ b/src/dspf-edit.commands/dspf-edit.center.ts
@@ -66,7 +66,9 @@ async function handleCenterCommand(node: DdsNode): Promise<void> {
 
         // Apply the position change
         await applyPositionChange(editor, element, newPosition);
-
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
+        
         // Show success message
         vscode.window.showInformationMessage(
             `${element.name} centered in ${windowSize.cols} columns`

--- a/src/dspf-edit.commands/dspf-edit.change-position.ts
+++ b/src/dspf-edit.commands/dspf-edit.change-position.ts
@@ -88,6 +88,8 @@ async function handleChangePositionCommand(node: DdsNode): Promise<void> {
 
         // Update the element position in the document
         await updateElementPosition(editor, element, newPosition);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
 
         // Show success message
         vscode.window.showInformationMessage(

--- a/src/dspf-edit.commands/dspf-edit.copy-constant.ts
+++ b/src/dspf-edit.commands/dspf-edit.copy-constant.ts
@@ -123,6 +123,8 @@ async function handleCopyConstantCommand(node: DdsNode): Promise<void> {
 
         // Insert the copied constant into the target record
         await insertCopiedConstant(editor, copyConfig.targetRecord, copiedConstantLines);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
 
         // Show success message
         vscode.window.showInformationMessage(

--- a/src/dspf-edit.commands/dspf-edit.copy-field.ts
+++ b/src/dspf-edit.commands/dspf-edit.copy-field.ts
@@ -143,6 +143,8 @@ async function handleCopyFieldCommand(node: DdsNode): Promise<void> {
 
         // Insert the copied field into the target record
         await insertCopiedField(editor, copyConfig.targetRecord, copiedFieldLines);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
 
         // Show success message
         const positionInfo = isHidden ? "(hidden field)" : `at position ${copyConfig.targetPosition!.row}, ${copyConfig.targetPosition!.column}`;

--- a/src/dspf-edit.commands/dspf-edit.copy-record.ts
+++ b/src/dspf-edit.commands/dspf-edit.copy-record.ts
@@ -95,6 +95,8 @@ async function handleCopyRecordCommand(node: DdsNode): Promise<void> {
 
         // Insert the copied record into the document
         await insertCopiedRecord(editor, modifiedLines);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
 
         // Show success message
         vscode.window.showInformationMessage(

--- a/src/dspf-edit.commands/dspf-edit.delete-record.ts
+++ b/src/dspf-edit.commands/dspf-edit.delete-record.ts
@@ -63,6 +63,8 @@ async function handleDeleteRecordCommand(node: DdsNode): Promise<void> {
 
         // Perform the deletion
         await deleteRecordLines(editor, recordBoundaries);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
         
         vscode.window.showInformationMessage(
             `Record '${element.name}' has been successfully deleted.`

--- a/src/dspf-edit.commands/dspf-edit.edit-constant.ts
+++ b/src/dspf-edit.commands/dspf-edit.edit-constant.ts
@@ -582,6 +582,9 @@ async function insertNewConstant(editor: vscode.TextEditor, constantInfo: NewCon
     };
 
     await vscode.workspace.applyEdit(workspaceEdit);
+    await vscode.commands.executeCommand('cursorRight');
+    await vscode.commands.executeCommand('cursorLeft');
+    
     vscode.window.showInformationMessage(`Constant added successfully.`);
 };
 

--- a/src/dspf-edit.commands/dspf-edit.edit-field.ts
+++ b/src/dspf-edit.commands/dspf-edit.edit-field.ts
@@ -228,6 +228,8 @@ async function handleEditFieldCommand(node: DdsNode): Promise<void> {
 
         // Apply the changes to the document
         await applyFieldChanges(editor, element, newName, newSize);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
         
         if ('name' in element) {
             vscode.window.showInformationMessage(

--- a/src/dspf-edit.commands/dspf-edit.fill-constant.ts
+++ b/src/dspf-edit.commands/dspf-edit.fill-constant.ts
@@ -70,6 +70,8 @@ async function handleFillConstantCommand(node: DdsNode): Promise<void> {
 
         // Fill the constant with the collected information 
         await fillElement(editor, node.ddsElement, fillInformation);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
 
         vscode.window.showInformationMessage(
             `${node.ddsElement.name} filled.`

--- a/src/dspf-edit.commands/dspf-edit.move-constants.ts
+++ b/src/dspf-edit.commands/dspf-edit.move-constants.ts
@@ -1,0 +1,168 @@
+/*
+    Christian Larsen, 2025
+    "RPG structure"
+    dspf-edit.move-constants.ts
+*/
+
+import * as vscode from 'vscode';
+import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
+import { fileSizeAttributes } from '../dspf-edit.model/dspf-edit.model';
+import { checkForEditorAndDocument, findEndLineIndex } from '../dspf-edit.utils/dspf-edit.helper';
+
+/**
+ * Gets the maximum columns value from fileSizeAttributes
+ */
+function getMaxCols(): number {
+    const maxCol1 = fileSizeAttributes.maxCol1 || 0;
+    const maxCol2 = fileSizeAttributes.maxCol2 || 0;
+    const maxCol = Math.max(maxCol1, maxCol2);
+    return maxCol > 0 ? maxCol : 132;
+}
+
+// COMMAND REGISTRATION FUNCTIONS
+
+/**
+ * Registers the move constant left (1 position) command.
+ * @param context - The VS Code extension context
+ */
+export function moveConstantLeft1(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand("dspf-edit.moveConstantLeft1", async (node: DdsNode) => {
+            await handleMoveConstantCommand(node, -1);
+        })
+    );
+}
+
+/**
+ * Registers the move constant left (5 positions) command.
+ * @param context - The VS Code extension context
+ */
+export function moveConstantLeft5(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand("dspf-edit.moveConstantLeft5", async (node: DdsNode) => {
+            await handleMoveConstantCommand(node, -5);
+        })
+    );
+}
+
+/**
+ * Registers the move constant right (1 position) command.
+ * @param context - The VS Code extension context
+ */
+export function moveConstantRight1(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand("dspf-edit.moveConstantRight1", async (node: DdsNode) => {
+            await handleMoveConstantCommand(node, 1);
+        })
+    );
+}
+
+/**
+ * Registers the move constant right (5 positions) command.
+ * @param context - The VS Code extension context
+ */
+export function moveConstantRight5(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand("dspf-edit.moveConstantRight5", async (node: DdsNode) => {
+            await handleMoveConstantCommand(node, 5);
+        })
+    );
+}
+
+// COMMAND HANDLER
+
+/**
+ * Handles the move constant command for an existing DDS constant.
+ * @param node - The DDS node containing the constant to move
+ * @param offset - The number of positions to move (negative for left, positive for right)
+ */
+async function handleMoveConstantCommand(node: DdsNode, offset: number): Promise<void> {
+    try {
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
+        if (!document || !editor) {
+            return;
+        }
+
+        const element = node.ddsElement;
+
+        // Validate that the element is a constant
+        if (element.kind !== "constant") {
+            vscode.window.showWarningMessage("Only constants can be moved.");
+            return;
+        }
+
+        // Calculate new column position
+        const newColumn = element.column + offset;
+        const maxCols = getMaxCols();
+
+        // Validate new position
+        if (newColumn < 1) {
+            vscode.window.showWarningMessage(`Cannot move constant. Minimum column is 1.`);
+            return;
+        }
+
+        if (newColumn > maxCols) {
+            vscode.window.showWarningMessage(`Cannot move constant. Maximum column is ${maxCols}.`);
+            return;
+        }
+
+        // Apply the constant update with new position
+        await moveConstantToNewColumn(editor, element, newColumn);
+
+        // Set focus on the editor and position cursor on the constant
+        await vscode.window.showTextDocument(editor.document, {
+            viewColumn: editor.viewColumn,
+            preserveFocus: false
+        });
+
+        // Position cursor at the beginning of the constant
+        const constantPosition = new vscode.Position(element.lineIndex, 44); // Start of constant value
+        editor.selection = new vscode.Selection(constantPosition, constantPosition);
+        editor.revealRange(
+            new vscode.Range(constantPosition, constantPosition),
+            vscode.TextEditorRevealType.InCenterIfOutsideViewport
+        );
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
+
+    } catch (error) {
+        console.error('Error moving constant:', error);
+        vscode.window.showErrorMessage('An error occurred while moving the constant.');
+    }
+}
+
+// CONSTANT MOVEMENT FUNCTIONS
+
+/**
+ * Moves a constant to a new column position by updating only the column field.
+ * @param editor - The active text editor
+ * @param element - The constant element to move
+ * @param newColumn - The new column position
+ */
+async function moveConstantToNewColumn(
+    editor: vscode.TextEditor,
+    element: any,
+    newColumn: number
+): Promise<void> {
+    const uri = editor.document.uri;
+    const workspaceEdit = new vscode.WorkspaceEdit();
+    const endLineIndex = findEndLineIndex(editor.document, element.lineIndex);
+
+    // Format the new column value (3 characters, right-aligned)
+    const formattedCol = String(newColumn).padStart(3, ' ');
+
+    // Update only the column positions (characters 42-44, 0-indexed: 41-43)
+    // We need to update all lines of the constant (first line only, as column is only on first line)
+    const firstLine = editor.document.lineAt(element.lineIndex);
+    
+    // Replace characters at positions 41-43 (0-indexed) with new column value
+    const range = new vscode.Range(
+        element.lineIndex, 41,  // Start at position 41 (column field start)
+        element.lineIndex, 44   // End at position 44 (column field end)
+    );
+
+    workspaceEdit.replace(uri, range, formattedCol);
+
+    await vscode.workspace.applyEdit(workspaceEdit);
+}

--- a/src/dspf-edit.commands/dspf-edit.move-fields.ts
+++ b/src/dspf-edit.commands/dspf-edit.move-fields.ts
@@ -1,0 +1,168 @@
+/*
+    Christian Larsen, 2025
+    "RPG structure"
+    dspf-edit.move-fields.ts
+*/
+
+import * as vscode from 'vscode';
+import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
+import { fileSizeAttributes } from '../dspf-edit.model/dspf-edit.model';
+import { checkForEditorAndDocument, findEndLineIndex } from '../dspf-edit.utils/dspf-edit.helper';
+
+/**
+ * Gets the maximum columns value from fileSizeAttributes
+ */
+function getMaxCols(): number {
+    const maxCol1 = fileSizeAttributes.maxCol1 || 0;
+    const maxCol2 = fileSizeAttributes.maxCol2 || 0;
+    const maxCol = Math.max(maxCol1, maxCol2);
+    return maxCol > 0 ? maxCol : 132;
+}
+
+// COMMAND REGISTRATION FUNCTIONS
+
+/**
+ * Registers the move field left (1 position) command.
+ * @param context - The VS Code extension context
+ */
+export function moveFieldLeft1(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand("dspf-edit.moveFieldLeft1", async (node: DdsNode) => {
+            await handleMoveFieldCommand(node, -1);
+        })
+    );
+}
+
+/**
+ * Registers the move field left (5 positions) command.
+ * @param context - The VS Code extension context
+ */
+export function moveFieldLeft5(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand("dspf-edit.moveFieldLeft5", async (node: DdsNode) => {
+            await handleMoveFieldCommand(node, -5);
+        })
+    );
+}
+
+/**
+ * Registers the move field right (1 position) command.
+ * @param context - The VS Code extension context
+ */
+export function moveFieldRight1(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand("dspf-edit.moveFieldRight1", async (node: DdsNode) => {
+            await handleMoveFieldCommand(node, 1);
+        })
+    );
+}
+
+/**
+ * Registers the move field right (5 positions) command.
+ * @param context - The VS Code extension context
+ */
+export function moveFieldRight5(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand("dspf-edit.moveFieldRight5", async (node: DdsNode) => {
+            await handleMoveFieldCommand(node, 5);
+        })
+    );
+}
+
+// COMMAND HANDLER
+
+/**
+ * Handles the move field command for an existing DDS field.
+ * @param node - The DDS node containing the field to move
+ * @param offset - The number of positions to move (negative for left, positive for right)
+ */
+async function handleMoveFieldCommand(node: DdsNode, offset: number): Promise<void> {
+    try {
+        // Check for editor and document
+        const { editor, document } = checkForEditorAndDocument();
+        if (!document || !editor) {
+            return;
+        }
+
+        const element = node.ddsElement;
+
+        // Validate that the element is a field
+        if (element.kind !== "field") {
+            vscode.window.showWarningMessage("Only fields can be moved.");
+            return;
+        }
+
+        // Calculate new column position
+        const newColumn = (element.column) ? element.column + offset : element.column;
+        const maxCols = getMaxCols();
+
+        // Validate new position
+        if (!newColumn || newColumn < 1) {
+            vscode.window.showWarningMessage(`Cannot move field.`);
+            return;
+        }
+
+        if (newColumn > maxCols) {
+            vscode.window.showWarningMessage(`Cannot move field. Maximum column is ${maxCols}.`);
+            return;
+        }
+
+        // Apply the field update with new position
+        await moveFieldToNewColumn(editor, element, newColumn);
+
+        // Set focus on the editor and position cursor on the field
+        await vscode.window.showTextDocument(editor.document, {
+            viewColumn: editor.viewColumn,
+            preserveFocus: false
+        });
+
+        // Position cursor at the beginning of the field name
+        const fieldPosition = new vscode.Position(element.lineIndex, 18); // Start of field name
+        editor.selection = new vscode.Selection(fieldPosition, fieldPosition);
+        editor.revealRange(
+            new vscode.Range(fieldPosition, fieldPosition),
+            vscode.TextEditorRevealType.InCenterIfOutsideViewport
+        );
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
+
+    } catch (error) {
+        console.error('Error moving field:', error);
+        vscode.window.showErrorMessage('An error occurred while moving the field.');
+    }
+}
+
+// FIELD MOVEMENT FUNCTIONS
+
+/**
+ * Moves a field to a new column position by updating only the column field.
+ * @param editor - The active text editor
+ * @param element - The field element to move
+ * @param newColumn - The new column position
+ */
+async function moveFieldToNewColumn(
+    editor: vscode.TextEditor,
+    element: any,
+    newColumn: number
+): Promise<void> {
+    const uri = editor.document.uri;
+    const workspaceEdit = new vscode.WorkspaceEdit();
+    const endLineIndex = findEndLineIndex(editor.document, element.lineIndex);
+
+    // Format the new column value (3 characters, right-aligned)
+    const formattedCol = String(newColumn).padStart(3, ' ');
+
+    // Update only the column positions (characters 42-44, 0-indexed: 41-43)
+    // We need to update all lines of the field (first line only, as column is only on first line)
+    const firstLine = editor.document.lineAt(element.lineIndex);
+    
+    // Replace characters at positions 41-43 (0-indexed) with new column value
+    const range = new vscode.Range(
+        element.lineIndex, 41,  // Start at position 41 (column field start)
+        element.lineIndex, 44   // End at position 44 (column field end)
+    );
+
+    workspaceEdit.replace(uri, range, formattedCol);
+
+    await vscode.workspace.applyEdit(workspaceEdit);
+}

--- a/src/dspf-edit.commands/dspf-edit.new-record.ts
+++ b/src/dspf-edit.commands/dspf-edit.new-record.ts
@@ -114,6 +114,8 @@ async function handleNewRecordCommand(node: DdsNode): Promise<void> {
 
         // Insert the new record into the document
         await insertNewRecord(editor, recordLines);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
 
         // Show success message
         const recordTypeLabel = getRecordTypeLabel(recordConfig.type);

--- a/src/dspf-edit.commands/dspf-edit.remove-attribute.ts
+++ b/src/dspf-edit.commands/dspf-edit.remove-attribute.ts
@@ -109,6 +109,8 @@ async function handleRemoveAttributeCommand(node: DdsNode): Promise<void> {
 
         // Execute the deletion
         await executeElementDeletion(editor, deletionPlan);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
 
         vscode.window.showInformationMessage(`Attribute deleted successfully.`);
 

--- a/src/dspf-edit.commands/dspf-edit.remove-element.ts
+++ b/src/dspf-edit.commands/dspf-edit.remove-element.ts
@@ -97,6 +97,8 @@ async function handleRemoveElementCommand(node: DdsNode): Promise<void> {
 
         // Execute the deletion
         await executeElementDeletion(editor, deletionPlan);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
 
         vscode.window.showInformationMessage(`${elementInfo.name} deleted successfully.`);
 

--- a/src/dspf-edit.commands/dspf-edit.rename.ts
+++ b/src/dspf-edit.commands/dspf-edit.rename.ts
@@ -118,6 +118,8 @@ async function handleRenameFieldCommand(node: DdsNode): Promise<void> {
 
         // Execute the rename
         await executeFieldRename(editor, renameInfo);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
 
         vscode.window.showInformationMessage(`Field "${oldName}" renamed to "${newName}" successfully.`);
 

--- a/src/dspf-edit.commands/dspf-edit.sort-elements.ts
+++ b/src/dspf-edit.commands/dspf-edit.sort-elements.ts
@@ -86,6 +86,8 @@ async function handleSortElementsCommand(node: DdsNode): Promise<void> {
 
         // Apply the sort to the document
         await applySortToDocument(editor, sortedElements);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
 
         const sortDescription = getSortDescription(sortCriteria);
         vscode.window.showInformationMessage(

--- a/src/dspf-edit.commands/dspf-edit.window-resize.ts
+++ b/src/dspf-edit.commands/dspf-edit.window-resize.ts
@@ -123,6 +123,8 @@ async function handleWindowResizeCommand(node: DdsNode): Promise<void> {
 
         // Apply the window resize
         await applyWindowResize(editor, element, windowLine, newDimensions);
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
 
         // Show success message
         const operationLabel = resizeConfig.operation === 'CHANGE_SIZE' ? 'resized' : 'auto-adjusted';

--- a/src/dspf-edit.commands/register-commands.ts
+++ b/src/dspf-edit.commands/register-commands.ts
@@ -32,6 +32,8 @@ import { copyConstant } from './dspf-edit.copy-constant';
 import { removeElement } from './dspf-edit.remove-element';
 import { removeAttribute } from './dspf-edit.remove-attribute';
 import { renameField, renameRecord } from './dspf-edit.rename';
+import { moveConstantLeft1, moveConstantLeft5, moveConstantRight1, moveConstantRight5 } from './dspf-edit.move-constants';
+import { moveFieldLeft1, moveFieldLeft5, moveFieldRight1, moveFieldRight5 } from './dspf-edit.move-fields';
 
 export const commands = [
     { name: 'viewStructure', handler: viewStructure, needsTreeProvider: true },
@@ -60,7 +62,16 @@ export const commands = [
     { name: 'removeElement', handler: removeElement, needsTreeProvider: false },
     { name: 'removeAttribute', handler: removeAttribute, needsTreeProvider: false },
     { name: 'renameField', handler: renameField, needsTreeProvider: false },
-    { name: 'renameRecord', handler: renameRecord, needsTreeProvider: false }
+    { name: 'renameRecord', handler: renameRecord, needsTreeProvider: false },
+    { name: 'moveConstantLeft1', handler: moveConstantLeft1, needsTreeProvider: false },
+    { name: 'moveConstantLeft5', handler: moveConstantLeft5, needsTreeProvider: false },
+    { name: 'moveConstantRight1', handler: moveConstantRight1, needsTreeProvider: false },
+    { name: 'moveConstantRight5', handler: moveConstantRight5, needsTreeProvider: false },
+    { name: 'moveFieldLeft1', handler: moveFieldLeft1, needsTreeProvider: false },
+    { name: 'moveFieldLeft5', handler: moveFieldLeft5, needsTreeProvider: false },
+    { name: 'moveFieldRight1', handler: moveFieldRight1, needsTreeProvider: false },
+    { name: 'moveFieldRight5', handler: moveFieldRight5, needsTreeProvider: false }
+
 ];
 
 /**
@@ -82,34 +93,26 @@ export function registerCommands(
     });
 
     context.subscriptions.push(
-        vscode.commands.registerCommand('ddsEdit.filterTreeView', () => {
+        vscode.commands.registerCommand('dspf-edit.filterTreeView', () => {
             treeProvider.showFilterMenu();
         }),
 
-        vscode.commands.registerCommand('ddsEdit.showAllElements', () => {
+        vscode.commands.registerCommand('dspf-edit.showAllElements', () => {
             treeProvider.showAll();
         }),
 
-        vscode.commands.registerCommand('ddsEdit.hideAllElements', () => {
+        vscode.commands.registerCommand('dspf-edit.hideAllElements', () => {
             treeProvider.hideAll();
         }),
 
-        vscode.commands.registerCommand('ddsEdit.toggleFields', () => {
+        vscode.commands.registerCommand('dspf-edit.toggleFields', () => {
             treeProvider.toggleVisibility('field');
         }),
 
-        vscode.commands.registerCommand('ddsEdit.toggleConstants', () => {
+        vscode.commands.registerCommand('dspf-edit.toggleConstants', () => {
             treeProvider.toggleVisibility('constant');
-        }),
-
-        vscode.commands.registerCommand('ddsEdit.expandAll', () => {
-            treeProvider.expandAll();
-        }),
-
-        vscode.commands.registerCommand('ddsEdit.collapseAll', () => {
-            treeProvider.collapseAll();
         })
-
+        
     );
 
 };

--- a/src/dspf-edit.listeners/listeners.ts
+++ b/src/dspf-edit.listeners/listeners.ts
@@ -34,13 +34,14 @@ export function initializeDocumentListeners(
     context.subscriptions.push(
         vscode.window.onDidChangeActiveTextEditor(editor => {
             generateIfDds(treeProvider, editor?.document, vscode.window.activeTextEditor);
+            
         })
     );
-
     context.subscriptions.push(
         vscode.workspace.onDidCloseTextDocument(document => {
             if (ExtensionState.lastDdsDocument && document === ExtensionState.lastDdsDocument) {
                 ExtensionState.clearTimeout();
+                treeProvider.cleanupDocumentFilter(document.uri.toString());
                 ExtensionState.lastDdsDocument = undefined;
                 ExtensionState.lastDdsEditor = undefined;
                 treeProvider.setElements([]);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,6 @@ import { ExtensionState } from './dspf-edit.states/state';
 import { initializeDocumentListeners } from './dspf-edit.listeners/listeners';
 
 // Activate extension
-// Activate extension
 export function activate(context: vscode.ExtensionContext) {
 
 	// Create the tree data provider


### PR DESCRIPTION
### Added
- Now you can move a constant or field, one or five positions to the right or left using a button directly from the schema view.
### Fixed
- Changes to the filter button. It now maintains the filter by file (you can have a different filter applied to another file while they remain open).