### PR TITLE
Add Preview Screen Layout feature and fix subfile move bugs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,12 +27,17 @@ jobs:
       - name: Install Extension Dependencies
         run: |
           npm install
-          npm install -g vsce
+          npm install -g vsce ovsx
 
       - name: Build Extension
         run: vsce package
 
-      - name: Publish to Marketplace
-        run: vsce publish -p $PUBLISHER_TOKEN
+      - name: Publish to VS Code Marketplace
+        run: vsce publish -p $PUBLISHER_TOKEN --packagePath *.vsix
         env:
           PUBLISHER_TOKEN: ${{ secrets.PUBLISHER_TOKEN }}
+
+      - name: Publish to Open VSX Registry
+        run: ovsx publish *.vsix -p $OVSX_TOKEN
+        env:
+          OVSX_TOKEN: ${{ secrets.OVSX_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
+## [0.13.0] - 2026-07-23
+### Added
+- New "Preview Screen Layout" option: shows a green-screen-style visual preview of a record on a canvas. Also available as an inline button on record tree items, in addition to the context-menu option.
+  - Supports COLOR() and DSPATR() keywords (HI, RI, BL, UL, CS, ND); input-capable fields are shown underlined.
+  - Fields/constants can be dragged to reposition them, writing the new position back into the source.
+  - "+ Field" / "+ Constant" buttons: click, then click a point on the screen to place a new field/constant there, reusing the same name/type/position prompts as the tree's "Add field"/"Add constant" commands. Validated against the record's own area (a window's content frame, or the SFL detail area below its header).
+  - WINDOW records are drawn at their real screen position and can be resized/moved with the mouse; WDWTITLE is shown. Windows shared via WINDOW(record-name) are supported.
+  - Clicking a window's title edits it directly; a "⋮" actions menu and a one-click "center horizontally" icon are also available on the window frame — all three only appear while hovering over the window.
+  - Subfile (SFL/SFLCTL) records show all SFLPAG rows, and automatically preview their paired header/detail record; the detail rows can't be dragged up over the header's own content.
+  - Any other record can be overlaid (dimmed) behind the one being previewed, to see how they compose.
+  - Indicator simulation: toggle indicators on/off to preview conditional fields, constants, and attributes.
+  - Display format switcher: for DSPF files declaring more than one DSPSIZ format (e.g. *DS3/*DS4), lets you switch between them — window positions/sizes, SFLSIZ/SFLPAG, and conditioned fields/constants/attributes are resolved for whichever format is active. Locked when the file only declares one format.
+  - The preview stays in sync with the schema tree selection in both directions.
+  - The toolbar (size, display format, overlay, indicators, add buttons) is laid out as a single, compact row.
+- New "Change Window Title" command (record context menu) to add, edit, or remove a window's WDWTITLE(), with horizontal alignment (*LEFT/*CENTER/*RIGHT) and vertical position (*TOP/*BOTTOM); also editable directly from the preview.
+### Fixed
+- Moving a field or constant left/right in a subfile (buttons in the schema view) wrote the new position into the wrong source columns.
+- The "Add buttons" command placed buttons in column 1 for window records instead of column 2 (column 1 isn't usable inside a window).
+- A line conditioned by a display format name (e.g. "*DS3") instead of indicators was misread as garbage indicator data.
+- Without indicator simulation, mutually-exclusive fields/constants/attributes conditioned by complementary indicators (e.g. one on "61", the other on "N61") could show at once instead of resolving to a single, deterministic state.
+- Switching between two open DSPF files could leak one file's second DSPSIZ format size into the other's display-format selector.
+- The record filter could silently hide a newly-added record with no obvious cause; it's now disabled (with a warning message) whenever a new record appears while the filter is active.
+- The record filter could reset unpredictably back to "show all" whenever any record became invalid (e.g. renamed/removed), instead of just pruning the stale entry.
+- "Hide all" in the record filter menu didn't actually hide records, only fields/constants.
+
 ## [0.12.3] - 2025-11-30
 ### Fixed
 - When creating a new field, the horizontal position was being saved incorrectly in the source.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ The extension provides a **navigable schema view** of the DDS source file that i
     - Assign command keys.
     - Add / Remove / Change indicators.
     - Resizing (if window record).
+    - Change Window Title (if window record).
     - Sort elements.
+    - Preview Screen Layout (also available as an inline button on the record).
 
 - **Constants**
   - Show text, position (row/column), indicators, and attributes.
@@ -66,6 +68,19 @@ The extension provides a **navigable schema view** of the DDS source file that i
 - **Attributes**
     - Add / Remove / Change indicators.
     - Remove attribute.
+
+- **Screen Preview**
+  - Visual, green-screen-style preview of a record's fields and constants (colors, DSPATR attributes, and placeholders for output/input/both fields).
+  - A single, compact toolbar (size, display format, overlay, indicators, add buttons) sits above the preview.
+  - Drag fields/constants to reposition them directly on the preview.
+  - "+ Field" / "+ Constant" buttons: click, then click a point on the screen to place a new field/constant there, using the same prompts as the tree's "Add field"/"Add constant" commands.
+  - WINDOW records are drawn at their real screen position and can be resized/moved with the mouse; shows WDWTITLE if present. Supports windows shared via WINDOW(record-name).
+  - Click a window's title to edit it, or use its "⋮" actions menu / one-click "center horizontally" icon — all shown only while hovering over the window.
+  - Subfile (SFL/SFLCTL) records show all SFLPAG rows, and automatically preview their paired header/detail record; detail rows can't be dragged up over the header's own content.
+  - Overlay any other record (dimmed) behind the one being previewed, to see how they compose.
+  - Simulate indicators on/off to preview conditional fields, constants, and attributes.
+  - For files with more than one DSPSIZ format (e.g. *DS3/*DS4), switch which one is previewed — window positions/sizes and conditioned elements are resolved for the selected format.
+  - Stays in sync with the schema tree selection in both directions.
 
 ---
 
@@ -103,8 +118,17 @@ Some features may not work as expected. Please leave an issue if something is no
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**0.12.3** - 2025-11-30
-- Fixed: When creating a new field, the horizontal position was being saved incorrectly in the source.
+**0.13.0** - 2026-07-23
+- Added: New "Preview Screen Layout" option — visual, green-screen-style preview of a record, with drag-to-move, window/subfile support, record overlay, indicator simulation, and a display format (*DS3/*DS4) switcher.
+- Added: "+ Field" / "+ Constant" buttons in the preview to create new elements by clicking a point on the screen.
+- Added: New "Change Window Title" command (also editable directly from the preview), plus a window actions menu and a one-click "center horizontally" icon, shown only while hovering over the window.
+- Added: Inline "Preview Screen Layout" button on record tree items.
+- Fixed: Moving a field or constant left/right in a subfile wrote the new position into the wrong source columns.
+- Fixed: The "Add buttons" command used the wrong starting column in window records.
+- Fixed: A line conditioned by a display format name was misread as garbage indicator data.
+- Fixed: Mutually-exclusive fields/constants conditioned by complementary indicators could show at once without indicator simulation enabled.
+- Fixed: Switching between two open DSPF files could leak a stale display-format size into the other file's selector.
+- Fixed: The record filter could silently hide a newly-added record, or reset unpredictably when a record was renamed/removed.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "dspf-edit",
-  "version": "0.4.1",
+  "version": "0.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dspf-edit",
-      "version": "0.4.1",
+      "version": "0.12.3",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "^20.19.11",
-        "@types/vscode": "^1.103.0",
+        "@types/vscode": "^1.75.0",
         "@typescript-eslint/eslint-plugin": "^8.31.1",
         "@typescript-eslint/parser": "^8.31.1",
         "@vscode/test-cli": "^0.0.10",

--- a/package.json
+++ b/package.json
@@ -146,6 +146,10 @@
         "title": "Change Window Size"
       },
       {
+        "command": "dspf-edit.preview-record",
+        "title": "Preview Screen Layout"
+      },
+      {
         "command": "dspf-edit.sort-elements",
         "title": "Sort Elements"
       },
@@ -336,6 +340,11 @@
           "command": "dspf-edit.new-record",
           "when": "view == dspf-edit.schema-view && (viewItem == file || viewItem == group:records)",
           "group": "file_navigation1@1"
+        },
+        {
+          "command": "dspf-edit.preview-record",
+          "when": "view == dspf-edit.schema-view && viewItem == record",
+          "group": "records_navigation5@1"
         },
         {
           "command": "dspf-edit.add-constant",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"
@@ -146,8 +146,13 @@
         "title": "Change Window Size"
       },
       {
+        "command": "dspf-edit.window-title",
+        "title": "Change Window Title"
+      },
+      {
         "command": "dspf-edit.preview-record",
-        "title": "Preview Screen Layout"
+        "title": "Preview Screen Layout",
+        "icon": "$(open-preview)"
       },
       {
         "command": "dspf-edit.sort-elements",
@@ -322,6 +327,11 @@
           "group": "records_navigation1@4"
         },
         {
+          "command": "dspf-edit.window-title",
+          "when": "view == dspf-edit.schema-view && viewItem == record",
+          "group": "records_navigation1@5"
+        },
+        {
           "command": "dspf-edit.add-buttons",
           "when": "view == dspf-edit.schema-view && viewItem == record",
           "group": "records_navigation2@1"
@@ -405,6 +415,11 @@
           "command" : "dspf-edit.rename-record",
           "when" : "view == dspf-edit.schema-view && viewItem == record",
           "group" : "inline@99"
+        },
+        {
+          "command": "dspf-edit.preview-record",
+          "when": "view == dspf-edit.schema-view && viewItem == record",
+          "group": "inline@1"
         },
         {
           "command" : "dspf-edit.rename-field",

--- a/src/dspf-edit.commands/dspf-edit.add-buttons.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-buttons.ts
@@ -307,13 +307,10 @@ function getRecordInformation(recordName: string): RecordInformation | null {
  * @returns Layout information for button placement
  */
 function calculateButtonLayout(buttons: ButtonDefinition[], recordInfo: RecordInformation): ButtonLayout {
-    let startCol = 2;       // Start column for buttons (for non window records)
+    const startCol = 2;     // Start column for buttons (relative column 1 is unusable in windows, so both cases start at 2)
     const spacing = 2;      // Space between buttons
     let col = startCol;
     let rowsNeeded = 1;
-
-    // If it is a window, then the start column is 1.
-    if (recordInfo.isWindow) startCol = 1;
 
     // Calculate how many rows are needed
     for (const btn of buttons) {

--- a/src/dspf-edit.commands/dspf-edit.add-buttons.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-buttons.ts
@@ -405,15 +405,14 @@ async function applyButtonsToRecord(
  * @returns The formatted DDS line
  */
 function createButtonDdsLine(text: string, row: number, col: number): string {
-    const rowStr = String(row).padStart(2, ' ');
-    const colStr = String(col).padStart(2, ' ');
+    const rowStr = String(row).padStart(3, ' ');
+    const colStr = String(col).padStart(3, ' ');
 
     // Build DDS line with proper formatting
-    // Format: "     A          [row][col]'[text]'"
-    let ddsLine = ''.padEnd(45, ' ');
+    // Row occupies raw columns 38-41, column occupies raw columns 41-44
+    let ddsLine = ''.padEnd(44, ' ');
     ddsLine = ddsLine.substring(0, 5) + 'A' + ddsLine.substring(6);
-    ddsLine = ddsLine.substring(0, 39) + rowStr + ddsLine.substring(41);
-    ddsLine = ddsLine.substring(0, 42) + colStr + `'${text}'`;
+    ddsLine = ddsLine.substring(0, 38) + rowStr + colStr + `'${text}'`;
 
     return ddsLine;
 };

--- a/src/dspf-edit.commands/dspf-edit.copy-constant.ts
+++ b/src/dspf-edit.commands/dspf-edit.copy-constant.ts
@@ -514,10 +514,10 @@ async function generateCopiedConstantLines(editor: vscode.TextEditor, config: Co
 function generateConstantContentLines(config: CopyConstantConfig, newConstantValue: string): string[] {
     const lines: string[] = [];
     
-    // Create base line with position
-    const rowStr = config.targetPosition.row.toString().padStart(2, ' ');
-    const colStr = config.targetPosition.column.toString().padStart(2, ' ');
-    const baseLine = `     A` + ' '.repeat(33) + `${rowStr} ${colStr}`;
+    // Create base line with position (row at raw 38-41, column at raw 41-44, each 3 chars wide)
+    const rowStr = config.targetPosition.row.toString().padStart(3, ' ');
+    const colStr = config.targetPosition.column.toString().padStart(3, ' ');
+    const baseLine = `     A` + ' '.repeat(32) + `${rowStr}${colStr}`;
 
     // Check if the new constant fits in a single line (36 characters or less)
     if (newConstantValue.length <= 36) {
@@ -635,11 +635,11 @@ function generateAttributeContentLines(
 ): string[] {
     const lines: string[] = [];
     
-    // Create base line with position for the attribute
-    const rowStr = targetPosition.row.toString().padStart(2, ' ');
-    const colStr = targetPosition.column.toString().padStart(2, ' ');
-    
-    const baseLine = `     A`+ ' '.repeat(33) + `${rowStr} ${colStr}`;
+    // Create base line with position for the attribute (row at raw 38-41, column at raw 41-44, each 3 chars wide)
+    const rowStr = targetPosition.row.toString().padStart(3, ' ');
+    const colStr = targetPosition.column.toString().padStart(3, ' ');
+
+    const baseLine = `     A`+ ' '.repeat(32) + `${rowStr}${colStr}`;
 
     // Check if the attribute value fits in a single line (36 characters or less)
     if (attributeValue.length <= 36) {

--- a/src/dspf-edit.commands/dspf-edit.copy-field.ts
+++ b/src/dspf-edit.commands/dspf-edit.copy-field.ts
@@ -61,9 +61,9 @@ const COPY_CONSTANTS = {
     MAX_NAME_LENGTH: 10,
     NAME_COLUMN_START: 18,
     NAME_COLUMN_END: 28,
-    ROW_COLUMN_START: 39,
+    ROW_COLUMN_START: 38,
     ROW_COLUMN_END: 41,
-    COLUMN_COLUMN_START: 42,
+    COLUMN_COLUMN_START: 41,
     COLUMN_COLUMN_END: 44
 } as const;
 
@@ -670,15 +670,15 @@ function updateMainFieldLine(originalLine: string, config: CopyFieldConfig, isHi
 
     // Update position only for visible fields
     if (!isHidden && config.targetPosition) {
-        // Update position (columns 40-41 row, 43-44 col, 0-based: 39-40, 42-43)
-        const rowStr = config.targetPosition.row.toString().padStart(2, ' ');
-        const colStr = config.targetPosition.column.toString().padStart(2, ' ');
+        // Update position (row at raw 38-41, column at raw 41-44, each 3 chars wide)
+        const rowStr = config.targetPosition.row.toString().padStart(3, ' ');
+        const colStr = config.targetPosition.column.toString().padStart(3, ' ');
         line = replaceAt(line, COPY_CONSTANTS.ROW_COLUMN_START, rowStr);
         line = replaceAt(line, COPY_CONSTANTS.COLUMN_COLUMN_START, colStr);
     } else if (isHidden) {
         // For hidden fields, clear the position columns
-        line = replaceAt(line, COPY_CONSTANTS.ROW_COLUMN_START, '  ');
-        line = replaceAt(line, COPY_CONSTANTS.COLUMN_COLUMN_START, '  ');
+        line = replaceAt(line, COPY_CONSTANTS.ROW_COLUMN_START, '   ');
+        line = replaceAt(line, COPY_CONSTANTS.COLUMN_COLUMN_START, '   ');
     };
 
     return line.trimEnd();

--- a/src/dspf-edit.commands/dspf-edit.edit-constant.ts
+++ b/src/dspf-edit.commands/dspf-edit.edit-constant.ts
@@ -705,7 +705,7 @@ function createMultiLineConstantFromBase(baseLine: string, value: string): strin
         const nextChunk = remainingText.substring(0, 35);
         remainingText = remainingText.substring(35);
         
-        const isLastChunk = remainingText.trim() === "'" || remainingText.length === 0;
+        const isLastChunk = remainingText.length === 0;
         const continuationChar = isLastChunk ? ' ' : '-';
         const contLine = '     A' + ' '.repeat(38) + nextChunk.padEnd(35, ' ') + continuationChar;
         lines.push(contLine);

--- a/src/dspf-edit.commands/dspf-edit.edit-constant.ts
+++ b/src/dspf-edit.commands/dspf-edit.edit-constant.ts
@@ -14,7 +14,7 @@ import { checkForEditorAndDocument, findEndLineIndex } from '../dspf-edit.utils/
 /**
  * Information needed to create a new constant.
  */
-interface NewConstantInfo {
+export interface NewConstantInfo {
     text: string;
     row: number;
     column: number;
@@ -165,9 +165,9 @@ async function handleAddConstantCommand(node?: DdsNode): Promise<void> {
  * @param column - Column position for length validation
  * @returns The entered text or null if cancelled
  */
-async function getConstantTextFromUser(
-    title: string, 
-    defaultValue: string, 
+export async function getConstantTextFromUser(
+    title: string,
+    defaultValue: string,
     column?: number
 ): Promise<string | null> {
     const newText = await vscode.window.showInputBox({
@@ -560,7 +560,7 @@ export async function updateExistingConstant(
  * @param editor - The active text editor
  * @param constantInfo - Information about the new constant
  */
-async function insertNewConstant(editor: vscode.TextEditor, constantInfo: NewConstantInfo): Promise<void> {
+export async function insertNewConstant(editor: vscode.TextEditor, constantInfo: NewConstantInfo): Promise<void> {
     const newValue = `'${constantInfo.text}'`;
     const uri = editor.document.uri;
     const workspaceEdit = new vscode.WorkspaceEdit();

--- a/src/dspf-edit.commands/dspf-edit.edit-field.ts
+++ b/src/dspf-edit.commands/dspf-edit.edit-field.ts
@@ -846,18 +846,18 @@ function parseFieldFromLine(lineText: string, lineIndex: number): ExistingElemen
     const nameArea = lineText.substring(18, 28).trim();
     if (!nameArea) return null;
     
-    // Extract row and column (positions 40-41 and 43-44)
-    const rowStr = lineText.substring(39, 41).trim();
-    const colStr = lineText.substring(42, 44).trim();
-    
+    // Extract row and column (raw offsets 38-41 and 41-44)
+    const rowStr = lineText.substring(38, 41).trim();
+    const colStr = lineText.substring(41, 44).trim();
+
     if (!rowStr || !colStr) return null;
-    
+
     const row = parseInt(rowStr, 10);
     const column = parseInt(colStr, 10);
-    
+
     if (isNaN(row) || isNaN(column)) return null;
-    
-    const lengthStr = lineText.substring(32, 33).trim();
+
+    const lengthStr = lineText.substring(32, 34).trim();
     const length = parseInt(lengthStr, 10) || 10; // Default to 10 if can't parse
     
     return {

--- a/src/dspf-edit.commands/dspf-edit.edit-field.ts
+++ b/src/dspf-edit.commands/dspf-edit.edit-field.ts
@@ -28,7 +28,7 @@ interface ValidationResult {
 /**
  * Interface for field position on screen
  */
-interface FieldPosition {
+export interface FieldPosition {
     row: number;
     column: number;
 };
@@ -292,6 +292,72 @@ async function handleAddFieldCommand(node: DdsNode): Promise<void> {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
         vscode.window.showErrorMessage(`Failed to add field: ${errorMessage}`);
         console.error('Error in addField command:', error);
+    };
+};
+
+/**
+ * Adds a new field to a record at an already-known screen position (used by the preview panel's
+ * "+ Field" placement mode, where the position comes from a canvas click instead of the
+ * absolute/relative positioning sub-flow). Collects the same name/usage/type-or-reference
+ * configuration as the tree's "Add field" command, just skipping the position-picking step.
+ * @param recordName - Name of the record to add the field to
+ * @param position - Row/column already determined (e.g. by a preview click); ignored for usage
+ * types that don't have a screen position (Hidden, Message, Program-to-system)
+ */
+export async function addFieldAtPosition(recordName: string, position: FieldPosition): Promise<void> {
+    try {
+        const { editor } = checkForEditorAndDocument();
+        if (!editor) {
+            return;
+        };
+
+        const recordElement = { name: recordName };
+
+        const fieldName = await promptForNewFieldName(recordElement);
+        if (!fieldName) return;
+
+        const usage = await collectFieldUsage(fieldName);
+        if (!usage) return;
+
+        const isReferenced = await promptForFieldReference();
+        if (isReferenced === null) return;
+
+        let reference: FieldReference | undefined;
+        let typeConfig: FieldTypeConfig | undefined;
+
+        if (isReferenced) {
+            const collectedReference = await collectFieldReference(fieldName);
+            if (!collectedReference) return;
+            reference = collectedReference;
+        } else {
+            const collectedTypeConfig = await collectFieldTypeConfiguration(fieldName);
+            if (!collectedTypeConfig) return;
+            typeConfig = collectedTypeConfig;
+        };
+
+        // These usage types don't have screen positions, same as the tree command's own flow.
+        const finalPosition: FieldPosition = (usage.type === 'H' || usage.type === 'M' || usage.type === 'P')
+            ? { row: 0, column: 0 }
+            : position;
+
+        const fieldConfig: NewFieldConfig = {
+            name: fieldName,
+            position: finalPosition,
+            usage,
+            isReferenced,
+            reference,
+            typeConfig
+        };
+
+        const newFieldLine = generateNewFieldLine(fieldConfig);
+        await insertNewField(editor, recordElement, newFieldLine);
+
+        vscode.window.showInformationMessage(`Field '${fieldName}' successfully added to record '${recordName}'.`);
+
+    } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+        vscode.window.showErrorMessage(`Failed to add field: ${errorMessage}`);
+        console.error('Error in addFieldAtPosition:', error);
     };
 };
 
@@ -1002,7 +1068,7 @@ function replaceAt(str: string, index: number, replacement: string): string {
 /**
  * Inserts the new field into the document
  */
-async function insertNewField(editor: vscode.TextEditor, recordElement: any, fieldLine: string): Promise<void> {
+export async function insertNewField(editor: vscode.TextEditor, recordElement: any, fieldLine: string): Promise<void> {
     const workspaceEdit = new vscode.WorkspaceEdit();
     const uri = editor.document.uri;
 

--- a/src/dspf-edit.commands/dspf-edit.move-constants.ts
+++ b/src/dspf-edit.commands/dspf-edit.move-constants.ts
@@ -26,12 +26,12 @@ function getMaxCols(): number {
  */
 function isSubfileRecord(recordName: string): boolean {
     const record = fieldsPerRecords.find(r => r.record === recordName);
-    
+
     if (!record || !record.attributes) {
         return false;
     }
-    
-    return record.attributes.some(attr => attr.attribute === 'SFL');
+
+    return record.attributes.some(attr => attr.value === 'SFL');
 }
 
 // COMMAND REGISTRATION FUNCTIONS
@@ -119,7 +119,10 @@ async function handleMoveConstantCommand(node: DdsNode, offset: number): Promise
         }
 
         const newPosition = currentPosition + offset;
-        const maxCols = getMaxCols();
+        // This command only ever moves a constant horizontally, so the bound is always the column
+        // limit — regardless of record type. For a subfile, currentPosition already came from
+        // element.row precisely because that's where the column value is stored for SFL records.
+        const maxPosition = getMaxCols();
 
         // Validate new position
         if (newPosition < 1) {
@@ -127,8 +130,8 @@ async function handleMoveConstantCommand(node: DdsNode, offset: number): Promise
             return;
         }
 
-        if (newPosition > maxCols) {
-            vscode.window.showWarningMessage(`Cannot move constant. Maximum position is ${maxCols}.`);
+        if (newPosition > maxPosition) {
+            vscode.window.showWarningMessage(`Cannot move constant. Maximum position is ${maxPosition}.`);
             return;
         }
 
@@ -160,12 +163,15 @@ async function handleMoveConstantCommand(node: DdsNode, offset: number): Promise
 // CONSTANT MOVEMENT FUNCTIONS
 
 /**
- * Moves a constant to a new position by updating either the column or row field.
- * For subfile records, it updates the row position. For regular records, it updates the column position.
+ * Moves a constant to a new column position by updating the column spec in the source line.
+ * The raw source columns 38-41 (line/row spec) and 41-44 (position/col spec) always keep that
+ * same meaning regardless of record type — a subfile only swaps which of those raw values ends up
+ * labeled element.row vs element.column internally (see isSubfileRecord's caller), the physical
+ * columns themselves never swap. Since this command always moves horizontally, it always writes
+ * the new value to the column spec (41-44).
  * @param editor - The active text editor
  * @param element - The constant element to move
- * @param newPosition - The new position value (column or row depending on record type)
- * @param isSubfileRecord - Whether the constant belongs to a subfile record (SFL)
+ * @param newPosition - The new column value
  */
 async function moveConstantToNewPosition(
     editor: vscode.TextEditor,
@@ -178,14 +184,10 @@ async function moveConstantToNewPosition(
     // Format the new position value (3 characters, right-aligned)
     const formattedPos = String(newPosition).padStart(3, ' ');
 
-    // Determine which field to update based on record type
-    const startCol = 41;
-    const endCol = 44;
-    
     // Replace characters at the appropriate positions with new value
     const range = new vscode.Range(
-        element.lineIndex, startCol,  // Start position
-        element.lineIndex, endCol     // End position
+        element.lineIndex, 41,  // Start position
+        element.lineIndex, 44   // End position
     );
 
     workspaceEdit.replace(uri, range, formattedPos);

--- a/src/dspf-edit.commands/dspf-edit.move-fields.ts
+++ b/src/dspf-edit.commands/dspf-edit.move-fields.ts
@@ -119,7 +119,10 @@ async function handleMoveFieldCommand(node: DdsNode, offset: number): Promise<vo
         }
 
         const newPosition = currentPosition + offset;
-        const maxCols = getMaxCols();
+        // This command only ever moves a field horizontally, so the bound is always the column
+        // limit — regardless of record type. For a subfile, currentPosition already came from
+        // element.row precisely because that's where the column value is stored for SFL records.
+        const maxPosition = getMaxCols();
 
         // Validate new position
         if (newPosition < 1) {
@@ -127,8 +130,8 @@ async function handleMoveFieldCommand(node: DdsNode, offset: number): Promise<vo
             return;
         }
 
-        if (newPosition > maxCols) {
-            vscode.window.showWarningMessage(`Cannot move field. Maximum position is ${maxCols}.`);
+        if (newPosition > maxPosition) {
+            vscode.window.showWarningMessage(`Cannot move field. Maximum position is ${maxPosition}.`);
             return;
         }
 
@@ -160,12 +163,15 @@ async function handleMoveFieldCommand(node: DdsNode, offset: number): Promise<vo
 // FIELD MOVEMENT FUNCTIONS
 
 /**
- * Moves a field to a new position by updating either the column or row field.
- * For subfile records, it updates the row position. For regular records, it updates the column position.
+ * Moves a field to a new column position by updating the column spec in the source line.
+ * The raw source columns 38-41 (line/row spec) and 41-44 (position/col spec) always keep that
+ * same meaning regardless of record type — a subfile only swaps which of those raw values ends up
+ * labeled element.row vs element.column internally (see isSubfileRecord's caller), the physical
+ * columns themselves never swap. Since this command always moves horizontally, it always writes
+ * the new value to the column spec (41-44).
  * @param editor - The active text editor
  * @param element - The field element to move
- * @param newPosition - The new position value (column or row depending on record type)
- * @param isSubfileRecord - Whether the field belongs to a subfile record (SFL)
+ * @param newPosition - The new column value
  */
 async function moveFieldToNewPosition(
     editor: vscode.TextEditor,
@@ -178,14 +184,10 @@ async function moveFieldToNewPosition(
     // Format the new position value (3 characters, right-aligned)
     const formattedPos = String(newPosition).padStart(3, ' ');
 
-    // Determine which field to update based on record type
-    const startCol = 41;
-    const endCol = 44;
-    
     // Replace characters at the appropriate positions with new value
     const range = new vscode.Range(
-        element.lineIndex, startCol,  // Start position
-        element.lineIndex, endCol     // End position
+        element.lineIndex, 41,  // Start position
+        element.lineIndex, 44   // End position
     );
 
     workspaceEdit.replace(uri, range, formattedPos);

--- a/src/dspf-edit.commands/dspf-edit.new-record.ts
+++ b/src/dspf-edit.commands/dspf-edit.new-record.ts
@@ -602,53 +602,48 @@ function generateWindowLine(dimensions: WindowDimensions): string {
 };
 
 /**
- * Generates window title lines, handling line wrapping if needed.
+ * Generates window title lines, handling line wrapping if needed. The whole keyword value (the
+ * quoted text plus the trailing *ALIGN/*BOTTOM) is treated as one continuous sequence and filled
+ * line by line up to column 80 — a continuation dash goes there whenever more content remains,
+ * splitting wherever that boundary happens to fall (including in the middle of *ALIGN/*BOTTOM),
+ * since DDS reconstructs a continued value by plain concatenation. Only the one separator space
+ * between the quoted text and *ALIGN is dropped when a wrap lands right on it, since it's just a
+ * token separator, not part of the title.
  * @param title - Window title text
+ * @param align - Horizontal alignment of the title within the window's top/bottom border
+ * @param position - Whether the title sits on the window's top or bottom border
  * @returns Array of formatted title lines
  */
-function generateWindowTitleLines(title: string): string[] {
+export function generateWindowTitleLines(
+    title: string,
+    align: 'LEFT' | 'CENTER' | 'RIGHT' = 'CENTER',
+    position: 'TOP' | 'BOTTOM' = 'TOP'
+): string[] {
     const maxLineLength = 80;
     const basePrefix = ' '.repeat(5) + 'A' + ' '.repeat(38);
-    
-    const keyword = "WDWTITLE((*TEXT '";
-    const suffix = "') *CENTER)";
-    
+    const contentWidth = maxLineLength - basePrefix.length; // Max chars on a line that needs no continuation dash.
+    const contentWidthWithDash = contentWidth - 1; // Max chars before the dash, on a continued line.
+
+    const textUnit = "WDWTITLE((*TEXT '" + title + "')";
+    const tail = position === 'BOTTOM' ? `*${align} *BOTTOM)` : `*${align})`;
+    const fullValue = textUnit + ' ' + tail;
+
     const lines: string[] = [];
-    let remaining = title;
-    let firstLine = true;
-    
-    while (remaining.length >= 0) {
-        if (firstLine) {
-            const available = maxLineLength - (basePrefix.length + keyword.length + suffix.length);
-            
-            if (remaining.length <= available) {
-                lines.push(basePrefix + keyword + remaining + suffix);
-                break;
-            } else {
-                // Para la primera línea con continuación, necesitamos espacio para el '-'
-                const availableWithDash = maxLineLength - (basePrefix.length + keyword.length + 1); // +1 para el '-'
-                const part = remaining.substring(0, availableWithDash);
-                lines.push(basePrefix + keyword + part + '-');
-                
-                remaining = remaining.substring(availableWithDash);
-                firstLine = false;
-            };
-        } else {
-            const available = maxLineLength - (basePrefix.length + suffix.length);
-            
-            if (remaining.length <= available) {
-                lines.push(basePrefix + remaining + suffix);
-                break;
-            } else {
-                // Para líneas intermedias con continuación, necesitamos espacio para el '-'
-                const availableWithDash = maxLineLength - (basePrefix.length + 1); // +1 para el '-'
-                const part = remaining.substring(0, availableWithDash);
-                lines.push(basePrefix + part + '-');
-                remaining = remaining.substring(availableWithDash);
-            };
+    let remaining = fullValue;
+    let consumed = 0;
+
+    while (remaining.length > contentWidth) {
+        const part = remaining.substring(0, contentWidthWithDash);
+        lines.push(basePrefix + part + '-');
+        consumed += contentWidthWithDash;
+        remaining = remaining.substring(contentWidthWithDash);
+
+        if (consumed >= textUnit.length && remaining.startsWith(' ')) {
+            remaining = remaining.slice(1);
         };
     };
-    
+
+    lines.push(basePrefix + remaining);
     return lines;
 };
 

--- a/src/dspf-edit.commands/dspf-edit.preview-record.ts
+++ b/src/dspf-edit.commands/dspf-edit.preview-record.ts
@@ -1,0 +1,102 @@
+/*
+    Christian Larsen, 2025
+    "RPG structure"
+    dspf-edit.preview-record.ts
+*/
+
+import * as vscode from 'vscode';
+import { DdsNode, DdsTreeProvider } from '../dspf-edit.providers/dspf-edit.providers';
+import { fieldsPerRecords, getRecordSize, getDefaultSize } from '../dspf-edit.model/dspf-edit.model';
+import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
+import { RecordPreviewPanel } from '../dspf-edit.webview/dspf-edit.record-preview-panel';
+
+/**
+ * Registers the "Preview Screen Layout" command for DDS records, and keeps the preview panel
+ * (when open) following the tree selection: clicking a different record retargets it, and clicking
+ * a field/constant highlights it in the preview (retargeting first if it belongs to another record).
+ * @param context - The VS Code extension context
+ * @param treeProvider - The tree provider, used to refresh the preview when the DDS source is re-parsed
+ */
+export function previewRecord(context: vscode.ExtensionContext, treeProvider: DdsTreeProvider): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand("dspf-edit.preview-record", (node: DdsNode) => {
+            handlePreviewRecordCommand(node, treeProvider);
+        })
+    );
+
+    const treeView = treeProvider.getTreeView();
+    if (treeView) {
+        context.subscriptions.push(
+            treeView.onDidChangeSelection(event => {
+                try {
+                    if (!RecordPreviewPanel.isOpen()) {
+                        return;
+                    };
+
+                    const element = event.selection[0]?.ddsElement;
+                    if (element?.kind === 'record') {
+                        showRecordInPreview(element.name, treeProvider);
+                    } else if (element?.kind === 'field' || element?.kind === 'constant') {
+                        if (element.recordname !== RecordPreviewPanel.getCurrentRecordName()) {
+                            showRecordInPreview(element.recordname, treeProvider);
+                        };
+                        RecordPreviewPanel.selectLineIfOpen(element.lineIndex);
+                    };
+                } catch (error) {
+                    console.error('Error updating record preview on selection change:', error);
+                };
+            })
+        );
+    };
+};
+
+/**
+ * Handles the preview record command: opens (or reveals) the preview panel for the selected record.
+ * @param node - The DDS node containing the record to preview
+ * @param treeProvider - The tree provider, whose refresh event drives the panel's updates
+ */
+function handlePreviewRecordCommand(node: DdsNode, treeProvider: DdsTreeProvider): void {
+    try {
+        if (!node || !node.ddsElement) {
+            vscode.window.showWarningMessage("No record selected to preview.");
+            return;
+        };
+
+        const element = node.ddsElement;
+
+        if (element.kind !== "record") {
+            vscode.window.showWarningMessage("Only records can be previewed.");
+            return;
+        };
+
+        const { document } = checkForEditorAndDocument();
+        if (!document) {
+            return;
+        };
+
+        showRecordInPreview(element.name, treeProvider);
+
+    } catch (error) {
+        console.error('Error previewing record:', error);
+        vscode.window.showErrorMessage(`An error occurred while previewing the record: ${error instanceof Error ? error.message : String(error)}`);
+    };
+};
+
+/**
+ * Shows the given record in the (single, shared) preview panel, creating it if needed,
+ * and keeps it refreshed on every subsequent tree/model refresh.
+ * @param recordName - Name of the record to preview
+ * @param treeProvider - The tree provider, whose refresh event drives the panel's updates
+ */
+function showRecordInPreview(recordName: string, treeProvider: DdsTreeProvider): void {
+    const panel = RecordPreviewPanel.getOrCreate(recordName, treeProvider);
+
+    const refresh = () => {
+        const recordInfo = fieldsPerRecords.find(r => r.record === recordName);
+        const size = getRecordSize(recordName) ?? getDefaultSize();
+        panel.update(recordInfo, size);
+    };
+
+    panel.setRefreshSource(treeProvider.onDidChangeTreeData, refresh);
+    refresh();
+};

--- a/src/dspf-edit.commands/dspf-edit.window-title.ts
+++ b/src/dspf-edit.commands/dspf-edit.window-title.ts
@@ -1,0 +1,294 @@
+/*
+    Christian Larsen, 2026
+    "RPG structure"
+    dspf-edit.window-title.ts
+*/
+
+import * as vscode from 'vscode';
+import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
+import { FieldsPerRecord, fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
+import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
+import { generateWindowTitleLines } from './dspf-edit.new-record';
+
+type TitleAlign = 'LEFT' | 'CENTER' | 'RIGHT';
+type TitlePosition = 'TOP' | 'BOTTOM';
+
+/** The record's current WDWTITLE() keyword, if any, parsed for editing. */
+interface ExistingWindowTitle {
+    text: string;
+    align: TitleAlign;
+    position: TitlePosition;
+    lineIndex: number;
+    lastLineIndex: number;
+};
+
+// COMMAND REGISTRATION
+
+/**
+ * Registers the "Change Window Title" command for DDS window records.
+ * Lets the user add, edit, or remove the WDWTITLE() keyword.
+ * @param context - The VS Code extension context
+ */
+export function windowTitle(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand("dspf-edit.window-title", async (node: DdsNode) => {
+            await handleWindowTitleCommand(node);
+        })
+    );
+};
+
+// COMMAND HANDLER
+
+/**
+ * Handles the window title command workflow for a tree node: validates it's a record, then
+ * delegates to the shared, record-name-based flow (also used by the preview panel).
+ * @param node - The DDS node containing the window record
+ */
+async function handleWindowTitleCommand(node: DdsNode): Promise<void> {
+    const element = node.ddsElement;
+    if (element.kind !== "record") {
+        vscode.window.showWarningMessage("Window title can only be set on records.");
+        return;
+    };
+
+    await editWindowTitleForRecord(element.name);
+};
+
+/**
+ * Collects the new title text/alignment/position from the user and writes (or removes) the
+ * WDWTITLE() keyword for the given window record. Shared by the tree context-menu command and by
+ * clicking the title directly in the record preview.
+ * @param recordName - Name of the window record to edit the title for
+ */
+export async function editWindowTitleForRecord(recordName: string): Promise<void> {
+    try {
+        const { editor } = checkForEditorAndDocument();
+        if (!editor) {
+            return;
+        };
+
+        const record = fieldsPerRecords.find(r => r.record === recordName);
+        const windowAttr = record?.attributes?.find(a => a.value.toUpperCase().startsWith('WINDOW('));
+        if (!record || !windowAttr) {
+            vscode.window.showWarningMessage(`Record '${recordName}' does not have a WINDOW keyword.`);
+            return;
+        };
+
+        const windowMatch = windowAttr.value.match(/WINDOW\s*\(\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s*\)/i);
+        if (!windowMatch) {
+            vscode.window.showWarningMessage(
+                `Record '${recordName}' shares another record's window (WINDOW(${windowAttr.value.replace(/^WINDOW\(|\)$/g, '')})) — change the title on that record instead.`
+            );
+            return;
+        };
+        const windowWidth = parseInt(windowMatch[4], 10);
+
+        const existing = findExistingWindowTitle(record);
+
+        const text = await collectTitleText(existing?.text, windowWidth);
+        if (text === null) {
+            return;
+        };
+
+        if (text === '') {
+            if (!existing) {
+                vscode.window.showInformationMessage('No title entered.');
+                return;
+            };
+            await removeWindowTitle(editor, existing);
+            vscode.window.showInformationMessage(`Removed window title for '${recordName}'.`);
+            return;
+        };
+
+        const align = await collectTitleAlign(existing?.align);
+        if (!align) {
+            return;
+        };
+
+        const position = await collectTitlePosition(existing?.position);
+        if (!position) {
+            return;
+        };
+
+        const anchorLineIndex = windowAttr.lastLineIndex ?? windowAttr.lineIndex;
+        await applyWindowTitle(editor, anchorLineIndex, existing, text, align, position);
+
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
+
+        vscode.window.showInformationMessage(`Window title updated for '${recordName}'.`);
+
+    } catch (error) {
+        console.error('Error changing window title:', error);
+        vscode.window.showErrorMessage('An error occurred while changing the window title.');
+    };
+};
+
+// EXISTING TITLE LOOKUP
+
+/**
+ * Finds and parses the record's WDWTITLE() keyword, if any.
+ * @param record - The record's field/attribute info
+ */
+function findExistingWindowTitle(record: FieldsPerRecord): ExistingWindowTitle | undefined {
+    const attr = record.attributes?.find(a => a.value.toUpperCase().startsWith('WDWTITLE('));
+    if (!attr) {
+        return undefined;
+    };
+
+    const textMatch = attr.value.match(/WDWTITLE\(\(\*\w+\s+'([^']*)'\)/i);
+    if (!textMatch) {
+        return undefined;
+    };
+
+    const upperValue = attr.value.toUpperCase();
+
+    return {
+        text: textMatch[1],
+        align: upperValue.includes('*RIGHT') ? 'RIGHT' : upperValue.includes('*LEFT') ? 'LEFT' : 'CENTER',
+        position: upperValue.includes('*BOTTOM') ? 'BOTTOM' : 'TOP',
+        lineIndex: attr.lineIndex,
+        lastLineIndex: attr.lastLineIndex ?? attr.lineIndex
+    };
+};
+
+// USER INPUT COLLECTION
+
+/**
+ * Collects the new title text from the user, pre-filled with the current one if editing.
+ * @param current - The record's current title text, if any
+ * @param maxLength - Maximum title length, i.e. the window's width (WINDOW's numCols)
+ * @returns The trimmed title (empty string means "remove the title"), or null if cancelled
+ */
+async function collectTitleText(current: string | undefined, maxLength: number): Promise<string | null> {
+    const value = await vscode.window.showInputBox({
+        title: 'Window Title',
+        prompt: `Enter the window title (max ${maxLength} characters — the window's width); leave empty to remove it`,
+        value: current ?? '',
+        placeHolder: 'Window Title',
+        ignoreFocusOut: true,
+        validateInput: (v) => validateWindowTitle(v, maxLength)
+    });
+
+    if (value === undefined) {
+        return null;
+    };
+    return value.trim();
+};
+
+/**
+ * Validates window title length against the window's width, and that it doesn't contain a
+ * single quote (which would break out of the DDS string literal).
+ * @param value - Title to validate
+ * @param maxLength - Maximum allowed length (the window's width)
+ */
+function validateWindowTitle(value: string, maxLength: number): string | null {
+    if (!value || value.trim() === '') {
+        return null;
+    };
+
+    const trimmedValue = value.trim();
+    if (trimmedValue.includes("'")) {
+        return "Title cannot contain a single quote (').";
+    };
+    if (trimmedValue.length > maxLength) {
+        return `Title cannot exceed ${maxLength} characters (the window's width).`;
+    };
+
+    return null;
+};
+
+/**
+ * Collects the title's horizontal alignment.
+ * @param current - The record's current alignment, if editing an existing title
+ */
+async function collectTitleAlign(current: TitleAlign | undefined): Promise<TitleAlign | null> {
+    const options: (vscode.QuickPickItem & { value: TitleAlign })[] = [
+        { label: 'Center', value: 'CENTER' },
+        { label: 'Left', value: 'LEFT' },
+        { label: 'Right', value: 'RIGHT' }
+    ];
+
+    const selection = await vscode.window.showQuickPick(options, {
+        title: `Window Title - Horizontal Alignment (current: ${current ?? 'CENTER'})`,
+        placeHolder: 'Select the title alignment',
+        ignoreFocusOut: true
+    });
+
+    return selection?.value ?? null;
+};
+
+/**
+ * Collects the title's vertical position (top or bottom border of the window).
+ * @param current - The record's current position, if editing an existing title
+ */
+async function collectTitlePosition(current: TitlePosition | undefined): Promise<TitlePosition | null> {
+    const options: (vscode.QuickPickItem & { value: TitlePosition })[] = [
+        { label: 'Top', value: 'TOP' },
+        { label: 'Bottom', value: 'BOTTOM' }
+    ];
+
+    const selection = await vscode.window.showQuickPick(options, {
+        title: `Window Title - Vertical Position (current: ${current ?? 'TOP'})`,
+        placeHolder: 'Select the title position',
+        ignoreFocusOut: true
+    });
+
+    return selection?.value ?? null;
+};
+
+// DDS SOURCE UPDATE
+
+/**
+ * Writes the new WDWTITLE() keyword, replacing the existing one's line(s) if present, or
+ * inserting a new line right after the WINDOW() keyword otherwise.
+ * @param editor - The active text editor
+ * @param anchorLineIndex - Line to insert after, when there's no existing title (the WINDOW keyword's own last line)
+ * @param existing - The record's current title, if any, to replace
+ * @param text - The new title text
+ * @param align - The new horizontal alignment
+ * @param position - The new vertical position
+ */
+async function applyWindowTitle(
+    editor: vscode.TextEditor,
+    anchorLineIndex: number,
+    existing: ExistingWindowTitle | undefined,
+    text: string,
+    align: TitleAlign,
+    position: TitlePosition
+): Promise<void> {
+    const lines = generateWindowTitleLines(text, align, position);
+    const workspaceEdit = new vscode.WorkspaceEdit();
+    const uri = editor.document.uri;
+
+    if (existing) {
+        const range = new vscode.Range(
+            existing.lineIndex, 0,
+            existing.lastLineIndex, editor.document.lineAt(existing.lastLineIndex).text.length
+        );
+        workspaceEdit.replace(uri, range, lines.join('\n'));
+    } else {
+        const insertPosition = new vscode.Position(anchorLineIndex + 1, 0);
+        workspaceEdit.insert(uri, insertPosition, lines.join('\n') + '\n');
+    };
+
+    await vscode.workspace.applyEdit(workspaceEdit);
+};
+
+/**
+ * Removes the record's existing WDWTITLE() keyword line(s) entirely.
+ * @param editor - The active text editor
+ * @param existing - The title to remove
+ */
+async function removeWindowTitle(editor: vscode.TextEditor, existing: ExistingWindowTitle): Promise<void> {
+    const workspaceEdit = new vscode.WorkspaceEdit();
+    const uri = editor.document.uri;
+
+    const range = new vscode.Range(
+        existing.lineIndex, 0,
+        existing.lastLineIndex + 1, 0
+    );
+    workspaceEdit.delete(uri, range);
+
+    await vscode.workspace.applyEdit(workspaceEdit);
+};

--- a/src/dspf-edit.commands/register-commands.ts
+++ b/src/dspf-edit.commands/register-commands.ts
@@ -26,6 +26,7 @@ import { addErrorMessage } from './dspf-edit.add-error-messages';
 import { addIndicators } from './dspf-edit.add-indicators';
 import { fillConstant } from './dspf-edit.fill-constant';
 import { windowResize } from './dspf-edit.window-resize';
+import { windowTitle } from './dspf-edit.window-title';
 import { sortElements } from './dspf-edit.sort-elements';
 import { copyField } from './dspf-edit.copy-field';
 import { copyConstant } from './dspf-edit.copy-constant';
@@ -58,6 +59,7 @@ export const commands = [
     { name: 'addIndicators', handler: addIndicators, needsTreeProvider: false },
     { name: 'fillConstant', handler: fillConstant, needsTreeProvider: false },
     { name: 'windowResize', handler: windowResize, needsTreeProvider: false },
+    { name: 'windowTitle', handler: windowTitle, needsTreeProvider: false },
     { name: 'sortElements', handler: sortElements, needsTreeProvider: false },
     { name: 'copyField', handler: copyField, needsTreeProvider: false },
     { name: 'copyConstant', handler: copyConstant, needsTreeProvider: false },

--- a/src/dspf-edit.commands/register-commands.ts
+++ b/src/dspf-edit.commands/register-commands.ts
@@ -34,9 +34,11 @@ import { removeAttribute } from './dspf-edit.remove-attribute';
 import { renameField, renameRecord } from './dspf-edit.rename';
 import { moveConstantLeft1, moveConstantLeft5, moveConstantRight1, moveConstantRight5 } from './dspf-edit.move-constants';
 import { moveFieldLeft1, moveFieldLeft5, moveFieldRight1, moveFieldRight5 } from './dspf-edit.move-fields';
+import { previewRecord } from './dspf-edit.preview-record';
 
 export const commands = [
     { name: 'viewStructure', handler: viewStructure, needsTreeProvider: true },
+    { name: 'previewRecord', handler: previewRecord, needsTreeProvider: true },
     { name: 'addConstant', handler: addConstant, needsTreeProvider: false },
     { name: 'editConstant', handler: editConstant, needsTreeProvider: false },
     { name: 'registerFieldCommands', handler: registerFieldCommands, needsTreeProvider: false },

--- a/src/dspf-edit.model/dspf-edit.model.ts
+++ b/src/dspf-edit.model/dspf-edit.model.ts
@@ -50,6 +50,13 @@ export interface DdsSize {
   source: 'default' | 'window';
   originRow : number;
   originCol : number;
+  /**
+   * Set when this size was inherited rather than defined locally: either because the record's own
+   * WINDOW() keyword names another record (WINDOW(other-record)) instead of giving row/col/rows/cols
+   * directly, or because it's an SFL/SFLCTL record that borrows its pair's window. Names the record
+   * that actually owns/defines the window (e.g. its WDWTITLE), so previews can show that owner too.
+   */
+  sharedFromRecord?: string;
 };
 
 // ELEMENT-SPECIFIC INTERFACES
@@ -196,6 +203,7 @@ export let fileSizeAttributes: DdsSizeAttributes = {
 export interface FieldInfo {
   name: string;
   type?: string;
+  usage?: string;
   row: number;
   col: number;
   length: number;
@@ -213,6 +221,7 @@ export interface ConstantInfo {
   col: number;
   length: number;
   attributes: AttributeWithIndicators[];
+  indicators?: DdsIndicator[];
   lineIndex: number;
   lastLineIndex: number;
 };

--- a/src/dspf-edit.model/dspf-edit.model.ts
+++ b/src/dspf-edit.model/dspf-edit.model.ts
@@ -30,6 +30,8 @@ export interface DdsAttribute {
   indicators?: DdsIndicator[];
   attributes?: DdsAttribute[];
   children?: DdsElement[];
+  /** Set when this line is conditioned by a display format name (e.g. "*DS3") instead of/besides indicators. */
+  displayFormat?: string;
 };
 
 /**
@@ -102,6 +104,8 @@ export interface DdsField {
   children?: DdsElement[];
   attributes?: DdsAttribute[];
   indicators?: DdsIndicator[];
+  /** Set when this field's line is conditioned by a display format name (e.g. "*DS3"). */
+  displayFormat?: string;
 };
 
 /** Field attribute (e.g., EDTCDE, DSPATR) */
@@ -128,6 +132,8 @@ export interface DdsConstant {
   attributes?: DdsAttribute[];
   indicators?: DdsIndicator[];
   children?: DdsElement[];
+  /** Set when this constant's line is conditioned by a display format name (e.g. "*DS3"). */
+  displayFormat?: string;
 };
 
 /** Constant attribute (similar to field attributes but for constants) */
@@ -211,6 +217,8 @@ export interface FieldInfo {
   indicators?: DdsIndicator[];
   lineIndex: number;
   lastLineIndex: number;
+  /** Set when this field's line is conditioned by a display format name (e.g. "*DS3"). */
+  displayFormat?: string;
 };
 
 /** Simplified constant info */
@@ -224,6 +232,8 @@ export interface ConstantInfo {
   indicators?: DdsIndicator[];
   lineIndex: number;
   lastLineIndex: number;
+  /** Set when this constant's line is conditioned by a display format name (e.g. "*DS3"). */
+  displayFormat?: string;
 };
 
 /*** Attribute with indicadors info */
@@ -232,6 +242,8 @@ export interface AttributeWithIndicators {
   indicators?: DdsIndicator[];
   lineIndex: number;
   lastLineIndex: number;
+  /** Set when this attribute's line is conditioned by a display format name (e.g. "*DS3"). */
+  displayFormat?: string;
 };
 
 /** Record container for fields & constants */
@@ -283,5 +295,43 @@ export function getAllRecordSizes(): Array<{ record: string; size: DdsSize }> {
   return fieldsPerRecords
     .filter(r => r.size)
     .map(r => ({ record: r.record, size: r.size! }));
+};
+
+/**
+ * Lists the display formats declared in DSPSIZ (e.g. *DS3/*DS4), if the file declares more than
+ * one. Used to offer a format switcher in the preview; empty when the file has a single size.
+ */
+export function getAvailableDisplayFormats(): Array<{ name: string; rows: number; cols: number }> {
+  const formats: Array<{ name: string; rows: number; cols: number }> = [];
+
+  if (fileSizeAttributes.nameDsply1) {
+    formats.push({ name: fileSizeAttributes.nameDsply1, rows: fileSizeAttributes.maxRow1, cols: fileSizeAttributes.maxCol1 });
+  };
+  if (fileSizeAttributes.nameDsply2) {
+    formats.push({ name: fileSizeAttributes.nameDsply2, rows: fileSizeAttributes.maxRow2, cols: fileSizeAttributes.maxCol2 });
+  };
+
+  return formats;
+};
+
+/**
+ * Gets the default (non-window) screen size for a specific named display format (e.g. "*DS3"),
+ * as declared in DSPSIZ. Undefined if the name doesn't match either declared format.
+ * @param formatName - The display format name to look up
+ */
+export function getSizeForFormat(formatName: string): DdsSize | undefined {
+  const format = getAvailableDisplayFormats().find(f => f.name === formatName);
+  if (!format) {
+    return undefined;
+  };
+
+  return {
+    rows: format.rows,
+    cols: format.cols,
+    name: format.name,
+    source: 'default',
+    originCol: 1,
+    originRow: 1
+  };
 };
 

--- a/src/dspf-edit.parser/dspf-edit.parser.ts
+++ b/src/dspf-edit.parser/dspf-edit.parser.ts
@@ -603,6 +603,7 @@ function addFieldToRecord(field: any, recordEntry: any): void {
         recordEntry.fields.push({
             name: field.name,
             type: field.type,
+            usage: field.usage,
             row: field.row || 0,
             col: field.column || 0,
             length: field.length || 0,
@@ -640,6 +641,7 @@ function addConstantToRecord(constant: any, recordEntry: any): void {
             col: constant.column || 0,
             length: constantName.length,
             attributes: processedAttributes,
+            indicators: constant.indicators || [],
             lineIndex: constant.lineIndex,
             lastLineIndex: constant.lastLineIndex
         });
@@ -791,23 +793,49 @@ function setDefaultScreenSize(): void {
 
 /**
  * NEW: Processes record sizes after all elements have been parsed
- * Assigns default size or WINDOW-specific size to each record
+ * Assigns default size or WINDOW-specific size to each record.
+ * Handles both forms of the WINDOW() keyword: the direct
+ * WINDOW(startRow startCol numRows numCols), and the shared-window reference
+ * WINDOW(other-record-name) — commonly used by a subfile's SFLCTL record to reuse the same
+ * window as another record (e.g. one that carries the WDWTITLE and footer text). It also
+ * propagates a window's size across an SFL/SFLCTL pair when only one side of the pair declares it,
+ * since both halves occupy the exact same screen area.
  * @param ddsElements - Array of all parsed DDS elements
  */
 function processRecordSizes(ddsElements: DdsElement[]): void {
     const recordElements = ddsElements.filter(el => el.kind === 'record') as DdsRecord[];
 
-    for (const record of recordElements) {
-        // Check if record has WINDOW attribute
-        const windowSize = extractWindowSize(record.attributes);
+    const sizeByRecord = new Map<string, DdsSize>();
+    const referenceByRecord = new Map<string, string>();
 
-        if (windowSize) {
-            // Use WINDOW-specific size
-            record.size = windowSize;
-        } else {
-            // Use default size from file attributes
-            record.size = getDefaultSize();
+    for (const record of recordElements) {
+        const extracted = extractWindowSize(record.attributes);
+        if (extracted?.size) {
+            sizeByRecord.set(record.name, extracted.size);
+        } else if (extracted?.referenceName) {
+            referenceByRecord.set(record.name, extracted.referenceName);
         };
+    };
+
+    // Resolve WINDOW(other-record-name) references, following chains and guarding against cycles.
+    for (const [recordName, referenceName] of referenceByRecord) {
+        const visited = new Set<string>([recordName]);
+        let ownerName = referenceName;
+        while (referenceByRecord.has(ownerName) && !sizeByRecord.has(ownerName) && !visited.has(ownerName)) {
+            visited.add(ownerName);
+            ownerName = referenceByRecord.get(ownerName)!;
+        };
+
+        const ownerSize = sizeByRecord.get(ownerName);
+        if (ownerSize) {
+            sizeByRecord.set(recordName, { ...ownerSize, sharedFromRecord: ownerSize.sharedFromRecord ?? ownerName });
+        };
+    };
+
+    propagateSubfileWindowSizes(recordElements, sizeByRecord);
+
+    for (const record of recordElements) {
+        record.size = sizeByRecord.get(record.name) ?? getDefaultSize();
 
         // Also update the fieldsPerRecords structure for easy access
         const recordEntry = fieldsPerRecords.find(r => r.record === record.name);
@@ -818,11 +846,52 @@ function processRecordSizes(ddsElements: DdsElement[]): void {
 };
 
 /**
- * Extracts WINDOW size information from record attributes
- * @param attributes - Record attributes to search
- * @returns DdsSize object if WINDOW attribute found, undefined otherwise
+ * Shares a window's size across an SFL/SFLCTL pair when only one side declares WINDOW(): the
+ * subfile detail (SFL) record and its control (SFLCTL) record occupy the exact same screen area,
+ * but the WINDOW() keyword (direct or shared-reference) commonly sits on just one of them.
+ * @param recordElements - All parsed records
+ * @param sizeByRecord - Sizes resolved so far (direct + reference), mutated in place
  */
-function extractWindowSize(attributes?: DdsAttribute[]): DdsSize | undefined {
+function propagateSubfileWindowSizes(recordElements: DdsRecord[], sizeByRecord: Map<string, DdsSize>): void {
+    const findSflCtlPairName = (sflName: string): string | undefined => {
+        const ctlRecord = recordElements.find(r =>
+            r.attributes?.some(attr => {
+                const match = attr.value.match(/^SFLCTL\(\s*([A-Za-z0-9@#$]+)\s*\)$/i);
+                return Boolean(match && match[1].toUpperCase() === sflName.toUpperCase());
+            })
+        );
+        return ctlRecord?.name;
+    };
+
+    const findSflNameFromCtl = (ctlRecord: DdsRecord): string | undefined => {
+        const attr = ctlRecord.attributes?.find(a => a.value.toUpperCase().startsWith('SFLCTL('));
+        return attr?.value.match(/^SFLCTL\(\s*([A-Za-z0-9@#$]+)\s*\)$/i)?.[1];
+    };
+
+    for (const record of recordElements) {
+        if (sizeByRecord.has(record.name)) {
+            continue;
+        };
+
+        const pairName = isSubfileRecord(record.attributes)
+            ? findSflCtlPairName(record.name)
+            : findSflNameFromCtl(record);
+
+        const pairSize = pairName ? sizeByRecord.get(pairName) : undefined;
+        if (pairSize) {
+            sizeByRecord.set(record.name, pairSize);
+        };
+    };
+};
+
+/**
+ * Extracts WINDOW size information from record attributes. Supports both the direct form,
+ * WINDOW(startRow startCol numRows numCols), and the shared-window reference form,
+ * WINDOW(other-record-name), which is resolved later against the other record's own size.
+ * @param attributes - Record attributes to search
+ * @returns The resolved size (direct form), a reference name to resolve later (name form), or undefined
+ */
+function extractWindowSize(attributes?: DdsAttribute[]): { size?: DdsSize; referenceName?: string } | undefined {
     if (!attributes) return undefined;
 
     const windowAttribute = attributes.find(attr =>
@@ -834,21 +903,31 @@ function extractWindowSize(attributes?: DdsAttribute[]): DdsSize | undefined {
     const windowMatch = windowAttribute.value.match(
         /WINDOW\s*\(\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s*\)/i
     );
-    if (!windowMatch) return undefined;
+    if (windowMatch) {
+        const startRow = parseInt(windowMatch[1], 10);
+        const startCol = parseInt(windowMatch[2], 10);
+        const rows = parseInt(windowMatch[3], 10);
+        const cols = parseInt(windowMatch[4], 10);
 
-    const startRow = parseInt(windowMatch[1], 10);
-    const startCol = parseInt(windowMatch[2], 10);
-    const rows = parseInt(windowMatch[3], 10);
-    const cols = parseInt(windowMatch[4], 10);
-
-    return {
-        rows,
-        cols,
-        name: `WINDOW_${startRow}_${startCol}_${rows}_${cols}`,
-        source: 'window',
-        originRow: startRow,
-        originCol: startCol
+        return {
+            size: {
+                rows,
+                cols,
+                name: `WINDOW_${startRow}_${startCol}_${rows}_${cols}`,
+                source: 'window',
+                originRow: startRow,
+                originCol: startCol
+            }
+        };
     };
+
+    // WINDOW(other-record-name): reuses the window defined by another record.
+    const referenceMatch = windowAttribute.value.match(/WINDOW\s*\(\s*([A-Za-z0-9@#$]+)\s*\)/i);
+    if (referenceMatch) {
+        return { referenceName: referenceMatch[1] };
+    };
+
+    return undefined;
 };
 
 /**

--- a/src/dspf-edit.parser/dspf-edit.parser.ts
+++ b/src/dspf-edit.parser/dspf-edit.parser.ts
@@ -15,6 +15,7 @@ import {
     records,
     fieldsPerRecords,
     getDefaultSize,
+    getSizeForFormat,
     attributesFileLevel
 } from '../dspf-edit.model/dspf-edit.model';
 
@@ -70,6 +71,11 @@ function clearGlobalState(): void {
     records.length = 0;
     fieldsPerRecords.length = 0;
     attributesFileLevel.length = 0;
+
+    // Reset both display-size slots so switching to a document with fewer (or no) DSPSIZ formats
+    // doesn't leak a stale second size (e.g. *DS4) left over from a previously parsed document —
+    // processDspsizAttribute below only overwrites the slots it actually finds in this document.
+    setDefaultScreenSize();
 };
 
 /**
@@ -155,14 +161,18 @@ function parseSingleDdsLine(
  * @returns Object containing parsed line components
  */
 function extractLineComponents(trimmedLine: string) {
-    const indicators = parseDdsIndicators(trimmedLine.substring(2, 11));
+    const conditionZone = trimmedLine.substring(2, 11);
+    // The same zone that normally holds up to 3 indicators can instead hold a display format
+    // name (e.g. "*DS3"), conditioning the line to only apply under that DSPSIZ format.
+    const displayFormat = parseDisplayFormatCondition(conditionZone);
+    const indicators = displayFormat ? [] : parseDdsIndicators(conditionZone);
     const fieldName = trimmedLine.substring(13, 23).trim();
     const rowText = trimmedLine.substring(33, 36).trim();
     const colText = trimmedLine.substring(36, 39).trim();
     const row = rowText ? Number(rowText) : undefined;
     const col = colText ? Number(colText) : undefined;
 
-    return { indicators, fieldName, row, col };
+    return { indicators, fieldName, row, col, displayFormat };
 };
 
 /**
@@ -266,7 +276,7 @@ function parseFieldElement(
     const isHidden = trimmedLine[32] === 'H';
     const isReferenced = trimmedLine[23] === 'R';
 
-    const { attributes, nextIndex } = extractAttributes('F', lines, lineIndex, true, components.indicators);
+    const { attributes, nextIndex } = extractAttributes('F', lines, lineIndex, true, components.indicators, components.displayFormat);
 
     // Check if the current record (lastRecord) is a subfile by looking at its attributes
     const currentRecordEntry = fieldsPerRecords.find(r => r.record === lastRecord);
@@ -298,6 +308,7 @@ function parseFieldElement(
         recordname: lastRecord,
         attributes: attributes || [],
         indicators: components.indicators || undefined,
+        displayFormat: components.displayFormat,
     };
 
     return { element, nextIndex, lastRecord };
@@ -321,7 +332,7 @@ function parseConstantElement(
 ) {
     // Handle multi-line constants
     const { fullValue, lastLineIndex } = extractMultiLineConstant(lines, lineIndex, trimmedLine);
-    const { attributes, nextIndex } = extractAttributes('C', lines, lastLineIndex, true, components.indicators);
+    const { attributes, nextIndex } = extractAttributes('C', lines, lastLineIndex, true, components.indicators, components.displayFormat);
 
     // Check if the current record (lastRecord) is a subfile by looking at its attributes
     const currentRecordEntry = fieldsPerRecords.find(r => r.record === lastRecord);
@@ -345,7 +356,8 @@ function parseConstantElement(
         lastLineIndex: lastLineIndex,
         recordname: lastRecord,
         attributes: attributes || [],
-        indicators: components.indicators
+        indicators: components.indicators,
+        displayFormat: components.displayFormat
     };
 
     return { element, nextIndex: lastLineIndex, lastRecord };
@@ -397,7 +409,7 @@ function parseAttributeElement(
     components: any,
     lastRecord: string
 ) {
-    const { attributes, nextIndex } = extractAttributes('A', lines, lineIndex, true, components.indicators);
+    const { attributes, nextIndex } = extractAttributes('A', lines, lineIndex, true, components.indicators, components.displayFormat);
 
     if (attributes.length > 0) {
         const maxLastLineIndex = attributes.reduce(
@@ -410,6 +422,7 @@ function parseAttributeElement(
             lastLineIndex: maxLastLineIndex,
             value: '',
             indicators: components.indicators,
+            displayFormat: components.displayFormat,
             attributes: attributes
         };
         return { element, nextIndex, lastRecord };
@@ -445,6 +458,19 @@ export function parseDdsIndicators(input: string): DdsIndicator[] {
     return indicators;
 };
 
+/**
+ * Detects a display format condition (e.g. "*DS3", "*DS4") in the same 9-character zone that
+ * normally holds indicators. A DDS line can be conditioned on a named DSPSIZ format instead of
+ * (or as well as) indicators, so this must be checked before treating that zone as indicators —
+ * otherwise the "*DS3" text gets misread as garbage indicator data.
+ * @param input - 9-character string containing indicator specifications or a format condition
+ * @returns The format name (e.g. "*DS3") if present, else undefined
+ */
+export function parseDisplayFormatCondition(input: string): string | undefined {
+    const match = input.trim().match(/^(\*[A-Z0-9]+)/i);
+    return match ? match[1].toUpperCase() : undefined;
+};
+
 
 /**
  * Extracts attribute specifications from DDS lines, handling multi-line attributes
@@ -460,7 +486,8 @@ function extractAttributes(
     lines: string[],
     startIndex: number,
     includeIndicators: boolean,
-    indicators?: DdsIndicator[]
+    indicators?: DdsIndicator[],
+    displayFormat?: string
 ): { attributes: DdsAttribute[]; nextIndex: number } {
 
     let rawAttributeText = '';
@@ -498,7 +525,8 @@ function extractAttributes(
         lineIndex: startIndex,
         lastLineIndex: currentIndex,
         value: lineType === 'C' ? '' : rawAttributeText,
-        indicators: includeIndicators && indicators ? indicators : []
+        indicators: includeIndicators && indicators ? indicators : [],
+        displayFormat: includeIndicators ? displayFormat : undefined
     };
 
     return { attributes: [attribute], nextIndex: currentIndex };
@@ -597,7 +625,8 @@ function addFieldToRecord(field: any, recordEntry: any): void {
             value: attr.value,
             indicators: attr.indicators || [],
             lineIndex: attr.lineIndex,
-            lastLineIndex: attr.lastLineIndex ?? attr.lineIndex
+            lastLineIndex: attr.lastLineIndex ?? attr.lineIndex,
+            displayFormat: attr.displayFormat
         })).filter((attr: any) => attr.value) || [];
 
         recordEntry.fields.push({
@@ -610,7 +639,8 @@ function addFieldToRecord(field: any, recordEntry: any): void {
             attributes: processedAttributes,
             indicators: field.indicators || [],
             lineIndex: field.lineIndex,
-            lastLineIndex: field.lastLineIndex || field.lineIndex
+            lastLineIndex: field.lastLineIndex || field.lineIndex,
+            displayFormat: field.displayFormat
         });
     }
 };
@@ -629,7 +659,8 @@ function addConstantToRecord(constant: any, recordEntry: any): void {
         value: attr.value,
         indicators: attr.indicators || [],
         lineIndex: attr.lineIndex,
-        lastLineIndex: attr.lastLineIndex ?? attr.lineIndex
+        lastLineIndex: attr.lastLineIndex ?? attr.lineIndex,
+        displayFormat: attr.displayFormat
     })).filter((attr: any) => attr.value) || [];
 
     // Avoid duplicate constants
@@ -643,7 +674,8 @@ function addConstantToRecord(constant: any, recordEntry: any): void {
             attributes: processedAttributes,
             indicators: constant.indicators || [],
             lineIndex: constant.lineIndex,
-            lastLineIndex: constant.lastLineIndex
+            lastLineIndex: constant.lastLineIndex,
+            displayFormat: constant.displayFormat
         });
     };
 };
@@ -774,6 +806,12 @@ function updateFileSizeAttributes(sizes: Array<{ row: number; col: number; name:
         fileSizeAttributes.maxRow2 = sizes[1].row;
         fileSizeAttributes.maxCol2 = sizes[1].col;
         fileSizeAttributes.nameDsply2 = sizes[1].name;
+    } else {
+        // No second format in this document — clear it explicitly rather than leaving whatever
+        // was there before (relevant if this is ever called more than once per parse).
+        fileSizeAttributes.maxRow2 = 0;
+        fileSizeAttributes.maxCol2 = 0;
+        fileSizeAttributes.nameDsply2 = '';
     };
 };
 
@@ -804,12 +842,35 @@ function setDefaultScreenSize(): void {
  */
 function processRecordSizes(ddsElements: DdsElement[]): void {
     const recordElements = ddsElements.filter(el => el.kind === 'record') as DdsRecord[];
+    const sizeByRecord = computeSizeByRecord(recordElements);
 
+    for (const record of recordElements) {
+        record.size = sizeByRecord.get(record.name) ?? getDefaultSize();
+
+        // Also update the fieldsPerRecords structure for easy access
+        const recordEntry = fieldsPerRecords.find(r => r.record === record.name);
+        if (recordEntry) {
+            recordEntry.size = record.size;
+        };
+    };
+};
+
+/**
+ * Computes each record's WINDOW-derived size: direct definition, WINDOW(other-record-name)
+ * references (following chains, guarding against cycles), and SFL/SFLCTL pair propagation.
+ * Shared by the parse-time cached resolution (processRecordSizes, format-oblivious — always picks
+ * the first WINDOW candidate) and the live, display-format-aware resolution used by the preview
+ * (resolveRecordSizeForFormat) when a record is conditioned by more than one DSPSIZ format.
+ * @param recordElements - All parsed records
+ * @param activeFormat - Selected display format name (e.g. "*DS3") to prefer when a record has
+ * more than one WINDOW() candidate; undefined to always take the first candidate (original behavior)
+ */
+function computeSizeByRecord(recordElements: DdsRecord[], activeFormat?: string): Map<string, DdsSize> {
     const sizeByRecord = new Map<string, DdsSize>();
     const referenceByRecord = new Map<string, string>();
 
     for (const record of recordElements) {
-        const extracted = extractWindowSize(record.attributes);
+        const extracted = extractWindowSize(record.attributes, activeFormat);
         if (extracted?.size) {
             sizeByRecord.set(record.name, extracted.size);
         } else if (extracted?.referenceName) {
@@ -834,15 +895,22 @@ function processRecordSizes(ddsElements: DdsElement[]): void {
 
     propagateSubfileWindowSizes(recordElements, sizeByRecord);
 
-    for (const record of recordElements) {
-        record.size = sizeByRecord.get(record.name) ?? getDefaultSize();
+    return sizeByRecord;
+};
 
-        // Also update the fieldsPerRecords structure for easy access
-        const recordEntry = fieldsPerRecords.find(r => r.record === record.name);
-        if (recordEntry) {
-            recordEntry.size = record.size;
-        };
-    };
+/**
+ * Live, display-format-aware version of the WINDOW size resolution done by processRecordSizes at
+ * parse time. Used by the preview panel to recompute a record's effective size on the fly when
+ * the user switches display format (*DS3/*DS4), without needing a re-parse — some records
+ * (typically a subfile's SFLCTL, or a window that reuses another record's WINDOW) declare a
+ * different WINDOW() for each format, one line per format, conditioned on that format's name.
+ * @param recordName - Name of the record to resolve
+ * @param activeFormat - Selected display format name (e.g. "*DS3")
+ */
+export function resolveRecordSizeForFormat(recordName: string, activeFormat: string): DdsSize {
+    const recordElements = currentDdsElements.filter(el => el.kind === 'record') as DdsRecord[];
+    const sizeByRecord = computeSizeByRecord(recordElements, activeFormat);
+    return sizeByRecord.get(recordName) ?? getSizeForFormat(activeFormat) ?? getDefaultSize();
 };
 
 /**
@@ -885,18 +953,39 @@ function propagateSubfileWindowSizes(recordElements: DdsRecord[], sizeByRecord: 
 };
 
 /**
+ * Picks which of a record's WINDOW() attribute candidates applies. A record can have more than
+ * one when it's conditioned by different DSPSIZ display formats (*DS3/*DS4), one WINDOW() line
+ * per format. Prefers the one matching activeFormat, falling back to an unconditioned one, then to
+ * the first candidate in source order — that last fallback is what makes this format-oblivious
+ * (always "first WINDOW wins") when no activeFormat is given, preserving the original behavior for
+ * the parse-time cached size.
+ * @param attributes - Record attributes to search
+ * @param activeFormat - Selected display format name (e.g. "*DS3"), or undefined
+ */
+function pickWindowAttribute(attributes: DdsAttribute[] | undefined, activeFormat?: string): DdsAttribute | undefined {
+    const candidates = (attributes ?? []).filter(attr => attr.value.toUpperCase().startsWith('WINDOW('));
+    if (candidates.length === 0) {
+        return undefined;
+    };
+    if (!activeFormat) {
+        return candidates[0];
+    };
+    return candidates.find(attr => attr.displayFormat === activeFormat)
+        ?? candidates.find(attr => !attr.displayFormat)
+        ?? candidates[0];
+};
+
+/**
  * Extracts WINDOW size information from record attributes. Supports both the direct form,
  * WINDOW(startRow startCol numRows numCols), and the shared-window reference form,
  * WINDOW(other-record-name), which is resolved later against the other record's own size.
  * @param attributes - Record attributes to search
+ * @param activeFormat - Selected display format name (e.g. "*DS3"), to pick the right candidate
+ * when the record has more than one WINDOW() line (one per DSPSIZ format)
  * @returns The resolved size (direct form), a reference name to resolve later (name form), or undefined
  */
-function extractWindowSize(attributes?: DdsAttribute[]): { size?: DdsSize; referenceName?: string } | undefined {
-    if (!attributes) return undefined;
-
-    const windowAttribute = attributes.find(attr =>
-        attr.value.toUpperCase().includes('WINDOW(')
-    );
+function extractWindowSize(attributes?: DdsAttribute[], activeFormat?: string): { size?: DdsSize; referenceName?: string } | undefined {
+    const windowAttribute = pickWindowAttribute(attributes, activeFormat);
     if (!windowAttribute) return undefined;
 
     // WINDOW(startRow startCol numRows numCols)

--- a/src/dspf-edit.providers/dspf-edit.providers.ts
+++ b/src/dspf-edit.providers/dspf-edit.providers.ts
@@ -16,6 +16,13 @@ import { ExtensionState } from '../dspf-edit.states/state';
 interface DocumentFilter {
 	visibilityFilter: Set<'field' | 'constant'>;
 	recordFilter: Set<string>;
+	/** Whether recordFilter has been seeded for this document yet. Needed to tell an intentional
+	 * "hide all" (empty recordFilter) apart from a brand-new document that just hasn't been
+	 * initialized yet — both look like an empty set otherwise. */
+	initialized: boolean;
+	/** Every record name seen as of the last setElements() call, filtered or not — used to detect
+	 * newly-added records (as opposed to ones that were already there but filtered out). */
+	knownRecords: Set<string>;
 }
 
 /**
@@ -35,7 +42,9 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 	// Filtro por defecto para nuevos documentos
 	private defaultFilter: DocumentFilter = {
 		visibilityFilter: new Set(['field', 'constant']),
-		recordFilter: new Set()
+		recordFilter: new Set(),
+		initialized: false,
+		knownRecords: new Set()
 	};
 
 	// TreeView instance for expand/collapse operations
@@ -55,15 +64,44 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 
 		const filter = this.getCurrentFilter();
 		const recordNames = this.elements.filter(e => e.kind === 'record').map(r => r.name);
+		const currentRecordNames = new Set(recordNames);
 
-		// Si el filtro está vacío o tiene registros que ya no existen, reinicializar con todos
-		const hasInvalidRecords = filter.recordFilter.size > 0 &&
-			[...filter.recordFilter].some(name => !recordNames.includes(name));
-
-		if (filter.recordFilter.size === 0 || hasInvalidRecords) {
+		if (!filter.initialized) {
+			// Brand-new document: seed the filter with every record, so nothing is hidden by
+			// default. Only happens once — an explicit "Hide all" afterwards must stick.
 			filter.recordFilter = new Set(recordNames);
-			this.setCurrentFilter(filter);
-		}
+			filter.initialized = true;
+		} else {
+			const newRecords = recordNames.filter(name => !filter.knownRecords.has(name));
+			// "Partially" filtered = some records are actively hidden (not none, not all) — a
+			// brand-new record would silently vanish into that hidden set with no obvious cause.
+			const wasPartiallyFiltered = filter.recordFilter.size > 0 && filter.recordFilter.size < filter.knownRecords.size;
+
+			if (newRecords.length > 0 && wasPartiallyFiltered) {
+				// Rather than leave the new record(s) invisible for no apparent reason, disable
+				// the record filter entirely (show everything) and let the user know why.
+				filter.recordFilter = new Set(recordNames);
+
+				const docName = ExtensionState.lastDdsDocument ? path.basename(ExtensionState.lastDdsDocument.uri.fsPath) : 'this document';
+				vscode.window.showWarningMessage(
+					`New record${newRecords.length > 1 ? 's' : ''} (${newRecords.join(', ')}) detected in ${docName} — record filter disabled so it's visible.`
+				);
+			} else {
+				// Prune record names that no longer exist (renamed/removed). Any new record is
+				// silently included too, unless the filter was intentionally emptied ("Hide all"),
+				// which stays that way.
+				const pruned = new Set([...filter.recordFilter].filter(name => currentRecordNames.has(name)));
+				if (filter.recordFilter.size > 0) {
+					for (const name of newRecords) {
+						pruned.add(name);
+					};
+				};
+				filter.recordFilter = pruned;
+			};
+		};
+
+		filter.knownRecords = currentRecordNames;
+		this.setCurrentFilter(filter);
 
 		// Actualizar el status bar después de establecer los elementos
 		// con un pequeño delay para evitar parpadeos
@@ -130,7 +168,9 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 			// Crear una copia del filtro por defecto para este documento
 			this.documentFilters.set(uri, {
 				visibilityFilter: new Set(this.defaultFilter.visibilityFilter),
-				recordFilter: new Set(this.defaultFilter.recordFilter)
+				recordFilter: new Set(this.defaultFilter.recordFilter),
+				initialized: false,
+				knownRecords: new Set()
 			});
 		}
 
@@ -226,7 +266,7 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 			.map(e => ({
 				label: `📄 ${e.name}`,
 				name: e.name,
-				picked: filter.recordFilter.size > 0 && filter.recordFilter.has(e.name)
+				picked: filter.recordFilter.has(e.name)
 			}));
 
 		const selectedRecords = await vscode.window.showQuickPick(recordItems, {
@@ -235,11 +275,9 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 		});
 
 		if (selectedRecords !== undefined) {
+			// Leaving none checked is a valid (if unusual) choice — it means "hide all records",
+			// same as the "Hide all" command; it's not silently reinterpreted as "show all".
 			filter.recordFilter = new Set(selectedRecords.map(r => r.name));
-			if (filter.recordFilter.size === 0) {
-				// Si no se selecciona ninguno, mostrar todos
-				filter.recordFilter = new Set(this.elements.filter(e => e.kind === 'record').map(r => r.name));
-			}
 		}
 
 		// Select which element types to show
@@ -247,7 +285,7 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 		const elementItems = allElementTypes.map(type => ({
 			label: type === 'field' ? '🔤 Fields' : '💡 Constants',
 			type: type,
-			picked: filter.visibilityFilter.has(type) || filter.visibilityFilter.size === 0
+			picked: filter.visibilityFilter.has(type)
 		}));
 
 		const selectedElements = await vscode.window.showQuickPick(elementItems, {
@@ -256,14 +294,12 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 		});
 
 		if (selectedElements !== undefined) {
+			// Same as above: leaving none checked means "hide all types", not a fallback to "all".
 			filter.visibilityFilter = new Set(selectedElements.map(e => e.type as 'field' | 'constant'));
-			if (filter.visibilityFilter.size === 0) {
-				// If none selected, restore all types
-				filter.visibilityFilter = new Set(allElementTypes);
-			}
 		}
 
 		// Guardar filtro actualizado
+		filter.initialized = true;
 		this.setCurrentFilter(filter);
 
 		// Refresh tree and update status bar
@@ -281,6 +317,7 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 		} else {
 			filter.visibilityFilter.add(kind);
 		}
+		filter.initialized = true;
 		this.setCurrentFilter(filter);
 		this.refresh();
 		this.updateStatusBar();
@@ -293,6 +330,7 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 		const filter = this.getCurrentFilter();
 		filter.visibilityFilter = new Set(['field', 'constant']);
 		filter.recordFilter = new Set(this.elements.filter(e => e.kind === 'record').map(r => r.name));
+		filter.initialized = true;
 		this.setCurrentFilter(filter);
 
 		this.refresh();
@@ -310,6 +348,7 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 		const filter = this.getCurrentFilter();
 		filter.visibilityFilter.clear();
 		filter.recordFilter.clear();
+		filter.initialized = true;
 		this.setCurrentFilter(filter);
 
 		this.refresh();
@@ -326,8 +365,7 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 	}
 
 	private isVisibleRecord(name: string): boolean {
-		const filter = this.getCurrentFilter();
-		return filter.recordFilter.size === 0 || filter.recordFilter.has(name);
+		return this.getCurrentFilter().recordFilter.has(name);
 	}
 
 	// TreeDataProvider required methods

--- a/src/dspf-edit.providers/dspf-edit.providers.ts
+++ b/src/dspf-edit.providers/dspf-edit.providers.ts
@@ -78,6 +78,37 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 	}
 
 	/**
+	 * Gets the TreeView instance, e.g. to listen for selection changes.
+	 */
+	getTreeView(): vscode.TreeView<DdsNode> | undefined {
+		return this.treeView;
+	}
+
+	/**
+	 * Finds the tree node for the field or constant at the given source line, by traversing the
+	 * tree via getChildren (mirroring how expandNodeRecursively walks it) so the returned node is
+	 * one TreeView.reveal() can actually locate. Used to sync the tree selection with a click in
+	 * the record preview. Returns undefined if the item is filtered out or no longer exists.
+	 * @param lineIndex - Zero-based source line index of the field/constant to find
+	 */
+	async findFieldOrConstantNode(lineIndex: number): Promise<DdsNode | undefined> {
+		const search = async (node?: DdsNode): Promise<DdsNode | undefined> => {
+			const children = await this.getChildren(node);
+			for (const child of children) {
+				if ((child.ddsElement.kind === 'field' || child.ddsElement.kind === 'constant') && child.ddsElement.lineIndex === lineIndex) {
+					return child;
+				}
+				const found = await search(child);
+				if (found) {
+					return found;
+				}
+			}
+			return undefined;
+		};
+		return search(undefined);
+	}
+
+	/**
 	 * Gets the current document URI as a string.
 	 * @returns The URI string of the current document or undefined
 	 */

--- a/src/dspf-edit.utils/dspf-edit.helper.ts
+++ b/src/dspf-edit.utils/dspf-edit.helper.ts
@@ -292,6 +292,7 @@ export function findElementInsertionPoint(editor: vscode.TextEditor, element: an
 
         // Skip commented lines
         if (line.startsWith('     A*')) {
+            insertionPoint++;
             continue;
         };
         // If the line is a new record, breaks
@@ -337,8 +338,9 @@ export function findElementInsertionPointRecordFirstLine(editor: vscode.TextEdit
         if (line.trim().startsWith('A ')) {
             break;
         };
+        insertionPoint++;
     };
-    
+
     return insertionPoint;
 };
 
@@ -349,9 +351,9 @@ export function findElementInsertionPointRecordFirstLine(editor: vscode.TextEdit
  */
 export function findElementInsertionPointFileFirstLine(editor: vscode.TextEditor): number {
     const elementLineIndex = 0;
-    
+
     let insertionPoint = elementLineIndex;
-    
+
     // Skip existing attribute lines (lines that start with "     A" and have attributes)
     while (insertionPoint < editor.document.lineCount) {
         const line = editor.document.lineAt(insertionPoint).text;
@@ -362,8 +364,9 @@ export function findElementInsertionPointFileFirstLine(editor: vscode.TextEditor
         if (line.trim().startsWith('A ')) {
             break;
         };
+        insertionPoint++;
     };
-    
+
     return insertionPoint;
 };
 

--- a/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
@@ -1,0 +1,1532 @@
+/*
+    Christian Larsen, 2025
+    "RPG structure"
+    dspf-edit.record-preview-panel.ts
+*/
+
+import * as vscode from 'vscode';
+import { FieldsPerRecord, DdsSize, AttributeWithIndicators, DdsIndicator, fieldsPerRecords, records, getDefaultSize } from '../dspf-edit.model/dspf-edit.model';
+import { checkForEditorAndDocument, updateTreeProvider } from '../dspf-edit.utils/dspf-edit.helper';
+import { DdsTreeProvider } from '../dspf-edit.providers/dspf-edit.providers';
+
+/**
+ * Item sent to the webview for rendering (a single field or constant on the screen grid).
+ */
+interface PreviewItem {
+    kind: 'field' | 'constant';
+    name: string;
+    text: string;
+    row: number;
+    col: number;
+    length: number;
+    lineIndex: number;
+    color: string;
+    highIntensity: boolean;
+    reverseImage: boolean;
+    blink: boolean;
+    underline: boolean;
+    columnSeparator: boolean;
+    nonDisplay: boolean;
+    /** Row/col offset that was added to place this item, so a drag-to-move can be converted back to record-local coordinates. */
+    rowOffset: number;
+    colOffset: number;
+    /** True when this item belongs to the record overlaid *behind* a window, not the record being previewed. */
+    isBackground: boolean;
+    /** False for subfile page-repeat ghosts and background items: only the "real" instance can be clicked/dragged. */
+    isInteractive: boolean;
+    /** True for input-capable fields (usage I or B), shown underlined instead of boxed. Always false for constants and output-only fields. */
+    isInputCapable: boolean;
+    /**
+     * True when this background item shares the *same* window as the record being previewed
+     * (an auto-paired SFL/SFLCTL half, or the window's owner record) rather than belonging to a
+     * genuinely different record positioned behind it. The window's own opaque frame is drawn over
+     * "behind" background items (they're physically covered by the window), but same-window items
+     * must be drawn on top of that frame fill, since they're part of the window's own content.
+     */
+    sameWindow?: boolean;
+};
+
+/** A rectangle in the coordinates of the canvas being drawn (the full display size). */
+interface WindowFrame {
+    row: number;
+    col: number;
+    rows: number;
+    cols: number;
+};
+
+// A WINDOW(row col numRows numCols) keyword gives the *border's* corner and the *content* area's
+// size. The content sits inset from the border: 1 row above/below, 1 column to the left, and
+// 2 columns to the right (confirmed against a real window: WINDOW(17 25 6 29) borders rows 17-24
+// and columns 25-56, with content usable across its full width up to the last column).
+const WINDOW_BORDER_TOP = 1;
+const WINDOW_BORDER_BOTTOM = 1;
+const WINDOW_BORDER_LEFT = 1;
+const WINDOW_BORDER_RIGHT = 2;
+
+/** Placeholder character shown across a field's width, keyed by [isNumeric][usage]. */
+const FIELD_USAGE_PLACEHOLDER: Record<'alpha' | 'numeric', Record<string, string>> = {
+    alpha: { O: 'O', B: 'B', I: 'I' },
+    numeric: { O: '6', B: '9', I: '3' }
+};
+
+/**
+ * Builds the placeholder text shown across a field's width, based on its data type and usage
+ * (O=output, B=both, I=input), matching the classic screen-design-aid convention.
+ * Falls back to the field name if the usage code isn't one of O/B/I.
+ * @param name - Field name (used as a fallback label)
+ * @param type - DDS data type code ('A' = alphanumeric; anything else is treated as numeric)
+ * @param usage - DDS usage code (O, B, I, H, ...)
+ * @param length - Field length, i.e. how many placeholder characters to repeat
+ */
+function getFieldPlaceholderText(name: string, type: string | undefined, usage: string | undefined, length: number): string {
+    const isNumeric = type !== 'A';
+    const usageCode = (usage || '').trim().toUpperCase();
+    const placeholderChar = FIELD_USAGE_PLACEHOLDER[isNumeric ? 'numeric' : 'alpha'][usageCode];
+
+    if (!placeholderChar) {
+        return name;
+    };
+
+    return placeholderChar.repeat(Math.max(length, 1));
+};
+
+/** Default 5250-style green, used when a field/constant has no COLOR() keyword. */
+const DEFAULT_COLOR = '#00ff00';
+
+/** Maps DDS COLOR() keyword codes to their on-screen color. */
+const DDS_COLOR_MAP: Record<string, string> = {
+    BLU: '#3366ff',
+    GRN: '#00ff00',
+    WHT: '#ffffff',
+    RED: '#ff4136',
+    TRQ: '#00e5ff',
+    YLW: '#ffe600',
+    PNK: '#ff66ff'
+};
+
+/**
+ * Determines the display color for a field/constant based on its COLOR() DDS keyword, if any.
+ * @param attributes - The element's DDS attributes
+ * @returns A CSS color string
+ */
+function getDisplayColor(attributes: AttributeWithIndicators[] | undefined): string {
+    const colorAttr = attributes?.find(attr => /^COLOR\([A-Z]{3}\)$/.test(attr.value));
+    if (!colorAttr) {
+        return DEFAULT_COLOR;
+    };
+
+    const code = colorAttr.value.match(/^COLOR\(([A-Z]{3})\)$/)?.[1];
+    return (code && DDS_COLOR_MAP[code]) || DEFAULT_COLOR;
+};
+
+/**
+ * Checks whether a field/constant carries a given DSPATR() keyword (e.g. DSPATR(UL)).
+ * @param attributes - The element's DDS attributes
+ * @param code - The two-letter DSPATR code to look for (HI, RI, BL, UL, ND, CS)
+ */
+function hasDisplayAttribute(attributes: AttributeWithIndicators[] | undefined, code: string): boolean {
+    return Boolean(attributes?.some(attr => attr.value === `DSPATR(${code})`));
+};
+
+/**
+ * Groups an attribute's DDS keyword for the "no indicator simulation" fallback: all COLOR() lines
+ * are alternatives for the same thing (only one color can apply), while each distinct DSPATR()
+ * code is its own independent flag.
+ * @param value - The attribute's raw keyword text (e.g. "COLOR(BLU)", "DSPATR(HI)")
+ */
+function attributeGroupKey(value: string): string {
+    const upper = value.toUpperCase();
+    return upper.startsWith('COLOR(') ? 'COLOR' : upper;
+};
+
+/**
+ * Finds the record's WINDOW() keyword, if any.
+ * @param recordName - Name of the record to inspect
+ */
+function findWindowAttribute(recordName: string): { startRow: number; startCol: number; numRows: number; numCols: number; lineIndex: number } | undefined {
+    const record = fieldsPerRecords.find(r => r.record === recordName);
+    const attr = record?.attributes?.find(a => a.value.toUpperCase().startsWith('WINDOW('));
+    if (!attr) {
+        return undefined;
+    };
+
+    const match = attr.value.match(/WINDOW\s*\(\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+)\s*\)/i);
+    if (!match) {
+        return undefined;
+    };
+
+    return {
+        startRow: parseInt(match[1], 10),
+        startCol: parseInt(match[2], 10),
+        numRows: parseInt(match[3], 10),
+        numCols: parseInt(match[4], 10),
+        lineIndex: attr.lineIndex
+    };
+};
+
+/** A window's title, extracted from its WDWTITLE() keyword. */
+interface WindowTitle {
+    text: string;
+    position: 'TOP' | 'BOTTOM';
+    align: 'LEFT' | 'CENTER' | 'RIGHT';
+};
+
+/**
+ * Finds and parses the record's WDWTITLE() keyword, if any. When the record shares its window
+ * with another record (WINDOW(other-record-name), or an SFL/SFLCTL pair where only one side
+ * declares the window), the title is commonly only present on that owner record — falls back
+ * to it if the record itself has none.
+ * Handles the common form WDWTITLE((*TEXT 'title text') [*TOP|*BOTTOM] [*LEFT|*CENTER|*RIGHT]).
+ * @param recordName - Name of the record to inspect
+ */
+function findWindowTitle(recordName: string): WindowTitle | undefined {
+    const record = fieldsPerRecords.find(r => r.record === recordName);
+    const ownerName = record?.size?.sharedFromRecord;
+
+    for (const name of ownerName ? [recordName, ownerName] : [recordName]) {
+        const rec = fieldsPerRecords.find(r => r.record === name);
+        const attr = rec?.attributes?.find(a => a.value.toUpperCase().startsWith('WDWTITLE('));
+        if (!attr) {
+            continue;
+        };
+
+        const textMatch = attr.value.match(/WDWTITLE\(\(\*\w+\s+'([^']*)'\)/i);
+        if (!textMatch) {
+            continue;
+        };
+
+        const upperValue = attr.value.toUpperCase();
+
+        return {
+            text: textMatch[1],
+            position: upperValue.includes('*BOTTOM') ? 'BOTTOM' : 'TOP',
+            align: upperValue.includes('*RIGHT') ? 'RIGHT' : upperValue.includes('*LEFT') ? 'LEFT' : 'CENTER'
+        };
+    };
+
+    return undefined;
+};
+
+/** Whether a record's attributes include the SFL keyword (i.e. it's a subfile detail record). */
+function isSflRecordInfo(recordInfo: FieldsPerRecord): boolean {
+    return recordInfo.attributes?.some(attr => attr.value === 'SFL') ?? false;
+};
+
+/**
+ * Finds the control record for a subfile (SFL) record, i.e. the one carrying SFLCTL(sflRecordName).
+ * @param sflRecordName - Name of the subfile (SFL) record
+ */
+function findSflControlRecord(sflRecordName: string): FieldsPerRecord | undefined {
+    return fieldsPerRecords.find(r =>
+        r.attributes?.some(attr => {
+            const match = attr.value.match(/^SFLCTL\(\s*([A-Za-z0-9@#$]+)\s*\)$/i);
+            return Boolean(match && match[1].toUpperCase() === sflRecordName.toUpperCase());
+        })
+    );
+};
+
+/**
+ * Finds the SFLPAG (page size, i.e. number of subfile rows shown at once) for a subfile record,
+ * by locating its control record (the one with SFLCTL(sflRecordName)) and reading SFLPAG() from it.
+ * @param sflRecordName - Name of the subfile (SFL) record
+ */
+function findSubfilePageSize(sflRecordName: string): number | undefined {
+    const controlRecord = findSflControlRecord(sflRecordName);
+    if (!controlRecord) {
+        return undefined;
+    };
+
+    const pagAttr = controlRecord.attributes?.find(a => a.value.toUpperCase().startsWith('SFLPAG('));
+    const match = pagAttr?.value.match(/SFLPAG\(\s*(\d+)\s*\)/i);
+    return match ? parseInt(match[1], 10) : undefined;
+};
+
+/**
+ * Finds the "other half" of a subfile pair: given the SFL detail record, its control record
+ * (SFLCTL); given the control record, the SFL detail record it controls. Used to automatically
+ * show the header (SFLCTL) alongside the detail rows (SFL), or vice versa, since neither preview
+ * is complete on its own.
+ * @param recordName - Name of an SFL or SFLCTL record
+ */
+function findSubfilePairRecordName(recordName: string): string | undefined {
+    const record = fieldsPerRecords.find(r => r.record === recordName);
+    if (!record) {
+        return undefined;
+    };
+
+    if (isSflRecordInfo(record)) {
+        return findSflControlRecord(recordName)?.record;
+    };
+
+    const sflctlAttr = record.attributes?.find(attr => attr.value.toUpperCase().startsWith('SFLCTL('));
+    const match = sflctlAttr?.value.match(/^SFLCTL\(\s*([A-Za-z0-9@#$]+)\s*\)$/i);
+    return match?.[1];
+};
+
+/**
+ * Finds the record that actually owns a shared window, i.e. the one named by
+ * WINDOW(other-record-name) (or, transitively, the SFL/SFLCTL pair that inherited it). Used to
+ * automatically show that owner as background too, since it commonly carries the WDWTITLE and
+ * other static text (e.g. function-key footers) that belong to the window as a whole.
+ * @param recordName - Name of the record to inspect
+ */
+function findWindowOwnerRecordName(recordName: string): string | undefined {
+    const record = fieldsPerRecords.find(r => r.record === recordName);
+    const owner = record?.size?.sharedFromRecord;
+    return owner && owner.toUpperCase() !== recordName.toUpperCase() ? owner : undefined;
+};
+
+/**
+ * Identifies which window a record's own content belongs to, for comparing whether two records
+ * share the exact same window (as opposed to one merely being positioned behind the other): the
+ * record's own name if it defines a window directly, or the name of the record it borrows one
+ * from (WINDOW(other-record-name), or an inherited SFL/SFLCTL pair). Undefined for non-window records.
+ * @param recordName - Name of the record to inspect
+ */
+function windowOwnerOf(recordName: string): string | undefined {
+    const record = fieldsPerRecords.find(r => r.record === recordName);
+    if (record?.size?.source !== 'window') {
+        return undefined;
+    };
+    return record.size.sharedFromRecord ?? recordName;
+};
+
+/**
+ * Read-only visual preview panel for a single DDS record.
+ * Shows fields/constants positioned on a monospace grid matching the record's screen size.
+ * WINDOW records are drawn at their real screen position, on a canvas sized to the full display,
+ * optionally with another record overlaid behind them to see how the window sits on top of it.
+ * Refreshes automatically whenever the DDS source is re-parsed.
+ */
+export class RecordPreviewPanel {
+
+    private static current: RecordPreviewPanel | undefined;
+
+    private readonly panel: vscode.WebviewPanel;
+    private recordName: string;
+    private treeSubscription: vscode.Disposable | undefined;
+    private treeProvider: DdsTreeProvider | undefined;
+    private overlayRecordName: string | undefined;
+    private indicatorsEnabled = false;
+    private activeIndicators: Set<number> = new Set();
+    private lastRecordInfo: FieldsPerRecord | undefined;
+    private lastSize: DdsSize | undefined;
+
+    private constructor(recordName: string) {
+        this.recordName = recordName;
+
+        this.panel = vscode.window.createWebviewPanel(
+            'dspfEditRecordPreview',
+            `Preview: ${recordName}`,
+            { viewColumn: vscode.ViewColumn.Beside, preserveFocus: true },
+            { enableScripts: true }
+        );
+
+        this.panel.webview.html = this.getHtml();
+
+        this.panel.webview.onDidReceiveMessage(message => this.onDidReceiveMessage(message));
+
+        this.panel.onDidDispose(() => {
+            this.treeSubscription?.dispose();
+            if (RecordPreviewPanel.current === this) {
+                RecordPreviewPanel.current = undefined;
+            };
+        });
+    }
+
+    /**
+     * Whether a preview panel is currently open (used to decide whether tree selection changes
+     * should retarget it to a different record).
+     */
+    static isOpen(): boolean {
+        return RecordPreviewPanel.current !== undefined;
+    };
+
+    /**
+     * Name of the record currently shown in the open preview panel, if any. Used to tell whether
+     * a tree selection needs to retarget the panel or just highlight an item already shown in it.
+     */
+    static getCurrentRecordName(): string | undefined {
+        return RecordPreviewPanel.current?.recordName;
+    };
+
+    /**
+     * Highlights the given source line in the open preview panel (the persistent selection box
+     * shown when clicking a field/constant), without navigating the editor or changing the
+     * previewed record. Used to mirror a tree selection into the preview. No-op if no panel is open.
+     * @param lineIndex - Zero-based source line index to highlight
+     */
+    static selectLineIfOpen(lineIndex: number): void {
+        RecordPreviewPanel.current?.panel.webview.postMessage({ type: 'selectLine', lineIndex });
+    };
+
+    /**
+     * Gets the single preview panel, retargeting it to the given record if it already exists,
+     * or creates a new one.
+     * @param recordName - Name of the record to preview
+     * @param treeProvider - The tree provider, used to force a re-parse right after a drag/resize edit
+     */
+    static getOrCreate(recordName: string, treeProvider: DdsTreeProvider): RecordPreviewPanel {
+        const existing = RecordPreviewPanel.current;
+        if (existing) {
+            existing.recordName = recordName;
+            existing.treeProvider = treeProvider;
+            existing.overlayRecordName = undefined;
+            existing.indicatorsEnabled = false;
+            existing.activeIndicators = new Set();
+            existing.panel.title = `Preview: ${recordName}`;
+            // Reveal without forcing a column: the user may have moved the panel elsewhere
+            // (e.g. to a bottom group), and switching records shouldn't snap it back to "Beside".
+            existing.panel.reveal(undefined, true);
+            return existing;
+        };
+
+        const created = new RecordPreviewPanel(recordName);
+        created.treeProvider = treeProvider;
+        RecordPreviewPanel.current = created;
+        return created;
+    };
+
+    /**
+     * Registers the listener that keeps this panel in sync with tree refreshes (i.e. re-parses of the DDS source).
+     * Only one subscription is kept per panel; callers may call this again safely.
+     * @param onRefresh - Callback invoked whenever the tree/model is refreshed
+     */
+    setRefreshSource(event: vscode.Event<any>, onRefresh: () => void): void {
+        this.treeSubscription?.dispose();
+        this.treeSubscription = event(onRefresh);
+    };
+
+    /**
+     * Receives the current record's data and (re-)renders the preview.
+     * @param recordInfo - The record's fields/constants, or undefined if the record no longer exists
+     * @param size - The record's screen size (rows/cols; window origin when it's a WINDOW record)
+     */
+    update(recordInfo: FieldsPerRecord | undefined, size: DdsSize | undefined): void {
+        this.lastRecordInfo = recordInfo;
+        this.lastSize = size;
+        this.render();
+    };
+
+    /**
+     * Renders the last received record data, honoring the current overlay selection.
+     * Split out from `update()` so changing the overlay (a pure view change) can re-render
+     * without needing a fresh parse.
+     */
+    private render(): void {
+        const recordInfo = this.lastRecordInfo;
+        const size = this.lastSize;
+
+        if (!recordInfo || !size) {
+            this.panel.webview.postMessage({ type: 'notFound' });
+            return;
+        };
+
+        const isWindow = size.source === 'window';
+        const defaultSize = getDefaultSize();
+
+        // A window is drawn at its real screen position, on a canvas sized to the full display,
+        // so its own fields/constants (which are stored record-local) need shifting by its origin.
+        // Content starts 1 row/col past the border's own corner (see WINDOW_BORDER_* above).
+        const rowOffset = isWindow ? size.originRow : 0;
+        const colOffset = isWindow ? size.originCol : 0;
+
+        const canvasSize = isWindow ? { rows: defaultSize.rows, cols: defaultSize.cols } : { rows: size.rows, cols: size.cols };
+
+        const items = this.buildItems(recordInfo, rowOffset, colOffset, false);
+        if (isSflRecordInfo(recordInfo)) {
+            items.push(...this.buildSubfileRepeats(items, this.recordName));
+        };
+
+        // The overlaid (background) record can be previewed on its own, whether or not it's itself
+        // a window, no matter what the record being previewed is. Indicator simulation doesn't
+        // apply to it, so its own indicators aren't offered in the toggle list either.
+        const backgroundItems: PreviewItem[] = [];
+        const shownAsBackground = new Set<string>([this.recordName]);
+        const toProcess: string[] = [this.recordName];
+
+        const addBackground = (name: string | undefined): void => {
+            if (!name || shownAsBackground.has(name)) {
+                return;
+            };
+            const items = this.buildBackgroundItemsFor(name);
+            if (!items) {
+                return;
+            };
+            backgroundItems.push(...items);
+            shownAsBackground.add(name);
+            toProcess.push(name);
+        };
+
+        addBackground(this.overlayRecordName);
+
+        // A subfile's own preview is incomplete without its counterpart: the SFL detail record
+        // has no header/titles of its own (those live on the SFLCTL record), and the SFLCTL record
+        // has no rows of its own. Likewise, a record whose WINDOW() keyword only names another
+        // record (or that inherited its window from an SFL/SFLCTL pair) is missing that owner's
+        // own content (e.g. WDWTITLE, footer text). Show whichever of these isn't already visible,
+        // automatically, following the chain (e.g. SFL -> its SFLCTL -> that SFLCTL's window owner).
+        for (let i = 0; i < toProcess.length; i++) {
+            const anchor = toProcess[i];
+            addBackground(findSubfilePairRecordName(anchor));
+            addBackground(findWindowOwnerRecordName(anchor));
+        };
+
+        const availableIndicators = this.collectIndicatorNumbers(recordInfo).sort((a, b) => a - b);
+
+        // The content area (where fields/constants live); its top-left is 1 row/col inside the border.
+        const windowFrame: WindowFrame | null = isWindow
+            ? { row: size.originRow + WINDOW_BORDER_TOP, col: size.originCol + WINDOW_BORDER_LEFT, rows: size.rows, cols: size.cols }
+            : null;
+
+        // The visual border itself: the content area padded out by the border widths.
+        const outerFrame: WindowFrame | null = (isWindow && windowFrame)
+            ? {
+                row: size.originRow,
+                col: size.originCol,
+                rows: windowFrame.rows + WINDOW_BORDER_TOP + WINDOW_BORDER_BOTTOM,
+                cols: windowFrame.cols + WINDOW_BORDER_LEFT + WINDOW_BORDER_RIGHT
+            }
+            : null;
+
+        // A window can't be resized past the edge of the physical screen it's positioned on
+        // (accounting for the border that surrounds the content area on every side).
+        const maxSize = isWindow
+            ? {
+                rows: defaultSize.rows - size.originRow - (WINDOW_BORDER_TOP + WINDOW_BORDER_BOTTOM) + 1,
+                cols: defaultSize.cols - size.originCol - (WINDOW_BORDER_LEFT + WINDOW_BORDER_RIGHT) + 1
+            }
+            : null;
+
+        const availableRecords = records.filter(name => name !== this.recordName);
+        const windowTitle = isWindow ? (findWindowTitle(this.recordName) ?? null) : null;
+
+        this.panel.webview.postMessage({
+            type: 'render',
+            recordName: this.recordName,
+            size: canvasSize,
+            isWindow,
+            windowFrame,
+            outerFrame,
+            windowTitle,
+            maxSize,
+            availableRecords,
+            overlayRecordName: this.overlayRecordName ?? null,
+            availableIndicators,
+            indicatorsEnabled: this.indicatorsEnabled,
+            activeIndicators: [...this.activeIndicators],
+            items,
+            backgroundItems
+        });
+    };
+
+    /**
+     * Builds background (dimmed, non-interactive) items for an arbitrary record by name: figures
+     * out its own offset (in case it's itself a window) and expands subfile page-repeats if it's
+     * an SFL record. Used for both the manual overlay and the automatic SFL/SFLCTL pairing.
+     * @param recordName - Name of the record to render as background
+     */
+    private buildBackgroundItemsFor(recordName: string): PreviewItem[] | undefined {
+        const record = fieldsPerRecords.find(r => r.record === recordName);
+        if (!record) {
+            return undefined;
+        };
+
+        const isWin = record.size?.source === 'window';
+        const rOffset = isWin && record.size ? record.size.originRow : 0;
+        const cOffset = isWin && record.size ? record.size.originCol : 0;
+
+        const items = this.buildItems(record, rOffset, cOffset, true);
+        if (isSflRecordInfo(record)) {
+            items.push(...this.buildSubfileRepeats(items, recordName));
+        };
+
+        // A same-window item (an auto-paired SFL/SFLCTL half, or the window's owner) is part of
+        // the window's own content and must show through its opaque frame, unlike a genuinely
+        // different record merely positioned behind the window.
+        const foregroundOwner = windowOwnerOf(this.recordName);
+        const sameWindow = foregroundOwner !== undefined && windowOwnerOf(recordName) === foregroundOwner;
+        for (const item of items) {
+            item.sameWindow = sameWindow;
+        };
+
+        return items;
+    };
+
+    /**
+     * Builds the preview items for a record's fields/constants, shifted by the given offset.
+     * @param recordInfo - The record's fields/constants
+     * @param rowOffset - Added to each field/constant's own row (0 unless this is a window's own content)
+     * @param colOffset - Added to each field/constant's own col (0 unless this is a window's own content)
+     * @param isBackground - Whether these items belong to the record overlaid behind a window
+     */
+    private buildItems(recordInfo: FieldsPerRecord, rowOffset: number, colOffset: number, isBackground: boolean): PreviewItem[] {
+        const items: PreviewItem[] = [];
+
+        // The parser stores a subfile (SFL) record's field/constant row and column swapped
+        // (a leftover of how move-fields/move-constants track "horizontal" movement for SFLs).
+        // Undo that swap here to get the real screen row/col for display.
+        const isSfl = isSflRecordInfo(recordInfo);
+
+        // Indicator simulation only applies to the record being actively previewed; an overlaid
+        // background record always renders as if indicators were off (the static "first wins" view).
+        const indicatorsApply = this.indicatorsEnabled && !isBackground;
+
+        for (const field of recordInfo.fields) {
+            if (indicatorsApply && !this.isItemDisplayed(field.indicators)) {
+                continue;
+            };
+
+            const trueRow = isSfl ? field.col : field.row;
+            const trueCol = isSfl ? field.row : field.col;
+
+            if (trueRow > 0 && trueCol > 0) {
+                const activeAttrs = this.getActiveAttributes(field.attributes, indicatorsApply);
+                const usageCode = (field.usage || '').trim().toUpperCase();
+                items.push({
+                    kind: 'field',
+                    name: field.name,
+                    text: getFieldPlaceholderText(field.name, field.type, field.usage, field.length),
+                    row: trueRow + rowOffset,
+                    col: trueCol + colOffset,
+                    length: field.length,
+                    lineIndex: field.lineIndex,
+                    color: getDisplayColor(activeAttrs),
+                    highIntensity: hasDisplayAttribute(activeAttrs, 'HI'),
+                    reverseImage: hasDisplayAttribute(activeAttrs, 'RI'),
+                    blink: hasDisplayAttribute(activeAttrs, 'BL'),
+                    underline: hasDisplayAttribute(activeAttrs, 'UL'),
+                    columnSeparator: hasDisplayAttribute(activeAttrs, 'CS'),
+                    nonDisplay: hasDisplayAttribute(activeAttrs, 'ND'),
+                    rowOffset,
+                    colOffset,
+                    isBackground,
+                    isInteractive: !isBackground,
+                    isInputCapable: usageCode === 'I' || usageCode === 'B'
+                });
+            };
+        };
+
+        for (const constant of recordInfo.constants) {
+            if (indicatorsApply && !this.isItemDisplayed(constant.indicators)) {
+                continue;
+            };
+
+            const trueRow = isSfl ? constant.col : constant.row;
+            const trueCol = isSfl ? constant.row : constant.col;
+
+            if (trueRow > 0 && trueCol > 0) {
+                const activeAttrs = this.getActiveAttributes(constant.attributes, indicatorsApply);
+                items.push({
+                    kind: 'constant',
+                    name: constant.name,
+                    text: constant.name,
+                    row: trueRow + rowOffset,
+                    col: trueCol + colOffset,
+                    length: constant.length,
+                    lineIndex: constant.lineIndex,
+                    color: getDisplayColor(activeAttrs),
+                    highIntensity: hasDisplayAttribute(activeAttrs, 'HI'),
+                    reverseImage: hasDisplayAttribute(activeAttrs, 'RI'),
+                    blink: hasDisplayAttribute(activeAttrs, 'BL'),
+                    underline: hasDisplayAttribute(activeAttrs, 'UL'),
+                    columnSeparator: hasDisplayAttribute(activeAttrs, 'CS'),
+                    nonDisplay: hasDisplayAttribute(activeAttrs, 'ND'),
+                    rowOffset,
+                    colOffset,
+                    isBackground,
+                    isInteractive: !isBackground,
+                    isInputCapable: false
+                });
+            };
+        };
+
+        // Without indicator simulation, we can't know which of several alternate constants/fields
+        // sharing the same spot (conditioned by complementary indicators) would really show, so
+        // just keep whichever one is defined first in the source, like a static "designer" view.
+        return indicatorsApply ? items : this.dedupByPosition(items);
+    };
+
+    /**
+     * Checks whether a field/constant's own line-level indicators (columns 7-15, e.g. "61"/"N61")
+     * are satisfied by the currently active indicator set. Multiple indicators on one line are
+     * ANDed together, matching real DDS conditioning. No indicators at all means "always shown".
+     * @param indicators - The item's own indicators
+     */
+    private isItemDisplayed(indicators: DdsIndicator[] | undefined): boolean {
+        if (!indicators || indicators.length === 0) {
+            return true;
+        };
+        return indicators.every(ind => this.activeIndicators.has(ind.number) === ind.active);
+    };
+
+    /**
+     * Filters a field/constant's own COLOR()/DSPATR() attributes the same way visibility is
+     * filtered: with indicator simulation on, keep only the ones whose own indicators are
+     * satisfied; otherwise, keep just the first (by source order) alternative of each keyword,
+     * so conditioned alternates (e.g. two COLOR() lines for different indicator states) don't
+     * all apply to the static preview at once.
+     * @param attributes - The field/constant's own attributes
+     * @param indicatorsApply - Whether indicator simulation applies to this record right now
+     */
+    private getActiveAttributes(attributes: AttributeWithIndicators[], indicatorsApply: boolean): AttributeWithIndicators[] {
+        if (indicatorsApply) {
+            return attributes.filter(attr => this.isItemDisplayed(attr.indicators));
+        };
+
+        const seen = new Set<string>();
+        const result: AttributeWithIndicators[] = [];
+        for (const attr of attributes) {
+            const key = attributeGroupKey(attr.value);
+            if (seen.has(key)) {
+                continue;
+            };
+            seen.add(key);
+            result.push(attr);
+        };
+        return result;
+    };
+
+    /**
+     * Keeps only the first (lowest lineIndex) item at each exact (row, col), so alternate
+     * constants/fields that occupy the same spot don't render stacked on top of each other.
+     */
+    private dedupByPosition(items: PreviewItem[]): PreviewItem[] {
+        const bestByPosition = new Map<string, PreviewItem>();
+
+        for (const item of items) {
+            const key = item.row + ',' + item.col;
+            const existing = bestByPosition.get(key);
+            if (!existing || item.lineIndex < existing.lineIndex) {
+                bestByPosition.set(key, item);
+            };
+        };
+
+        const kept = new Set(bestByPosition.values());
+        return items.filter(item => kept.has(item));
+    };
+
+    /**
+     * Collects the distinct indicator numbers referenced by a record's own fields/constants
+     * (used to populate the indicator toggle list in the toolbar).
+     */
+    private collectIndicatorNumbers(recordInfo: FieldsPerRecord): number[] {
+        const numbers = new Set<number>();
+        for (const field of recordInfo.fields) {
+            for (const ind of field.indicators ?? []) {
+                numbers.add(ind.number);
+            };
+            for (const attr of field.attributes) {
+                for (const ind of attr.indicators ?? []) {
+                    numbers.add(ind.number);
+                };
+            };
+        };
+        for (const constant of recordInfo.constants) {
+            for (const ind of constant.indicators ?? []) {
+                numbers.add(ind.number);
+            };
+            for (const attr of constant.attributes) {
+                for (const ind of attr.indicators ?? []) {
+                    numbers.add(ind.number);
+                };
+            };
+        };
+        return [...numbers];
+    };
+
+    /**
+     * Repeats a subfile's own base items for each additional visible page row (SFLPAG), stacked
+     * downward. The repeats are display-only: dragging/clicking always targets the single real
+     * source line, so only the first (base) instance stays interactive.
+     * @param baseItems - The subfile's own items, as built for its first (real) row
+     * @param recordName - Name of the subfile (SFL) record
+     */
+    private buildSubfileRepeats(baseItems: PreviewItem[], recordName: string): PreviewItem[] {
+        const sflPag = findSubfilePageSize(recordName);
+        if (!sflPag || sflPag <= 1 || baseItems.length === 0) {
+            return [];
+        };
+
+        const rows = baseItems.map(item => item.row);
+        const rowSpan = Math.max(...rows) - Math.min(...rows) + 1;
+
+        const repeats: PreviewItem[] = [];
+        for (let page = 1; page < sflPag; page++) {
+            for (const item of baseItems) {
+                repeats.push({ ...item, row: item.row + page * rowSpan, isInteractive: false });
+            };
+        };
+
+        return repeats;
+    };
+
+    /**
+     * Handles messages posted from the webview: click-to-navigate, drag-to-move, window resize,
+     * and overlay selection.
+     */
+    private async onDidReceiveMessage(message: any): Promise<void> {
+        if (message?.type === 'navigate' && typeof message.lineIndex === 'number') {
+            await this.navigateToLine(message.lineIndex);
+            return;
+        };
+
+        if (message?.type === 'move'
+            && typeof message.lineIndex === 'number'
+            && typeof message.newRow === 'number'
+            && typeof message.newCol === 'number') {
+            await this.moveElement(
+                message.lineIndex,
+                message.newRow,
+                message.newCol,
+                typeof message.rowOffset === 'number' ? message.rowOffset : 0,
+                typeof message.colOffset === 'number' ? message.colOffset : 0
+            );
+            return;
+        };
+
+        if (message?.type === 'resize' && typeof message.newRows === 'number' && typeof message.newCols === 'number') {
+            await this.resizeWindow(message.newRows, message.newCols);
+            return;
+        };
+
+        if (message?.type === 'moveWindow' && typeof message.newRow === 'number' && typeof message.newCol === 'number') {
+            await this.moveWindowPosition(message.newRow, message.newCol);
+            return;
+        };
+
+        if (message?.type === 'setOverlay') {
+            this.overlayRecordName = message.recordName || undefined;
+            this.render();
+            return;
+        };
+
+        if (message?.type === 'setIndicatorsEnabled') {
+            this.indicatorsEnabled = Boolean(message.enabled);
+            this.render();
+            return;
+        };
+
+        if (message?.type === 'toggleIndicator' && typeof message.number === 'number') {
+            if (this.activeIndicators.has(message.number)) {
+                this.activeIndicators.delete(message.number);
+            } else {
+                this.activeIndicators.add(message.number);
+            };
+            this.render();
+        };
+    };
+
+    /**
+     * Navigates the DDS editor to the given line (used when clicking a field/constant in the preview),
+     * and also selects the matching node in the tree view, if one is found.
+     * @param lineIndex - Zero-based line index to jump to
+     */
+    private async navigateToLine(lineIndex: number): Promise<void> {
+        const { editor } = checkForEditorAndDocument();
+        if (!editor) {
+            return;
+        };
+
+        await vscode.window.showTextDocument(editor.document, {
+            viewColumn: editor.viewColumn,
+            preserveFocus: false
+        });
+
+        const position = new vscode.Position(lineIndex, 0);
+        editor.selection = new vscode.Selection(position, position);
+        editor.revealRange(
+            new vscode.Range(position, position),
+            vscode.TextEditorRevealType.InCenterIfOutsideViewport
+        );
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
+
+        const treeView = this.treeProvider?.getTreeView();
+        if (this.treeProvider && treeView) {
+            const node = await this.treeProvider.findFieldOrConstantNode(lineIndex);
+            if (node) {
+                try {
+                    await treeView.reveal(node, { select: true, focus: false, expand: true });
+                } catch {
+                    // Ignore reveal errors (e.g. the item is currently filtered out of the tree).
+                };
+            };
+        };
+    };
+
+    /**
+     * Applies a drag-and-drop move from the preview: writes the new row/column back into the
+     * DDS source line, at the same fixed columns used by the move-fields/move-constants commands
+     * (raw columns 38-41 for the row/line spec, 41-44 for the column/position spec).
+     * The screen position is converted back to record-local coordinates using the offset that was
+     * applied when the item was built (non-zero only for a window's own fields/constants).
+     * @param lineIndex - Zero-based line index of the field/constant being moved
+     * @param newRow - New row, in screen coordinates (as shown in the preview grid)
+     * @param newCol - New column, in screen coordinates (as shown in the preview grid)
+     * @param rowOffset - Offset to subtract to get back to the record-local row
+     * @param colOffset - Offset to subtract to get back to the record-local column
+     */
+    private async moveElement(lineIndex: number, newRow: number, newCol: number, rowOffset: number, colOffset: number): Promise<void> {
+        const { editor } = checkForEditorAndDocument();
+        if (!editor || lineIndex >= editor.document.lineCount) {
+            return;
+        };
+
+        const localRow = newRow - rowOffset;
+        const localCol = newCol - colOffset;
+
+        // The raw source columns are always "Line spec" (38-41) / "Position spec" (41-44) — i.e.
+        // row/col in that fixed order — for every record type. A subfile only swaps which of these
+        // ends up labeled model.row/model.col internally (see buildItems' undo); the physical
+        // columns themselves never swap, so no subfile-specific handling is needed here.
+        const workspaceEdit = new vscode.WorkspaceEdit();
+        const uri = editor.document.uri;
+
+        workspaceEdit.replace(uri, new vscode.Range(lineIndex, 38, lineIndex, 41), String(localRow).padStart(3, ' '));
+        workspaceEdit.replace(uri, new vscode.Range(lineIndex, 41, lineIndex, 44), String(localCol).padStart(3, ' '));
+
+        await vscode.workspace.applyEdit(workspaceEdit);
+        this.forceReparse(editor.document);
+    };
+
+    /**
+     * Name of the record whose WINDOW() keyword should actually be edited for the current record:
+     * itself, unless its window was inherited (WINDOW(other-record-name), or an SFL/SFLCTL pair
+     * sharing one side's window) — in which case the real geometry lives on the owner record.
+     */
+    private resolveWindowRecordName(): string {
+        return fieldsPerRecords.find(r => r.record === this.recordName)?.size?.sharedFromRecord ?? this.recordName;
+    };
+
+    /**
+     * Applies a resize (from dragging the window's corner handle), keeping its screen position unchanged.
+     * @param newRows - New window height
+     * @param newCols - New window width
+     */
+    private async resizeWindow(newRows: number, newCols: number): Promise<void> {
+        const windowInfo = findWindowAttribute(this.resolveWindowRecordName());
+        if (!windowInfo) {
+            return;
+        };
+
+        await this.rewriteWindowKeyword(windowInfo.lineIndex, windowInfo.startRow, windowInfo.startCol, newRows, newCols);
+    };
+
+    /**
+     * Applies a move (from dragging the window's frame), keeping its size unchanged.
+     * @param newRow - New window screen row
+     * @param newCol - New window screen column
+     */
+    private async moveWindowPosition(newRow: number, newCol: number): Promise<void> {
+        const windowInfo = findWindowAttribute(this.resolveWindowRecordName());
+        if (!windowInfo) {
+            return;
+        };
+
+        await this.rewriteWindowKeyword(windowInfo.lineIndex, newRow, newCol, windowInfo.numRows, windowInfo.numCols);
+    };
+
+    /**
+     * Rewrites the record's WINDOW(startRow startCol numRows numCols) keyword in place.
+     */
+    private async rewriteWindowKeyword(lineIndex: number, startRow: number, startCol: number, numRows: number, numCols: number): Promise<void> {
+        const { editor } = checkForEditorAndDocument();
+        if (!editor) {
+            return;
+        };
+
+        const line = editor.document.lineAt(lineIndex);
+        const updatedLine = line.text.replace(
+            /WINDOW\s*\(\s*\d+\s+\d+\s+\d+\s+\d+\s*\)/i,
+            `WINDOW(${startRow} ${startCol} ${numRows} ${numCols})`
+        );
+
+        if (updatedLine === line.text) {
+            return;
+        };
+
+        const workspaceEdit = new vscode.WorkspaceEdit();
+        workspaceEdit.replace(editor.document.uri, line.range, updatedLine);
+        await vscode.workspace.applyEdit(workspaceEdit);
+        this.forceReparse(editor.document);
+    };
+
+    /**
+     * The webview holds focus during drag/resize, so the normal onDidChangeTextDocument listener
+     * (which only reacts when the edited document is the active text editor) won't fire.
+     * Force the re-parse immediately instead of waiting for the user to click back into the source.
+     */
+    private forceReparse(document: vscode.TextDocument): void {
+        if (this.treeProvider) {
+            updateTreeProvider(this.treeProvider, document);
+        };
+    };
+
+    /**
+     * Builds the webview HTML: a canvas that draws the field/constant grid and reports clicks,
+     * drags, resizes and overlay selection back.
+     */
+    private getHtml(): string {
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<style>
+    body {
+        margin: 0;
+        padding: 8px;
+        background: #000000;
+        color: #00ff00;
+        font-family: var(--vscode-editor-font-family, monospace);
+    }
+    #info {
+        margin-bottom: 6px;
+        opacity: 0.7;
+        font-size: 12px;
+    }
+    #toolbar {
+        display: none;
+        margin-bottom: 6px;
+        font-size: 12px;
+    }
+    #toolbar select {
+        background: #000000;
+        color: #00ff00;
+        border: 1px solid #333333;
+        font-family: inherit;
+    }
+    #indicatorBar {
+        display: none;
+        margin-bottom: 6px;
+        font-size: 12px;
+    }
+    #indicatorList {
+        display: none;
+        margin-top: 4px;
+    }
+    .indicator-btn {
+        display: inline-block;
+        min-width: 20px;
+        margin: 2px;
+        padding: 1px 4px;
+        text-align: center;
+        border: 1px solid #555555;
+        color: #888888;
+        background: #000000;
+        cursor: pointer;
+        font-family: inherit;
+        font-size: 11px;
+    }
+    .indicator-btn.on {
+        color: #000000;
+        background: #00ff00;
+        border-color: #00ff00;
+    }
+    canvas {
+        background: #000000;
+        border: 1px solid #333333;
+        cursor: default;
+    }
+</style>
+</head>
+<body>
+<div id="info">Loading...</div>
+<div id="toolbar">
+    <label for="overlaySelect">Overlay on: </label>
+    <select id="overlaySelect"></select>
+</div>
+<div id="indicatorBar">
+    <label><input type="checkbox" id="indicatorsToggle"> Use indicators</label>
+    <div id="indicatorList"></div>
+</div>
+<canvas id="screen"></canvas>
+<script>
+    const vscode = acquireVsCodeApi();
+    const canvas = document.getElementById('screen');
+    const ctx = canvas.getContext('2d');
+    const info = document.getElementById('info');
+    const toolbar = document.getElementById('toolbar');
+    const overlaySelect = document.getElementById('overlaySelect');
+    const indicatorBar = document.getElementById('indicatorBar');
+    const indicatorsToggle = document.getElementById('indicatorsToggle');
+    const indicatorList = document.getElementById('indicatorList');
+
+    const CHAR_W = 9;
+    const CHAR_H = 18;
+    const BLINK_INTERVAL_MS = 600;
+    const HANDLE_SIZE = 8;
+    // Mirrors WINDOW_BORDER_* on the host: content sits 1 row/col inside the border, except on
+    // the right, where it's 2 (verified against a real window's on-screen footprint).
+    const WINDOW_BORDER_TOP = 1;
+    const WINDOW_BORDER_BOTTOM = 1;
+    const WINDOW_BORDER_LEFT = 1;
+    const WINDOW_BORDER_RIGHT = 2;
+
+    let currentItems = [];
+    let currentBackgroundItems = [];
+    let currentSize = null;
+    let currentWindowFrame = null;
+    let currentOuterFrame = null;
+    let currentWindowTitle = null;
+    let maxSize = null;
+    let blinkOn = true;
+    let dragState = null;
+    let resizeState = null;
+    let moveWindowState = null;
+    let selectedLineIndex = null;
+    let currentRecordName = null;
+
+    function clamp(value, min, max) {
+        return Math.min(Math.max(value, min), max);
+    }
+
+    function drawItem(item, fontFamily, moveDelta) {
+        if (item.nonDisplay) {
+            return;
+        }
+        if (item.blink && !blinkOn) {
+            return;
+        }
+
+        const isDragged = dragState && dragState.item === item;
+        const isSelected = item.lineIndex === selectedLineIndex;
+        let row = isDragged ? dragState.row : item.row;
+        let col = isDragged ? dragState.col : item.col;
+
+        if (moveDelta && !item.isBackground) {
+            row += moveDelta.row;
+            col += moveDelta.col;
+        }
+
+        const x = (col - 1) * CHAR_W;
+        const y = (row - 1) * CHAR_H;
+        const w = Math.max(item.length, item.text.length, 1) * CHAR_W;
+
+        ctx.font = (item.highIntensity ? 'bold ' : '') + (CHAR_H - 4) + 'px ' + fontFamily;
+
+        if (item.reverseImage) {
+            ctx.fillStyle = item.color;
+            ctx.fillRect(x, y, w, CHAR_H);
+            ctx.fillStyle = '#000000';
+        } else {
+            ctx.fillStyle = item.color;
+        }
+
+        const text = item.text.length > item.length ? item.text.substring(0, item.length) : item.text;
+        ctx.fillText(text, x + 2, y + CHAR_H / 2);
+
+        if (item.underline || item.isInputCapable) {
+            ctx.strokeStyle = item.reverseImage ? '#000000' : item.color;
+            ctx.beginPath();
+            ctx.moveTo(x, y + CHAR_H - 2.5);
+            ctx.lineTo(x + w, y + CHAR_H - 2.5);
+            ctx.stroke();
+        }
+
+        if (item.columnSeparator) {
+            ctx.strokeStyle = item.color;
+            ctx.beginPath();
+            ctx.moveTo(x + 0.5, y);
+            ctx.lineTo(x + 0.5, y + CHAR_H);
+            ctx.moveTo(x + w - 0.5, y);
+            ctx.lineTo(x + w - 0.5, y + CHAR_H);
+            ctx.stroke();
+        }
+
+        if (isSelected) {
+            ctx.save();
+            ctx.strokeStyle = '#ffffff';
+            ctx.setLineDash(isDragged ? [3, 2] : []);
+            ctx.strokeRect(x - 1.5, y - 1.5, w + 2, CHAR_H + 2);
+            ctx.restore();
+        }
+    }
+
+    function draw(size, items, backgroundItems, windowFrame, windowTitle, outerFrame) {
+        currentItems = items;
+        currentBackgroundItems = backgroundItems || [];
+        currentSize = size;
+        currentWindowFrame = windowFrame || null;
+        currentOuterFrame = outerFrame || null;
+        currentWindowTitle = windowTitle || null;
+        canvas.width = size.cols * CHAR_W;
+        canvas.height = size.rows * CHAR_H;
+
+        const fontFamily = getComputedStyle(document.body).getPropertyValue('--vscode-editor-font-family').trim() || 'monospace';
+
+        ctx.fillStyle = '#000000';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.textBaseline = 'middle';
+
+        // A "behind" background item (a genuinely different record positioned behind the window)
+        // is drawn before the window's own opaque frame fill, so the frame physically covers it,
+        // just like the real window would. A "same window" item (an auto-paired SFL/SFLCTL half,
+        // or the window's owner record) is part of the window's own content and is drawn later,
+        // after the frame fill, so it shows through instead of being hidden by it.
+        const behindItems = currentBackgroundItems.filter(item => !item.sameWindow);
+        const sameWindowItems = currentBackgroundItems.filter(item => item.sameWindow);
+
+        if (behindItems.length) {
+            ctx.save();
+            ctx.globalAlpha = 0.45;
+            for (const item of behindItems) {
+                drawItem(item, fontFamily, null);
+            }
+            ctx.restore();
+        }
+
+        // While the window is being dragged, its own fields/constants move along with its border
+        // (the background record's items stay put, since that record isn't being moved).
+        const moveDelta = (moveWindowState && currentOuterFrame)
+            ? { row: currentOuterFrame.row - moveWindowState.startRow, col: currentOuterFrame.col - moveWindowState.startCol }
+            : null;
+
+        if (currentOuterFrame) {
+            const fx = (currentOuterFrame.col - 1) * CHAR_W;
+            const fy = (currentOuterFrame.row - 1) * CHAR_H;
+            const fw = currentOuterFrame.cols * CHAR_W;
+            const fh = currentOuterFrame.rows * CHAR_H;
+
+            ctx.fillStyle = '#000000';
+            ctx.fillRect(fx, fy, fw, fh);
+            ctx.strokeStyle = '#666666';
+            ctx.strokeRect(fx + 0.5, fy + 0.5, fw - 1, fh - 1);
+        }
+
+        if (sameWindowItems.length) {
+            ctx.save();
+            ctx.globalAlpha = 0.45;
+            for (const item of sameWindowItems) {
+                drawItem(item, fontFamily, null);
+            }
+            ctx.restore();
+        }
+
+        for (const item of items) {
+            drawItem(item, fontFamily, moveDelta);
+        }
+
+        if (currentOuterFrame) {
+            const hx = (currentOuterFrame.col - 1 + currentOuterFrame.cols) * CHAR_W;
+            const hy = (currentOuterFrame.row - 1 + currentOuterFrame.rows) * CHAR_H;
+            ctx.fillStyle = '#ffffff';
+            ctx.fillRect(hx - HANDLE_SIZE, hy - HANDLE_SIZE, HANDLE_SIZE, HANDLE_SIZE);
+        }
+
+        if (currentOuterFrame && currentWindowTitle) {
+            const fx = (currentOuterFrame.col - 1) * CHAR_W;
+            const fy = (currentOuterFrame.row - 1) * CHAR_H;
+            const fw = currentOuterFrame.cols * CHAR_W;
+            const fh = currentOuterFrame.rows * CHAR_H;
+
+            const titleY = currentWindowTitle.position === 'BOTTOM' ? fy + fh - CHAR_H : fy;
+            const text = ' ' + currentWindowTitle.text + ' ';
+
+            ctx.font = (CHAR_H - 4) + 'px ' + fontFamily;
+            const textWidth = Math.min(ctx.measureText(text).width, fw - 4);
+
+            let textX;
+            if (currentWindowTitle.align === 'LEFT') {
+                textX = fx + 2;
+            } else if (currentWindowTitle.align === 'RIGHT') {
+                textX = fx + fw - textWidth - 2;
+            } else {
+                textX = fx + (fw - textWidth) / 2;
+            }
+
+            ctx.fillStyle = '#000000';
+            ctx.fillRect(textX, titleY, textWidth, CHAR_H);
+            ctx.fillStyle = '#ffffff';
+            ctx.fillText(text, textX, titleY + CHAR_H / 2);
+        }
+    }
+
+    setInterval(() => {
+        const anyBlinking = currentItems.some(item => item.blink) || currentBackgroundItems.some(item => item.blink);
+        if (!anyBlinking) {
+            return;
+        }
+        blinkOn = !blinkOn;
+        draw(currentSize, currentItems, currentBackgroundItems, currentWindowFrame, currentWindowTitle, currentOuterFrame);
+    }, BLINK_INTERVAL_MS);
+
+    function cellAt(ev) {
+        const rect = canvas.getBoundingClientRect();
+        const col = Math.floor((ev.clientX - rect.left) / CHAR_W) + 1;
+        const row = Math.floor((ev.clientY - rect.top) / CHAR_H) + 1;
+        return { row, col };
+    }
+
+    function findItemAt(ev) {
+        // Only the real, interactive instance can be clicked/selected/dragged: an overlaid
+        // background record is reference-only, and subfile page-repeat ghosts aren't real lines.
+        const { row, col } = cellAt(ev);
+        return currentItems.find(item =>
+            item.isInteractive &&
+            row === item.row &&
+            col >= item.col &&
+            col < item.col + Math.max(item.length, item.text.length, 1)
+        );
+    }
+
+    function isOverResizeHandle(ev) {
+        if (!currentOuterFrame) {
+            return false;
+        }
+        const rect = canvas.getBoundingClientRect();
+        const px = ev.clientX - rect.left;
+        const py = ev.clientY - rect.top;
+        const hx = (currentOuterFrame.col - 1 + currentOuterFrame.cols) * CHAR_W;
+        const hy = (currentOuterFrame.row - 1 + currentOuterFrame.rows) * CHAR_H;
+        return px >= hx - HANDLE_SIZE && px <= hx && py >= hy - HANDLE_SIZE && py <= hy;
+    }
+
+    function isOverWindowFrame(ev) {
+        if (!currentOuterFrame) {
+            return false;
+        }
+        const { row, col } = cellAt(ev);
+        return row >= currentOuterFrame.row && row < currentOuterFrame.row + currentOuterFrame.rows &&
+               col >= currentOuterFrame.col && col < currentOuterFrame.col + currentOuterFrame.cols;
+    }
+
+    canvas.addEventListener('mousedown', (ev) => {
+        if (isOverResizeHandle(ev)) {
+            resizeState = {
+                contentRows: currentOuterFrame.rows - WINDOW_BORDER_TOP - WINDOW_BORDER_BOTTOM,
+                contentCols: currentOuterFrame.cols - WINDOW_BORDER_LEFT - WINDOW_BORDER_RIGHT
+            };
+            return;
+        }
+
+        const hit = findItemAt(ev);
+        selectedLineIndex = hit ? hit.lineIndex : null;
+        draw(currentSize, currentItems, currentBackgroundItems, currentWindowFrame, currentWindowTitle, currentOuterFrame);
+
+        if (hit) {
+            const { row, col } = cellAt(ev);
+            dragState = {
+                item: hit,
+                grabRowOffset: row - hit.row,
+                grabColOffset: col - hit.col,
+                row: hit.row,
+                col: hit.col,
+                moved: false
+            };
+            return;
+        }
+
+        // Clicked empty space inside the window's own frame (not on a field/constant): drag the window itself.
+        if (isOverWindowFrame(ev)) {
+            const { row, col } = cellAt(ev);
+            moveWindowState = {
+                grabRowOffset: row - currentOuterFrame.row,
+                grabColOffset: col - currentOuterFrame.col,
+                startRow: currentOuterFrame.row,
+                startCol: currentOuterFrame.col,
+                moved: false
+            };
+        }
+    });
+
+    window.addEventListener('mousemove', (ev) => {
+        if (resizeState) {
+            const { row, col } = cellAt(ev);
+            const limitRows = maxSize ? maxSize.rows : currentSize.rows;
+            const limitCols = maxSize ? maxSize.cols : currentSize.cols;
+            // Content top-left (currentWindowFrame) stays fixed; the corner being dragged maps to
+            // content size, not the outer border's own size (see WINDOW_BORDER_* above).
+            const newContentRows = clamp(row - currentWindowFrame.row - (WINDOW_BORDER_BOTTOM - 1), 1, limitRows);
+            const newContentCols = clamp(col - currentWindowFrame.col - (WINDOW_BORDER_RIGHT - 1), 1, limitCols);
+
+            if (newContentRows !== resizeState.contentRows || newContentCols !== resizeState.contentCols) {
+                resizeState.contentRows = newContentRows;
+                resizeState.contentCols = newContentCols;
+                currentOuterFrame = Object.assign({}, currentOuterFrame, {
+                    rows: newContentRows + WINDOW_BORDER_TOP + WINDOW_BORDER_BOTTOM,
+                    cols: newContentCols + WINDOW_BORDER_LEFT + WINDOW_BORDER_RIGHT
+                });
+                draw(currentSize, currentItems, currentBackgroundItems, currentWindowFrame, currentWindowTitle, currentOuterFrame);
+            }
+            return;
+        }
+
+        if (moveWindowState) {
+            const { row, col } = cellAt(ev);
+            const limitRow = Math.max(currentSize.rows - currentOuterFrame.rows + 1, 1);
+            const limitCol = Math.max(currentSize.cols - currentOuterFrame.cols + 1, 1);
+            const newRow = clamp(row - moveWindowState.grabRowOffset, 1, limitRow);
+            const newCol = clamp(col - moveWindowState.grabColOffset, 1, limitCol);
+
+            if (newRow !== currentOuterFrame.row || newCol !== currentOuterFrame.col) {
+                currentOuterFrame = Object.assign({}, currentOuterFrame, { row: newRow, col: newCol });
+                moveWindowState.moved = true;
+                draw(currentSize, currentItems, currentBackgroundItems, currentWindowFrame, currentWindowTitle, currentOuterFrame);
+            }
+            return;
+        }
+
+        if (!dragState) {
+            const overHandle = isOverResizeHandle(ev);
+            if (overHandle) {
+                canvas.style.cursor = 'nwse-resize';
+                canvas.title = '';
+                return;
+            }
+            const hit = findItemAt(ev);
+            canvas.style.cursor = (!hit && isOverWindowFrame(ev)) ? 'move' : 'default';
+            canvas.title = hit ? hit.name : '';
+            return;
+        }
+
+        const { row, col } = cellAt(ev);
+        const width = Math.max(dragState.item.length, dragState.item.text.length, 1);
+
+        // A window's own fields/constants can't be dragged past its frame; background (overlay)
+        // items, or items in a plain (non-window) record, are bounded by the whole canvas instead.
+        let minRow = 1, maxRow = currentSize.rows, minCol = 1, maxCol = currentSize.cols - width + 1;
+        if (currentWindowFrame && !dragState.item.isBackground) {
+            minRow = currentWindowFrame.row;
+            maxRow = Math.max(currentWindowFrame.row + currentWindowFrame.rows - 1, minRow);
+            // The window's own first content column can't be written to; the rest of its width,
+            // including the last column, is usable.
+            minCol = currentWindowFrame.col + 1;
+            maxCol = Math.max(currentWindowFrame.col + currentWindowFrame.cols - width, minCol);
+        }
+
+        const newRow = clamp(row - dragState.grabRowOffset, minRow, maxRow);
+        const newCol = clamp(col - dragState.grabColOffset, minCol, maxCol);
+
+        if (newRow !== dragState.row || newCol !== dragState.col) {
+            dragState.row = newRow;
+            dragState.col = newCol;
+            dragState.moved = true;
+            draw(currentSize, currentItems, currentBackgroundItems, currentWindowFrame, currentWindowTitle, currentOuterFrame);
+        }
+    });
+
+    window.addEventListener('mouseup', () => {
+        if (resizeState) {
+            const { contentRows, contentCols } = resizeState;
+            resizeState = null;
+            vscode.postMessage({ type: 'resize', newRows: contentRows, newCols: contentCols });
+            return;
+        }
+
+        if (moveWindowState) {
+            const moved = moveWindowState.moved;
+            const finalRow = currentOuterFrame.row;
+            const finalCol = currentOuterFrame.col;
+            moveWindowState = null;
+            if (moved) {
+                vscode.postMessage({ type: 'moveWindow', newRow: finalRow, newCol: finalCol });
+            }
+            return;
+        }
+
+        if (!dragState) {
+            return;
+        }
+
+        if (dragState.moved) {
+            vscode.postMessage({
+                type: 'move',
+                lineIndex: dragState.item.lineIndex,
+                newRow: dragState.row,
+                newCol: dragState.col,
+                rowOffset: dragState.item.rowOffset,
+                colOffset: dragState.item.colOffset
+            });
+        } else {
+            vscode.postMessage({ type: 'navigate', lineIndex: dragState.item.lineIndex });
+        }
+
+        dragState = null;
+        draw(currentSize, currentItems, currentBackgroundItems, currentWindowFrame, currentWindowTitle, currentOuterFrame);
+    });
+
+    overlaySelect.addEventListener('change', () => {
+        vscode.postMessage({ type: 'setOverlay', recordName: overlaySelect.value || null });
+    });
+
+    function rebuildOverlayOptions(availableRecords, selectedValue) {
+        overlaySelect.innerHTML = '';
+
+        const noneOption = document.createElement('option');
+        noneOption.value = '';
+        noneOption.textContent = '(none)';
+        overlaySelect.appendChild(noneOption);
+
+        for (const name of availableRecords) {
+            const opt = document.createElement('option');
+            opt.value = name;
+            opt.textContent = name;
+            overlaySelect.appendChild(opt);
+        }
+
+        overlaySelect.value = selectedValue;
+    }
+
+    indicatorsToggle.addEventListener('change', () => {
+        vscode.postMessage({ type: 'setIndicatorsEnabled', enabled: indicatorsToggle.checked });
+    });
+
+    function rebuildIndicatorList(availableIndicators, activeIndicators) {
+        indicatorList.innerHTML = '';
+
+        for (const number of availableIndicators) {
+            const btn = document.createElement('span');
+            btn.className = 'indicator-btn' + (activeIndicators.includes(number) ? ' on' : '');
+            btn.textContent = number;
+            btn.addEventListener('click', () => {
+                vscode.postMessage({ type: 'toggleIndicator', number });
+            });
+            indicatorList.appendChild(btn);
+        }
+    }
+
+    window.addEventListener('message', (event) => {
+        const message = event.data;
+        if (message.type === 'render') {
+            if (message.recordName !== currentRecordName) {
+                currentRecordName = message.recordName;
+                selectedLineIndex = null;
+                dragState = null;
+            }
+
+            maxSize = message.maxSize || null;
+            const hasOverlayOptions = message.availableRecords && message.availableRecords.length > 0;
+            toolbar.style.display = hasOverlayOptions ? 'block' : 'none';
+            if (hasOverlayOptions) {
+                rebuildOverlayOptions(message.availableRecords, message.overlayRecordName || '');
+            }
+
+            const hasIndicators = message.availableIndicators && message.availableIndicators.length > 0;
+            indicatorBar.style.display = hasIndicators ? 'block' : 'none';
+            if (hasIndicators) {
+                indicatorsToggle.checked = Boolean(message.indicatorsEnabled);
+                indicatorList.style.display = message.indicatorsEnabled ? 'block' : 'none';
+                rebuildIndicatorList(message.availableIndicators, message.activeIndicators || []);
+            }
+
+            const baseInfo = message.size.rows + ' x ' + message.size.cols;
+            info.textContent = message.windowFrame
+                ? baseInfo + '  —  window ' + message.windowFrame.rows + 'x' + message.windowFrame.cols +
+                  ' at (' + message.windowFrame.row + ',' + message.windowFrame.col + ')'
+                : baseInfo;
+
+            draw(message.size, message.items, message.backgroundItems, message.windowFrame, message.windowTitle, message.outerFrame);
+        } else if (message.type === 'notFound') {
+            info.textContent = 'Record no longer exists.';
+            ctx.clearRect(0, 0, canvas.width, canvas.height);
+        } else if (message.type === 'selectLine') {
+            selectedLineIndex = message.lineIndex;
+            draw(currentSize, currentItems, currentBackgroundItems, currentWindowFrame, currentWindowTitle, currentOuterFrame);
+        }
+    });
+</script>
+</body>
+</html>`;
+    };
+};

--- a/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
@@ -1,13 +1,17 @@
 /*
-    Christian Larsen, 2025
+    Christian Larsen, 2026
     "RPG structure"
     dspf-edit.record-preview-panel.ts
 */
 
 import * as vscode from 'vscode';
-import { FieldsPerRecord, DdsSize, AttributeWithIndicators, DdsIndicator, fieldsPerRecords, records, getDefaultSize } from '../dspf-edit.model/dspf-edit.model';
+import { FieldsPerRecord, DdsSize, AttributeWithIndicators, DdsIndicator, fieldsPerRecords, records, getDefaultSize, getAvailableDisplayFormats, getSizeForFormat } from '../dspf-edit.model/dspf-edit.model';
 import { checkForEditorAndDocument, updateTreeProvider } from '../dspf-edit.utils/dspf-edit.helper';
 import { DdsTreeProvider } from '../dspf-edit.providers/dspf-edit.providers';
+import { resolveRecordSizeForFormat } from '../dspf-edit.parser/dspf-edit.parser';
+import { editWindowTitleForRecord } from '../dspf-edit.commands/dspf-edit.window-title';
+import { getConstantTextFromUser, insertNewConstant } from '../dspf-edit.commands/dspf-edit.edit-constant';
+import { addFieldAtPosition } from '../dspf-edit.commands/dspf-edit.edit-field';
 
 /**
  * Item sent to the webview for rendering (a single field or constant on the screen grid).
@@ -140,12 +144,15 @@ function attributeGroupKey(value: string): string {
 };
 
 /**
- * Finds the record's WINDOW() keyword, if any.
+ * Finds the record's WINDOW() keyword, if any. When the record is conditioned by more than one
+ * display format (one WINDOW() line per format), picks the one matching activeFormat.
  * @param recordName - Name of the record to inspect
+ * @param activeFormat - Currently selected display format name (e.g. "*DS3"), or undefined
  */
-function findWindowAttribute(recordName: string): { startRow: number; startCol: number; numRows: number; numCols: number; lineIndex: number } | undefined {
+function findWindowAttribute(recordName: string, activeFormat?: string): { startRow: number; startCol: number; numRows: number; numCols: number; lineIndex: number } | undefined {
     const record = fieldsPerRecords.find(r => r.record === recordName);
-    const attr = record?.attributes?.find(a => a.value.toUpperCase().startsWith('WINDOW('));
+    const candidates = record?.attributes?.filter(a => a.value.toUpperCase().startsWith('WINDOW(')) ?? [];
+    const attr = pickForActiveFormat(candidates, activeFormat);
     if (!attr) {
         return undefined;
     };
@@ -175,17 +182,19 @@ interface WindowTitle {
  * Finds and parses the record's WDWTITLE() keyword, if any. When the record shares its window
  * with another record (WINDOW(other-record-name), or an SFL/SFLCTL pair where only one side
  * declares the window), the title is commonly only present on that owner record — falls back
- * to it if the record itself has none.
+ * to it if the record itself has none. When conditioned by more than one display format (one
+ * WDWTITLE() per format), picks the one matching activeFormat.
  * Handles the common form WDWTITLE((*TEXT 'title text') [*TOP|*BOTTOM] [*LEFT|*CENTER|*RIGHT]).
  * @param recordName - Name of the record to inspect
+ * @param activeFormat - Currently selected display format name (e.g. "*DS3"), or undefined
  */
-function findWindowTitle(recordName: string): WindowTitle | undefined {
-    const record = fieldsPerRecords.find(r => r.record === recordName);
-    const ownerName = record?.size?.sharedFromRecord;
+function findWindowTitle(recordName: string, activeFormat?: string): WindowTitle | undefined {
+    const ownerName = getEffectiveSize(recordName, activeFormat)?.sharedFromRecord;
 
     for (const name of ownerName ? [recordName, ownerName] : [recordName]) {
         const rec = fieldsPerRecords.find(r => r.record === name);
-        const attr = rec?.attributes?.find(a => a.value.toUpperCase().startsWith('WDWTITLE('));
+        const candidates = rec?.attributes?.filter(a => a.value.toUpperCase().startsWith('WDWTITLE(')) ?? [];
+        const attr = pickForActiveFormat(candidates, activeFormat);
         if (!attr) {
             continue;
         };
@@ -228,15 +237,19 @@ function findSflControlRecord(sflRecordName: string): FieldsPerRecord | undefine
 /**
  * Finds the SFLPAG (page size, i.e. number of subfile rows shown at once) for a subfile record,
  * by locating its control record (the one with SFLCTL(sflRecordName)) and reading SFLPAG() from it.
+ * When conditioned by more than one display format (one SFLPAG() per format), picks the one
+ * matching activeFormat.
  * @param sflRecordName - Name of the subfile (SFL) record
+ * @param activeFormat - Currently selected display format name (e.g. "*DS3"), or undefined
  */
-function findSubfilePageSize(sflRecordName: string): number | undefined {
+function findSubfilePageSize(sflRecordName: string, activeFormat?: string): number | undefined {
     const controlRecord = findSflControlRecord(sflRecordName);
     if (!controlRecord) {
         return undefined;
     };
 
-    const pagAttr = controlRecord.attributes?.find(a => a.value.toUpperCase().startsWith('SFLPAG('));
+    const candidates = controlRecord.attributes?.filter(a => a.value.toUpperCase().startsWith('SFLPAG(')) ?? [];
+    const pagAttr = pickForActiveFormat(candidates, activeFormat);
     const match = pagAttr?.value.match(/SFLPAG\(\s*(\d+)\s*\)/i);
     return match ? parseInt(match[1], 10) : undefined;
 };
@@ -270,9 +283,8 @@ function findSubfilePairRecordName(recordName: string): string | undefined {
  * other static text (e.g. function-key footers) that belong to the window as a whole.
  * @param recordName - Name of the record to inspect
  */
-function findWindowOwnerRecordName(recordName: string): string | undefined {
-    const record = fieldsPerRecords.find(r => r.record === recordName);
-    const owner = record?.size?.sharedFromRecord;
+function findWindowOwnerRecordName(recordName: string, activeFormat?: string): string | undefined {
+    const owner = getEffectiveSize(recordName, activeFormat)?.sharedFromRecord;
     return owner && owner.toUpperCase() !== recordName.toUpperCase() ? owner : undefined;
 };
 
@@ -283,12 +295,60 @@ function findWindowOwnerRecordName(recordName: string): string | undefined {
  * from (WINDOW(other-record-name), or an inherited SFL/SFLCTL pair). Undefined for non-window records.
  * @param recordName - Name of the record to inspect
  */
-function windowOwnerOf(recordName: string): string | undefined {
-    const record = fieldsPerRecords.find(r => r.record === recordName);
-    if (record?.size?.source !== 'window') {
+function windowOwnerOf(recordName: string, activeFormat?: string): string | undefined {
+    const size = getEffectiveSize(recordName, activeFormat);
+    if (size?.source !== 'window') {
         return undefined;
     };
-    return record.size.sharedFromRecord ?? recordName;
+    return size.sharedFromRecord ?? recordName;
+};
+
+/**
+ * Resolves a record's effective size: the live, display-format-aware resolution
+ * (resolveRecordSizeForFormat) when a display format is actively selected in the preview, else the
+ * cached parse-time size — unchanged behavior for files that don't declare multiple DSPSIZ formats.
+ * @param recordName - Name of the record to resolve
+ * @param activeFormat - Currently selected display format name (e.g. "*DS3"), or undefined
+ */
+function getEffectiveSize(recordName: string, activeFormat?: string): DdsSize | undefined {
+    if (activeFormat) {
+        return resolveRecordSizeForFormat(recordName, activeFormat);
+    };
+    return fieldsPerRecords.find(r => r.record === recordName)?.size;
+};
+
+/**
+ * Filters out attributes/fields/constants conditioned by a display format other than the active
+ * one; unconditioned ones (and everything, when no format is active) always pass through.
+ * @param items - Items carrying an optional displayFormat condition
+ * @param activeFormat - Currently selected display format name (e.g. "*DS3"), or undefined
+ */
+function filterForActiveFormat<T extends { displayFormat?: string }>(items: T[], activeFormat: string | undefined): T[] {
+    if (!activeFormat) {
+        return items;
+    };
+    return items.filter(item => !item.displayFormat || item.displayFormat === activeFormat);
+};
+
+/**
+ * Picks which of several same-keyword candidates applies, when a record/field/constant is
+ * conditioned by more than one display format (one line per format, e.g. WDWTITLE or SFLPAG
+ * declared once for *DS3 and once for *DS4). Prefers the one matching activeFormat, falling back
+ * to an unconditioned one, then to the first candidate — so behavior is unchanged when no format
+ * is active.
+ * @param candidates - Same-keyword attribute candidates, in source order
+ * @param activeFormat - Currently selected display format name (e.g. "*DS3"), or undefined
+ */
+function pickForActiveFormat<T extends { displayFormat?: string }>(candidates: T[], activeFormat?: string): T | undefined {
+    if (candidates.length === 0) {
+        return undefined;
+    };
+    if (!activeFormat) {
+        return candidates[0];
+    };
+    return candidates.find(c => c.displayFormat === activeFormat)
+        ?? candidates.find(c => !c.displayFormat)
+        ?? candidates[0];
 };
 
 /**
@@ -309,6 +369,7 @@ export class RecordPreviewPanel {
     private overlayRecordName: string | undefined;
     private indicatorsEnabled = false;
     private activeIndicators: Set<number> = new Set();
+    private activeDisplayFormat: string | undefined;
     private lastRecordInfo: FieldsPerRecord | undefined;
     private lastSize: DdsSize | undefined;
 
@@ -374,6 +435,7 @@ export class RecordPreviewPanel {
             existing.overlayRecordName = undefined;
             existing.indicatorsEnabled = false;
             existing.activeIndicators = new Set();
+            existing.activeDisplayFormat = undefined;
             existing.panel.title = `Preview: ${recordName}`;
             // Reveal without forcing a column: the user may have moved the panel elsewhere
             // (e.g. to a bottom group), and switching records shouldn't snap it back to "Beside".
@@ -409,27 +471,79 @@ export class RecordPreviewPanel {
     };
 
     /**
-     * Renders the last received record data, honoring the current overlay selection.
-     * Split out from `update()` so changing the overlay (a pure view change) can re-render
-     * without needing a fresh parse.
+     * Resolves the previewed record's current geometry (size, whether it's a window, and the
+     * row/col offset that places its record-local coordinates on the screen canvas), honoring the
+     * active display format. Shared by `render()` and by anything that needs to convert a screen
+     * click back to a record-local position (e.g. placing a new constant).
      */
-    private render(): void {
+    private resolveActiveGeometry(): {
+        recordInfo: FieldsPerRecord;
+        size: DdsSize;
+        isWindow: boolean;
+        rowOffset: number;
+        colOffset: number;
+        minDetailRow: number | null;
+    } | null {
         const recordInfo = this.lastRecordInfo;
-        const size = this.lastSize;
-
-        if (!recordInfo || !size) {
-            this.panel.webview.postMessage({ type: 'notFound' });
-            return;
+        if (!recordInfo || !this.lastSize) {
+            return null;
         };
 
+        // Default to the first declared format so a record's WINDOW()/attributes conditioned per
+        // format resolve consistently from the very first render, instead of showing every
+        // candidate at once. The selector itself stays locked to it when the file only declares one.
+        const availableFormats = getAvailableDisplayFormats();
+        if (availableFormats.length > 0 && !this.activeDisplayFormat) {
+            this.activeDisplayFormat = availableFormats[0].name;
+        };
+
+        // With a format actively selected, re-resolve the record's size live (it may be
+        // conditioned differently per format, e.g. a WINDOW() line per format); otherwise use the
+        // cached, parse-time size exactly as before.
+        const size = this.activeDisplayFormat
+            ? resolveRecordSizeForFormat(this.recordName, this.activeDisplayFormat)
+            : this.lastSize;
+
         const isWindow = size.source === 'window';
-        const defaultSize = getDefaultSize();
 
         // A window is drawn at its real screen position, on a canvas sized to the full display,
         // so its own fields/constants (which are stored record-local) need shifting by its origin.
         // Content starts 1 row/col past the border's own corner (see WINDOW_BORDER_* above).
         const rowOffset = isWindow ? size.originRow : 0;
         const colOffset = isWindow ? size.originCol : 0;
+
+        // A subfile detail (SFL) record's own rows shouldn't be draggable up into the area already
+        // occupied by its SFLCTL header's static content (labels, titles...) — that's not a valid
+        // screen layout, the repeating detail area has to start below wherever the header ends.
+        let minDetailRow: number | null = null;
+        if (isSflRecordInfo(recordInfo)) {
+            const pairName = findSubfilePairRecordName(this.recordName);
+            const headerItems = pairName ? this.buildBackgroundItemsFor(pairName) : undefined;
+            if (headerItems && headerItems.length > 0) {
+                minDetailRow = Math.max(...headerItems.map(item => item.row)) + 1;
+            };
+        };
+
+        return { recordInfo, size, isWindow, rowOffset, colOffset, minDetailRow };
+    };
+
+    /**
+     * Renders the last received record data, honoring the current overlay selection.
+     * Split out from `update()` so changing the overlay (a pure view change) can re-render
+     * without needing a fresh parse.
+     */
+    private render(): void {
+        const geometry = this.resolveActiveGeometry();
+        if (!geometry) {
+            this.panel.webview.postMessage({ type: 'notFound' });
+            return;
+        };
+        const { recordInfo, size, isWindow, rowOffset, colOffset, minDetailRow } = geometry;
+
+        const availableFormats = getAvailableDisplayFormats();
+        const defaultSize = this.activeDisplayFormat
+            ? (getSizeForFormat(this.activeDisplayFormat) ?? getDefaultSize())
+            : getDefaultSize();
 
         const canvasSize = isWindow ? { rows: defaultSize.rows, cols: defaultSize.cols } : { rows: size.rows, cols: size.cols };
 
@@ -469,7 +583,7 @@ export class RecordPreviewPanel {
         for (let i = 0; i < toProcess.length; i++) {
             const anchor = toProcess[i];
             addBackground(findSubfilePairRecordName(anchor));
-            addBackground(findWindowOwnerRecordName(anchor));
+            addBackground(findWindowOwnerRecordName(anchor, this.activeDisplayFormat));
         };
 
         const availableIndicators = this.collectIndicatorNumbers(recordInfo).sort((a, b) => a - b);
@@ -499,7 +613,7 @@ export class RecordPreviewPanel {
             : null;
 
         const availableRecords = records.filter(name => name !== this.recordName);
-        const windowTitle = isWindow ? (findWindowTitle(this.recordName) ?? null) : null;
+        const windowTitle = isWindow ? (findWindowTitle(this.recordName, this.activeDisplayFormat) ?? null) : null;
 
         this.panel.webview.postMessage({
             type: 'render',
@@ -515,6 +629,9 @@ export class RecordPreviewPanel {
             availableIndicators,
             indicatorsEnabled: this.indicatorsEnabled,
             activeIndicators: [...this.activeIndicators],
+            availableFormats,
+            activeDisplayFormat: this.activeDisplayFormat ?? null,
+            minDetailRow,
             items,
             backgroundItems
         });
@@ -532,9 +649,10 @@ export class RecordPreviewPanel {
             return undefined;
         };
 
-        const isWin = record.size?.source === 'window';
-        const rOffset = isWin && record.size ? record.size.originRow : 0;
-        const cOffset = isWin && record.size ? record.size.originCol : 0;
+        const size = getEffectiveSize(recordName, this.activeDisplayFormat);
+        const isWin = size?.source === 'window';
+        const rOffset = isWin && size ? size.originRow : 0;
+        const cOffset = isWin && size ? size.originCol : 0;
 
         const items = this.buildItems(record, rOffset, cOffset, true);
         if (isSflRecordInfo(record)) {
@@ -544,8 +662,8 @@ export class RecordPreviewPanel {
         // A same-window item (an auto-paired SFL/SFLCTL half, or the window's owner) is part of
         // the window's own content and must show through its opaque frame, unlike a genuinely
         // different record merely positioned behind the window.
-        const foregroundOwner = windowOwnerOf(this.recordName);
-        const sameWindow = foregroundOwner !== undefined && windowOwnerOf(recordName) === foregroundOwner;
+        const foregroundOwner = windowOwnerOf(this.recordName, this.activeDisplayFormat);
+        const sameWindow = foregroundOwner !== undefined && windowOwnerOf(recordName, this.activeDisplayFormat) === foregroundOwner;
         for (const item of items) {
             item.sameWindow = sameWindow;
         };
@@ -568,12 +686,16 @@ export class RecordPreviewPanel {
         // Undo that swap here to get the real screen row/col for display.
         const isSfl = isSflRecordInfo(recordInfo);
 
-        // Indicator simulation only applies to the record being actively previewed; an overlaid
-        // background record always renders as if indicators were off (the static "first wins" view).
-        const indicatorsApply = this.indicatorsEnabled && !isBackground;
+        // Indicator toggling only applies to the record being actively previewed; an overlaid
+        // background record always uses the resting state (every indicator OFF), regardless of
+        // what's toggled for the foreground record.
+        const useLiveIndicators = this.indicatorsEnabled && !isBackground;
 
         for (const field of recordInfo.fields) {
-            if (indicatorsApply && !this.isItemDisplayed(field.indicators)) {
+            if (this.activeDisplayFormat && field.displayFormat && field.displayFormat !== this.activeDisplayFormat) {
+                continue;
+            };
+            if (!this.isItemDisplayed(field.indicators, useLiveIndicators)) {
                 continue;
             };
 
@@ -581,7 +703,7 @@ export class RecordPreviewPanel {
             const trueCol = isSfl ? field.row : field.col;
 
             if (trueRow > 0 && trueCol > 0) {
-                const activeAttrs = this.getActiveAttributes(field.attributes, indicatorsApply);
+                const activeAttrs = this.getActiveAttributes(field.attributes, useLiveIndicators);
                 const usageCode = (field.usage || '').trim().toUpperCase();
                 items.push({
                     kind: 'field',
@@ -608,7 +730,10 @@ export class RecordPreviewPanel {
         };
 
         for (const constant of recordInfo.constants) {
-            if (indicatorsApply && !this.isItemDisplayed(constant.indicators)) {
+            if (this.activeDisplayFormat && constant.displayFormat && constant.displayFormat !== this.activeDisplayFormat) {
+                continue;
+            };
+            if (!this.isItemDisplayed(constant.indicators, useLiveIndicators)) {
                 continue;
             };
 
@@ -616,7 +741,7 @@ export class RecordPreviewPanel {
             const trueCol = isSfl ? constant.row : constant.col;
 
             if (trueRow > 0 && trueCol > 0) {
-                const activeAttrs = this.getActiveAttributes(constant.attributes, indicatorsApply);
+                const activeAttrs = this.getActiveAttributes(constant.attributes, useLiveIndicators);
                 items.push({
                     kind: 'constant',
                     name: constant.name,
@@ -641,42 +766,49 @@ export class RecordPreviewPanel {
             };
         };
 
-        // Without indicator simulation, we can't know which of several alternate constants/fields
-        // sharing the same spot (conditioned by complementary indicators) would really show, so
-        // just keep whichever one is defined first in the source, like a static "designer" view.
-        return indicatorsApply ? items : this.dedupByPosition(items);
+        // Even with indicators resolved (live or resting-state), two genuinely unconditioned
+        // items (or ones whose conditions aren't perfectly complementary) could still land on the
+        // exact same spot — keep only the first-defined one so they don't render stacked.
+        return this.dedupByPosition(items);
     };
 
     /**
      * Checks whether a field/constant's own line-level indicators (columns 7-15, e.g. "61"/"N61")
-     * are satisfied by the currently active indicator set. Multiple indicators on one line are
-     * ANDed together, matching real DDS conditioning. No indicators at all means "always shown".
+     * are satisfied. With live indicators, checks them against the currently toggled-on set
+     * (multiple indicators on one line are ANDed together, matching real DDS conditioning).
+     * Otherwise, uses the resting state — every indicator assumed OFF — so only unconditioned
+     * items and negated ("N") conditions show; this is what makes mutually-exclusive alternates
+     * (e.g. one shown on "61", another on "N61") resolve to a single, deterministic one even when
+     * they don't happen to share the same screen position. No indicators at all means "always shown".
      * @param indicators - The item's own indicators
+     * @param useLiveIndicators - Whether to check against the toggled-on indicator set, or assume all OFF
      */
-    private isItemDisplayed(indicators: DdsIndicator[] | undefined): boolean {
+    private isItemDisplayed(indicators: DdsIndicator[] | undefined, useLiveIndicators: boolean): boolean {
         if (!indicators || indicators.length === 0) {
             return true;
+        };
+        if (!useLiveIndicators) {
+            return indicators.every(ind => !ind.active);
         };
         return indicators.every(ind => this.activeIndicators.has(ind.number) === ind.active);
     };
 
     /**
      * Filters a field/constant's own COLOR()/DSPATR() attributes the same way visibility is
-     * filtered: with indicator simulation on, keep only the ones whose own indicators are
-     * satisfied; otherwise, keep just the first (by source order) alternative of each keyword,
-     * so conditioned alternates (e.g. two COLOR() lines for different indicator states) don't
-     * all apply to the static preview at once.
+     * filtered: attributes conditioned on a display format other than the active one are dropped
+     * first; then, ones whose own indicators aren't satisfied (checked live or against the resting
+     * state — see isItemDisplayed) are dropped too. If more than one candidate for the same
+     * keyword still remains (e.g. two unconditioned COLOR() lines), keeps just the first-defined one.
      * @param attributes - The field/constant's own attributes
-     * @param indicatorsApply - Whether indicator simulation applies to this record right now
+     * @param useLiveIndicators - Whether to check against the toggled-on indicator set, or assume all OFF
      */
-    private getActiveAttributes(attributes: AttributeWithIndicators[], indicatorsApply: boolean): AttributeWithIndicators[] {
-        if (indicatorsApply) {
-            return attributes.filter(attr => this.isItemDisplayed(attr.indicators));
-        };
+    private getActiveAttributes(attributes: AttributeWithIndicators[], useLiveIndicators: boolean): AttributeWithIndicators[] {
+        const forFormat = filterForActiveFormat(attributes, this.activeDisplayFormat);
+        const displayed = forFormat.filter(attr => this.isItemDisplayed(attr.indicators, useLiveIndicators));
 
         const seen = new Set<string>();
         const result: AttributeWithIndicators[] = [];
-        for (const attr of attributes) {
+        for (const attr of displayed) {
             const key = attributeGroupKey(attr.value);
             if (seen.has(key)) {
                 continue;
@@ -743,7 +875,7 @@ export class RecordPreviewPanel {
      * @param recordName - Name of the subfile (SFL) record
      */
     private buildSubfileRepeats(baseItems: PreviewItem[], recordName: string): PreviewItem[] {
-        const sflPag = findSubfilePageSize(recordName);
+        const sflPag = findSubfilePageSize(recordName, this.activeDisplayFormat);
         if (!sflPag || sflPag <= 1 || baseItems.length === 0) {
             return [];
         };
@@ -795,8 +927,39 @@ export class RecordPreviewPanel {
             return;
         };
 
+        if (message?.type === 'editWindowTitle') {
+            await this.editWindowTitle();
+            return;
+        };
+
+        if (message?.type === 'windowMenu') {
+            await this.showWindowMenu();
+            return;
+        };
+
+        if (message?.type === 'centerWindowHorizontally') {
+            await this.centerWindowHorizontally();
+            return;
+        };
+
+        if (message?.type === 'addConstantAt' && typeof message.row === 'number' && typeof message.col === 'number') {
+            await this.addConstantAt(message.row, message.col);
+            return;
+        };
+
+        if (message?.type === 'addFieldAt' && typeof message.row === 'number' && typeof message.col === 'number') {
+            await this.addFieldAt(message.row, message.col);
+            return;
+        };
+
         if (message?.type === 'setOverlay') {
             this.overlayRecordName = message.recordName || undefined;
+            this.render();
+            return;
+        };
+
+        if (message?.type === 'setDisplayFormat' && typeof message.name === 'string') {
+            this.activeDisplayFormat = message.name || undefined;
             this.render();
             return;
         };
@@ -891,12 +1054,99 @@ export class RecordPreviewPanel {
     };
 
     /**
+     * Places a brand-new constant at a screen position picked directly in the preview (the
+     * "+ Constant" button's placement mode): converts the click back to a record-local row/col,
+     * validates it's actually within the previewed record's own area, then reuses the same
+     * text-prompt and insertion logic as the tree's "Add constant" command.
+     * @param screenRow - Row clicked, in screen/canvas coordinates
+     * @param screenCol - Column clicked, in screen/canvas coordinates
+     */
+    private async addConstantAt(screenRow: number, screenCol: number): Promise<void> {
+        const { editor } = checkForEditorAndDocument();
+        if (!editor) {
+            return;
+        };
+
+        const position = this.resolveClickPosition(screenRow, screenCol, 'constant');
+        if (!position) {
+            return;
+        };
+        const { row, col } = position;
+
+        const text = await getConstantTextFromUser("Enter constant text (without quotes)", "", col);
+        if (!text) {
+            return;
+        };
+
+        await insertNewConstant(editor, { text, row, column: col, recordName: this.recordName });
+        this.forceReparse(editor.document);
+    };
+
+    /**
+     * Places a brand-new field at a screen position picked directly in the preview (the
+     * "+ Field" button's placement mode): converts the click back to a record-local row/col,
+     * validates it, then reuses the same name/usage/type prompts and insertion logic as the
+     * tree's "Add field" command.
+     * @param screenRow - Row clicked, in screen/canvas coordinates
+     * @param screenCol - Column clicked, in screen/canvas coordinates
+     */
+    private async addFieldAt(screenRow: number, screenCol: number): Promise<void> {
+        const { editor } = checkForEditorAndDocument();
+        if (!editor) {
+            return;
+        };
+
+        const position = this.resolveClickPosition(screenRow, screenCol, 'field');
+        if (!position) {
+            return;
+        };
+
+        await addFieldAtPosition(this.recordName, { row: position.row, column: position.col });
+        this.forceReparse(editor.document);
+    };
+
+    /**
+     * Converts a screen click to a record-local row/col for the currently previewed record,
+     * validating it falls within the record's own area (its window's content frame, if it's a
+     * window; the record's own screen size otherwise) and, for an SFL detail record, below its
+     * SFLCTL header's occupied rows. Shows a warning and returns null on an invalid click.
+     * @param screenRow - Row clicked, in screen/canvas coordinates
+     * @param screenCol - Column clicked, in screen/canvas coordinates
+     * @param kind - What's being placed, only used to word the warning message
+     */
+    private resolveClickPosition(screenRow: number, screenCol: number, kind: 'constant' | 'field'): { row: number; col: number } | null {
+        const geometry = this.resolveActiveGeometry();
+        if (!geometry) {
+            return null;
+        };
+        const { size, rowOffset, colOffset, minDetailRow } = geometry;
+
+        const row = screenRow - rowOffset;
+        const col = screenCol - colOffset;
+
+        if (row < 1 || row > size.rows || col < 1 || col > size.cols) {
+            vscode.window.showWarningMessage(
+                `Cannot place a ${kind} there — click inside record '${this.recordName}' (rows 1-${size.rows}, columns 1-${size.cols}).`
+            );
+            return null;
+        };
+        if (minDetailRow !== null && row < minDetailRow) {
+            vscode.window.showWarningMessage(
+                `Cannot place a ${kind} on row ${row} — it's occupied by the subfile header (rows below ${minDetailRow} only).`
+            );
+            return null;
+        };
+
+        return { row, col };
+    };
+
+    /**
      * Name of the record whose WINDOW() keyword should actually be edited for the current record:
      * itself, unless its window was inherited (WINDOW(other-record-name), or an SFL/SFLCTL pair
      * sharing one side's window) — in which case the real geometry lives on the owner record.
      */
     private resolveWindowRecordName(): string {
-        return fieldsPerRecords.find(r => r.record === this.recordName)?.size?.sharedFromRecord ?? this.recordName;
+        return getEffectiveSize(this.recordName, this.activeDisplayFormat)?.sharedFromRecord ?? this.recordName;
     };
 
     /**
@@ -905,7 +1155,7 @@ export class RecordPreviewPanel {
      * @param newCols - New window width
      */
     private async resizeWindow(newRows: number, newCols: number): Promise<void> {
-        const windowInfo = findWindowAttribute(this.resolveWindowRecordName());
+        const windowInfo = findWindowAttribute(this.resolveWindowRecordName(), this.activeDisplayFormat);
         if (!windowInfo) {
             return;
         };
@@ -919,12 +1169,75 @@ export class RecordPreviewPanel {
      * @param newCol - New window screen column
      */
     private async moveWindowPosition(newRow: number, newCol: number): Promise<void> {
-        const windowInfo = findWindowAttribute(this.resolveWindowRecordName());
+        const windowInfo = findWindowAttribute(this.resolveWindowRecordName(), this.activeDisplayFormat);
         if (!windowInfo) {
             return;
         };
 
         await this.rewriteWindowKeyword(windowInfo.lineIndex, newRow, newCol, windowInfo.numRows, windowInfo.numCols);
+    };
+
+    /**
+     * Opens the same "Change Window Title" prompt used from the tree's context menu, triggered by
+     * clicking the title directly on the preview. Edits the window-owner record when the title
+     * belongs to a shared window (WINDOW(other-record-name), or an inherited SFL/SFLCTL pair).
+     */
+    private async editWindowTitle(): Promise<void> {
+        await editWindowTitleForRecord(this.resolveWindowRecordName());
+
+        const { editor } = checkForEditorAndDocument();
+        if (editor) {
+            this.forceReparse(editor.document);
+        };
+    };
+
+    /**
+     * Shows the window's action menu, opened from the "⋮" button drawn in the frame's corner.
+     * Currently just offers "Change Title...", but is meant to grow: additional actions (e.g. a
+     * one-click "Center Horizontally") can be appended here, and/or given their own icon on the
+     * canvas later, following the same pattern as the title button.
+     */
+    private async showWindowMenu(): Promise<void> {
+        const options: (vscode.QuickPickItem & { action: string })[] = [
+            { label: '$(edit) Change Title...', action: 'editTitle' }
+        ];
+
+        const selection = await vscode.window.showQuickPick(options, {
+            title: `Window '${this.recordName}' — Actions`,
+            placeHolder: 'Select an action',
+            ignoreFocusOut: true
+        });
+        if (!selection) {
+            return;
+        };
+
+        if (selection.action === 'editTitle') {
+            await this.editWindowTitle();
+        };
+    };
+
+    /**
+     * Centers the window horizontally on the screen, keeping its row and size unchanged. A
+     * one-click action triggered from its own icon, bypassing the actions menu — the same
+     * centering math as the "Change Window Size" command's CENTERED option, for consistency.
+     */
+    private async centerWindowHorizontally(): Promise<void> {
+        const windowRecordName = this.resolveWindowRecordName();
+        const windowInfo = findWindowAttribute(windowRecordName, this.activeDisplayFormat);
+        if (!windowInfo) {
+            return;
+        };
+
+        const defaultSize = this.activeDisplayFormat
+            ? (getSizeForFormat(this.activeDisplayFormat) ?? getDefaultSize())
+            : getDefaultSize();
+
+        const newStartCol = Math.max(1, Math.floor((defaultSize.cols - windowInfo.numCols) / 2) + 1);
+        if (newStartCol === windowInfo.startCol) {
+            return;
+        };
+
+        await this.rewriteWindowKeyword(windowInfo.lineIndex, windowInfo.startRow, newStartCol, windowInfo.numRows, windowInfo.numCols);
     };
 
     /**
@@ -980,30 +1293,62 @@ export class RecordPreviewPanel {
         color: #00ff00;
         font-family: var(--vscode-editor-font-family, monospace);
     }
+    #toolbarRow {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        column-gap: 16px;
+        row-gap: 4px;
+        margin-bottom: 6px;
+        font-size: 12px;
+    }
     #info {
-        margin-bottom: 6px;
         opacity: 0.7;
-        font-size: 12px;
     }
-    #toolbar {
+    #formatBar, #toolbar {
         display: none;
-        margin-bottom: 6px;
-        font-size: 12px;
+        align-items: center;
+        gap: 4px;
     }
-    #toolbar select {
+    #formatBar select, #toolbar select {
         background: #000000;
         color: #00ff00;
         border: 1px solid #333333;
         font-family: inherit;
     }
+    #formatBar select:disabled {
+        color: #666666;
+        border-color: #222222;
+        cursor: default;
+    }
+    #actionBar {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+    #actionBar button {
+        background: #000000;
+        color: #00ff00;
+        border: 1px solid #333333;
+        font-family: inherit;
+        font-size: 12px;
+        padding: 2px 6px;
+        cursor: pointer;
+    }
+    #actionBar button.active {
+        background: #00ff00;
+        color: #000000;
+        border-color: #00ff00;
+    }
     #indicatorBar {
         display: none;
-        margin-bottom: 6px;
-        font-size: 12px;
+        align-items: center;
+        gap: 4px;
+        cursor: pointer;
     }
     #indicatorList {
         display: none;
-        margin-top: 4px;
+        margin-bottom: 6px;
     }
     .indicator-btn {
         display: inline-block;
@@ -1031,31 +1376,44 @@ export class RecordPreviewPanel {
 </style>
 </head>
 <body>
-<div id="info">Loading...</div>
-<div id="toolbar">
-    <label for="overlaySelect">Overlay on: </label>
-    <select id="overlaySelect"></select>
+<div id="toolbarRow">
+    <span id="info">Loading...</span>
+    <span id="formatBar">
+        <label for="formatSelect">Format: </label>
+        <select id="formatSelect"></select>
+    </span>
+    <span id="toolbar">
+        <label for="overlaySelect">Overlay: </label>
+        <select id="overlaySelect"></select>
+    </span>
+    <label id="indicatorBar"><input type="checkbox" id="indicatorsToggle"> Indicators</label>
+    <span id="actionBar">
+        <button id="addFieldBtn" title="Click, then click a point in the screen to place a new field there">+ Field</button>
+        <button id="addConstantBtn" title="Click, then click a point in the screen to place a new constant there">+ Constant</button>
+    </span>
 </div>
-<div id="indicatorBar">
-    <label><input type="checkbox" id="indicatorsToggle"> Use indicators</label>
-    <div id="indicatorList"></div>
-</div>
+<div id="indicatorList"></div>
 <canvas id="screen"></canvas>
 <script>
     const vscode = acquireVsCodeApi();
     const canvas = document.getElementById('screen');
     const ctx = canvas.getContext('2d');
     const info = document.getElementById('info');
+    const formatBar = document.getElementById('formatBar');
+    const formatSelect = document.getElementById('formatSelect');
     const toolbar = document.getElementById('toolbar');
     const overlaySelect = document.getElementById('overlaySelect');
     const indicatorBar = document.getElementById('indicatorBar');
     const indicatorsToggle = document.getElementById('indicatorsToggle');
     const indicatorList = document.getElementById('indicatorList');
+    const addConstantBtn = document.getElementById('addConstantBtn');
+    const addFieldBtn = document.getElementById('addFieldBtn');
 
     const CHAR_W = 9;
     const CHAR_H = 18;
     const BLINK_INTERVAL_MS = 600;
     const HANDLE_SIZE = 8;
+    const MENU_ICON_SIZE = 16;
     // Mirrors WINDOW_BORDER_* on the host: content sits 1 row/col inside the border, except on
     // the right, where it's 2 (verified against a real window's on-screen footprint).
     const WINDOW_BORDER_TOP = 1;
@@ -1069,13 +1427,19 @@ export class RecordPreviewPanel {
     let currentWindowFrame = null;
     let currentOuterFrame = null;
     let currentWindowTitle = null;
+    let currentTitleRect = null;
+    let currentMenuIconRect = null;
+    let currentCenterIconRect = null;
+    let windowHovered = false;
     let maxSize = null;
+    let minDetailRow = null;
     let blinkOn = true;
     let dragState = null;
     let resizeState = null;
     let moveWindowState = null;
     let selectedLineIndex = null;
     let currentRecordName = null;
+    let placingKind = null; // null | 'constant' | 'field'
 
     function clamp(value, min, max) {
         return Math.min(Math.max(value, min), max);
@@ -1214,6 +1578,8 @@ export class RecordPreviewPanel {
             ctx.fillRect(hx - HANDLE_SIZE, hy - HANDLE_SIZE, HANDLE_SIZE, HANDLE_SIZE);
         }
 
+        currentTitleRect = null;
+
         if (currentOuterFrame && currentWindowTitle) {
             const fx = (currentOuterFrame.col - 1) * CHAR_W;
             const fy = (currentOuterFrame.row - 1) * CHAR_H;
@@ -1239,6 +1605,38 @@ export class RecordPreviewPanel {
             ctx.fillRect(textX, titleY, textWidth, CHAR_H);
             ctx.fillStyle = '#ffffff';
             ctx.fillText(text, textX, titleY + CHAR_H / 2);
+
+            currentTitleRect = { x: textX, y: titleY, width: textWidth, height: CHAR_H };
+        }
+
+        currentMenuIconRect = null;
+        currentCenterIconRect = null;
+        if (currentOuterFrame && windowHovered) {
+            const drawIconButton = (x, y, glyph, title) => {
+                ctx.fillStyle = '#dddddd';
+                ctx.fillRect(x, y, MENU_ICON_SIZE, MENU_ICON_SIZE);
+                ctx.strokeStyle = '#666666';
+                ctx.strokeRect(x + 0.5, y + 0.5, MENU_ICON_SIZE - 1, MENU_ICON_SIZE - 1);
+
+                ctx.fillStyle = '#000000';
+                ctx.font = (MENU_ICON_SIZE - 2) + 'px ' + fontFamily;
+                const glyphWidth = ctx.measureText(glyph).width;
+                ctx.fillText(glyph, x + (MENU_ICON_SIZE - glyphWidth) / 2, y + MENU_ICON_SIZE / 2);
+
+                return { x, y, width: MENU_ICON_SIZE, height: MENU_ICON_SIZE };
+            };
+
+            // "Window actions" button in the frame's top-right corner: always available (even
+            // before a title exists), and where future menu-based actions can be added.
+            const menuX = (currentOuterFrame.col - 1 + currentOuterFrame.cols) * CHAR_W - MENU_ICON_SIZE - 2;
+            const menuY = (currentOuterFrame.row - 1) * CHAR_H + (CHAR_H - MENU_ICON_SIZE) / 2;
+            currentMenuIconRect = drawIconButton(menuX, menuY, '⋮', 'Window actions');
+
+            // "Center horizontally" button, a one-click action next to it (no menu needed) — the
+            // pattern any future direct-action icon can follow.
+            const centerX = menuX - MENU_ICON_SIZE - 2;
+            const centerY = menuY;
+            currentCenterIconRect = drawIconButton(centerX, centerY, '↔', 'Center horizontally');
         }
     }
 
@@ -1291,12 +1689,99 @@ export class RecordPreviewPanel {
                col >= currentOuterFrame.col && col < currentOuterFrame.col + currentOuterFrame.cols;
     }
 
+    function isOverTitle(ev) {
+        if (!currentTitleRect) {
+            return false;
+        }
+        const rect = canvas.getBoundingClientRect();
+        const px = ev.clientX - rect.left;
+        const py = ev.clientY - rect.top;
+        return px >= currentTitleRect.x && px < currentTitleRect.x + currentTitleRect.width &&
+               py >= currentTitleRect.y && py < currentTitleRect.y + currentTitleRect.height;
+    }
+
+    function isOverMenuIcon(ev) {
+        if (!currentMenuIconRect) {
+            return false;
+        }
+        const rect = canvas.getBoundingClientRect();
+        const px = ev.clientX - rect.left;
+        const py = ev.clientY - rect.top;
+        return px >= currentMenuIconRect.x && px < currentMenuIconRect.x + currentMenuIconRect.width &&
+               py >= currentMenuIconRect.y && py < currentMenuIconRect.y + currentMenuIconRect.height;
+    }
+
+    function isOverCenterIcon(ev) {
+        if (!currentCenterIconRect) {
+            return false;
+        }
+        const rect = canvas.getBoundingClientRect();
+        const px = ev.clientX - rect.left;
+        const py = ev.clientY - rect.top;
+        return px >= currentCenterIconRect.x && px < currentCenterIconRect.x + currentCenterIconRect.width &&
+               py >= currentCenterIconRect.y && py < currentCenterIconRect.y + currentCenterIconRect.height;
+    }
+
+    // Icons only show while the mouse is over the window (frame + content); redraw only happens
+    // when this actually flips, so hovering elsewhere doesn't repaint on every mousemove pixel.
+    function updateWindowHoverState(ev) {
+        const hovering = isOverWindowFrame(ev);
+        if (hovering !== windowHovered) {
+            windowHovered = hovering;
+            draw(currentSize, currentItems, currentBackgroundItems, currentWindowFrame, currentWindowTitle, currentOuterFrame);
+        }
+    }
+
+    function setPlacingKind(kind) {
+        placingKind = kind;
+        addConstantBtn.classList.toggle('active', placingKind === 'constant');
+        addFieldBtn.classList.toggle('active', placingKind === 'field');
+        canvas.style.cursor = placingKind ? 'crosshair' : '';
+        canvas.title = placingKind ? ('Click a point in the screen to place the new ' + placingKind) : '';
+    }
+
+    addConstantBtn.addEventListener('click', () => {
+        setPlacingKind(placingKind === 'constant' ? null : 'constant');
+    });
+
+    addFieldBtn.addEventListener('click', () => {
+        setPlacingKind(placingKind === 'field' ? null : 'field');
+    });
+
+    document.addEventListener('keydown', (ev) => {
+        if (ev.key === 'Escape' && placingKind) {
+            setPlacingKind(null);
+        }
+    });
+
     canvas.addEventListener('mousedown', (ev) => {
+        if (placingKind) {
+            const { row, col } = cellAt(ev);
+            vscode.postMessage({ type: placingKind === 'field' ? 'addFieldAt' : 'addConstantAt', row, col });
+            setPlacingKind(null);
+            return;
+        }
+
         if (isOverResizeHandle(ev)) {
             resizeState = {
                 contentRows: currentOuterFrame.rows - WINDOW_BORDER_TOP - WINDOW_BORDER_BOTTOM,
                 contentCols: currentOuterFrame.cols - WINDOW_BORDER_LEFT - WINDOW_BORDER_RIGHT
             };
+            return;
+        }
+
+        if (isOverMenuIcon(ev)) {
+            vscode.postMessage({ type: 'windowMenu' });
+            return;
+        }
+
+        if (isOverCenterIcon(ev)) {
+            vscode.postMessage({ type: 'centerWindowHorizontally' });
+            return;
+        }
+
+        if (isOverTitle(ev)) {
+            vscode.postMessage({ type: 'editWindowTitle' });
             return;
         }
 
@@ -1330,7 +1815,21 @@ export class RecordPreviewPanel {
         }
     });
 
+    document.addEventListener('mouseleave', () => {
+        // The mouse left the whole webview, so no more mousemove events will arrive to notice it —
+        // hide the icons explicitly instead of leaving them stuck showing.
+        if (windowHovered) {
+            windowHovered = false;
+            draw(currentSize, currentItems, currentBackgroundItems, currentWindowFrame, currentWindowTitle, currentOuterFrame);
+        }
+    });
+
     window.addEventListener('mousemove', (ev) => {
+        if (placingKind) {
+            canvas.style.cursor = 'crosshair';
+            return;
+        }
+
         if (resizeState) {
             const { row, col } = cellAt(ev);
             const limitRows = maxSize ? maxSize.rows : currentSize.rows;
@@ -1368,10 +1867,27 @@ export class RecordPreviewPanel {
         }
 
         if (!dragState) {
+            updateWindowHoverState(ev);
+
             const overHandle = isOverResizeHandle(ev);
             if (overHandle) {
                 canvas.style.cursor = 'nwse-resize';
                 canvas.title = '';
+                return;
+            }
+            if (isOverMenuIcon(ev)) {
+                canvas.style.cursor = 'pointer';
+                canvas.title = 'Window actions';
+                return;
+            }
+            if (isOverCenterIcon(ev)) {
+                canvas.style.cursor = 'pointer';
+                canvas.title = 'Center horizontally';
+                return;
+            }
+            if (isOverTitle(ev)) {
+                canvas.style.cursor = 'pointer';
+                canvas.title = 'Click to change the window title';
                 return;
             }
             const hit = findItemAt(ev);
@@ -1393,6 +1909,11 @@ export class RecordPreviewPanel {
             // including the last column, is usable.
             minCol = currentWindowFrame.col + 1;
             maxCol = Math.max(currentWindowFrame.col + currentWindowFrame.cols - width, minCol);
+        }
+
+        // A subfile detail record's own rows can't be dragged up into its header's static content.
+        if (minDetailRow !== null && !dragState.item.isBackground) {
+            minRow = Math.max(minRow, minDetailRow);
         }
 
         const newRow = clamp(row - dragState.grabRowOffset, minRow, maxRow);
@@ -1446,6 +1967,23 @@ export class RecordPreviewPanel {
         draw(currentSize, currentItems, currentBackgroundItems, currentWindowFrame, currentWindowTitle, currentOuterFrame);
     });
 
+    formatSelect.addEventListener('change', () => {
+        vscode.postMessage({ type: 'setDisplayFormat', name: formatSelect.value || null });
+    });
+
+    function rebuildFormatOptions(availableFormats, selectedValue) {
+        formatSelect.innerHTML = '';
+
+        for (const format of availableFormats) {
+            const opt = document.createElement('option');
+            opt.value = format.name;
+            opt.textContent = format.name + ' (' + format.rows + 'x' + format.cols + ')';
+            formatSelect.appendChild(opt);
+        }
+
+        formatSelect.value = selectedValue;
+    }
+
     overlaySelect.addEventListener('change', () => {
         vscode.postMessage({ type: 'setOverlay', recordName: overlaySelect.value || null });
     });
@@ -1496,14 +2034,23 @@ export class RecordPreviewPanel {
             }
 
             maxSize = message.maxSize || null;
+            minDetailRow = typeof message.minDetailRow === 'number' ? message.minDetailRow : null;
+            const availableFormats = message.availableFormats || [];
+            formatBar.style.display = availableFormats.length > 0 ? 'inline-flex' : 'none';
+            if (availableFormats.length > 0) {
+                rebuildFormatOptions(availableFormats, message.activeDisplayFormat || '');
+                // Locked (disabled) when the file only declares one display format — nothing to switch to.
+                formatSelect.disabled = availableFormats.length <= 1;
+            }
+
             const hasOverlayOptions = message.availableRecords && message.availableRecords.length > 0;
-            toolbar.style.display = hasOverlayOptions ? 'block' : 'none';
+            toolbar.style.display = hasOverlayOptions ? 'inline-flex' : 'none';
             if (hasOverlayOptions) {
                 rebuildOverlayOptions(message.availableRecords, message.overlayRecordName || '');
             }
 
             const hasIndicators = message.availableIndicators && message.availableIndicators.length > 0;
-            indicatorBar.style.display = hasIndicators ? 'block' : 'none';
+            indicatorBar.style.display = hasIndicators ? 'inline-flex' : 'none';
             if (hasIndicators) {
                 indicatorsToggle.checked = Boolean(message.indicatorsEnabled);
                 indicatorList.style.display = message.indicatorsEnabled ? 'block' : 'none';


### PR DESCRIPTION
## [0.13.0] - 2026-07-23
### Added
- New "Preview Screen Layout" option: shows a green-screen-style visual preview of a record on a canvas. Also available as an inline button on record tree items, in addition to the context-menu option.
  - Supports COLOR() and DSPATR() keywords (HI, RI, BL, UL, CS, ND); input-capable fields are shown underlined.
  - Fields/constants can be dragged to reposition them, writing the new position back into the source.
  - "+ Field" / "+ Constant" buttons: click, then click a point on the screen to place a new field/constant there, reusing the same name/type/position prompts as the tree's "Add field"/"Add constant" commands. Validated against the record's own area (a window's content frame, or the SFL detail area below its header).
  - WINDOW records are drawn at their real screen position and can be resized/moved with the mouse; WDWTITLE is shown. Windows shared via WINDOW(record-name) are supported.
  - Clicking a window's title edits it directly; a "⋮" actions menu and a one-click "center horizontally" icon are also available on the window frame — all three only appear while hovering over the window.
  - Subfile (SFL/SFLCTL) records show all SFLPAG rows, and automatically preview their paired header/detail record; the detail rows can't be dragged up over the header's own content.
  - Any other record can be overlaid (dimmed) behind the one being previewed, to see how they compose.
  - Indicator simulation: toggle indicators on/off to preview conditional fields, constants, and attributes.
  - Display format switcher: for DSPF files declaring more than one DSPSIZ format (e.g. *DS3/*DS4), lets you switch between them — window positions/sizes, SFLSIZ/SFLPAG, and conditioned fields/constants/attributes are resolved for whichever format is active. Locked when the file only declares one format.
  - The preview stays in sync with the schema tree selection in both directions.
  - The toolbar (size, display format, overlay, indicators, add buttons) is laid out as a single, compact row.
- New "Change Window Title" command (record context menu) to add, edit, or remove a window's WDWTITLE(), with horizontal alignment (*LEFT/*CENTER/*RIGHT) and vertical position (*TOP/*BOTTOM); also editable directly from the preview.
### Fixed
- Moving a field or constant left/right in a subfile (buttons in the schema view) wrote the new position into the wrong source columns.
- The "Add buttons" command placed buttons in column 1 for window records instead of column 2 (column 1 isn't usable inside a window).
- A line conditioned by a display format name (e.g. "*DS3") instead of indicators was misread as garbage indicator data.
- Without indicator simulation, mutually-exclusive fields/constants/attributes conditioned by complementary indicators (e.g. one on "61", the other on "N61") could show at once instead of resolving to a single, deterministic state.
- Switching between two open DSPF files could leak one file's second DSPSIZ format size into the other's display-format selector.
- The record filter could silently hide a newly-added record with no obvious cause; it's now disabled (with a warning message) whenever a new record appears while the filter is active.
- The record filter could reset unpredictably back to "show all" whenever any record became invalid (e.g. renamed/removed), instead of just pruning the stale entry.
- "Hide all" in the record filter menu didn't actually hide records, only fields/constants.
