### PR TITLE
feat: add "Add Commands Record" command and enhance SFLCTL handling in preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
+## [0.13.2] - 2026-07-25
+### Added
+- New "Add Commands Record" command (record context menu, shown only on subfile control (SFLCTL) records): creates a record right after the subfile for its function-key legend (e.g. "F3=Exit"). For window subfiles, moves the SFLCTL's own `WINDOW()` (and `WDWTITLE()`/`WDWBORDER()`) onto the new record and leaves a `WINDOW(record)` reference behind, so the legend shares the subfile's window.
+- New "Page rows" +/- control in the preview toolbar for SFLCTL records: adjusts `SFLPAG()`, always keeping `SFLSIZ()` one more than `SFLPAG()`.
+### Fixed
+- An SFL/SFLCTL pair sharing a window (the SFLCTL declaring `WINDOW()` directly) could hide the other half's content behind the window's own opaque background in the preview.
+- Dragging a window in the preview left the paired SFL/SFLCTL record's dimmed content static until the mouse was released, instead of moving live with the window.
+
 ## [0.13.1] - 2026-07-24
 ### Added
 - New "Grid Dots" toggle in the preview toolbar: marks every empty character cell with a dot, to see spacing between fields/constants (and around a window's border) while designing a screen.

--- a/README.md
+++ b/README.md
@@ -118,22 +118,11 @@ Some features may not work as expected. Please leave an issue if something is no
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**0.13.1** - 2026-07-24
-- Added: New "Grid Dots" toggle in the preview toolbar — marks every empty character cell with a dot, to see spacing between fields/constants (and around a window's border) while designing a screen.
-- Added: Indicator simulation now resolves `ERRMSG()` — when its conditioning indicator is on, the message shows on the display's message line (in white), and the field it's attached to is shown in reverse image.
-- Fixed: A `WINDOW()` keyword followed by an optional parameter (e.g. `*NOMSGLIN`, `*RESTORE`, `*PRINT`) was not recognized, so the window wasn't rendered in the preview; moving/resizing a window with such a parameter, or editing its title, no longer strips it.
-
-**0.13.0** - 2026-07-23
-- Added: New "Preview Screen Layout" option — visual, green-screen-style preview of a record, with drag-to-move, window/subfile support, record overlay, indicator simulation, and a display format (*DS3/*DS4) switcher.
-- Added: "+ Field" / "+ Constant" buttons in the preview to create new elements by clicking a point on the screen.
-- Added: New "Change Window Title" command (also editable directly from the preview), plus a window actions menu and a one-click "center horizontally" icon, shown only while hovering over the window.
-- Added: Inline "Preview Screen Layout" button on record tree items.
-- Fixed: Moving a field or constant left/right in a subfile wrote the new position into the wrong source columns.
-- Fixed: The "Add buttons" command used the wrong starting column in window records.
-- Fixed: A line conditioned by a display format name was misread as garbage indicator data.
-- Fixed: Mutually-exclusive fields/constants conditioned by complementary indicators could show at once without indicator simulation enabled.
-- Fixed: Switching between two open DSPF files could leak a stale display-format size into the other file's selector.
-- Fixed: The record filter could silently hide a newly-added record, or reset unpredictably when a record was renamed/removed.
+**0.13.2** - 2026-07-25
+- Added: New "Add Commands Record" command (record context menu, shown only on subfile control (SFLCTL) records) — creates a record right after the subfile for its function-key legend (e.g. "F3=Exit"). For window subfiles, moves the SFLCTL's own `WINDOW()` (and `WDWTITLE()`/`WDWBORDER()`) onto the new record and leaves a `WINDOW(record)` reference behind, so the legend shares the subfile's window.
+- Added: New "Page rows" +/- control in the preview toolbar for SFLCTL records — adjusts `SFLPAG()`, always keeping `SFLSIZ()` one more than `SFLPAG()`.
+- Fixed: An SFL/SFLCTL pair sharing a window (the SFLCTL declaring `WINDOW()` directly) could hide the other half's content behind the window's own opaque background in the preview.
+- Fixed: Dragging a window in the preview left the paired SFL/SFLCTL record's dimmed content static until the mouse was released, instead of moving live with the window.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"
@@ -104,6 +104,10 @@
       {
         "command": "dspf-edit.add-buttons",
         "title": "Add Buttons"
+      },
+      {
+        "command": "dspf-edit.add-commands-record",
+        "title": "Add Commands Record"
       },
       {
         "command": "dspf-edit.add-constant",
@@ -308,42 +312,47 @@
         },
         {
           "command": "dspf-edit.window-resize",
-          "when": "view == dspf-edit.schema-view && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\brecord\\b/",
           "group": "records_navigation1@1"
         },
         {
           "command": "dspf-edit.rename-record",
-          "when": "view == dspf-edit.schema-view && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\brecord\\b/",
           "group": "records_navigation1@2"
         },
         {
           "command": "dspf-edit.copy-record",
-          "when": "view == dspf-edit.schema-view && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\brecord\\b/",
           "group": "records_navigation1@3"
         },
         {
           "command": "dspf-edit.delete-record",
-          "when": "view == dspf-edit.schema-view && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\brecord\\b/",
           "group": "records_navigation1@4"
         },
         {
           "command": "dspf-edit.window-title",
-          "when": "view == dspf-edit.schema-view && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\brecord\\b/",
           "group": "records_navigation1@5"
         },
         {
           "command": "dspf-edit.add-buttons",
-          "when": "view == dspf-edit.schema-view && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\brecord\\b/",
           "group": "records_navigation2@1"
         },
         {
+          "command": "dspf-edit.add-commands-record",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\bsflctl\\b/",
+          "group": "records_navigation2@2"
+        },
+        {
           "command": "dspf-edit.add-key",
-          "when": "view == dspf-edit.schema-view && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\brecord\\b/",
           "group": "records_navigation3@1"
         },
         {
           "command": "dspf-edit.sort-elements",
-          "when": "view == dspf-edit.schema-view && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\brecord\\b/",
           "group": "records_navigation4@1"
         },
         {
@@ -353,17 +362,17 @@
         },
         {
           "command": "dspf-edit.preview-record",
-          "when": "view == dspf-edit.schema-view && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\brecord\\b/",
           "group": "records_navigation5@1"
         },
         {
           "command": "dspf-edit.add-constant",
-          "when": "view == dspf-edit.schema-view && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\brecord\\b/",
           "group": "records_navigation0@1"
         },
         {
           "command": "dspf-edit.add-field",
-          "when": "view == dspf-edit.schema-view && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\brecord\\b/",
           "group": "records_navigation0@2"
         },
         {
@@ -413,12 +422,12 @@
         },
         {
           "command" : "dspf-edit.rename-record",
-          "when" : "view == dspf-edit.schema-view && viewItem == record",
+          "when" : "view == dspf-edit.schema-view && viewItem =~ /\\brecord\\b/",
           "group" : "inline@99"
         },
         {
           "command": "dspf-edit.preview-record",
-          "when": "view == dspf-edit.schema-view && viewItem == record",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\brecord\\b/",
           "group": "inline@1"
         },
         {

--- a/src/dspf-edit.commands/dspf-edit.add-commands-record.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-commands-record.ts
@@ -1,0 +1,176 @@
+/*
+    Christian Larsen, 2026
+    "RPG structure"
+    dspf-edit.add-commands-record.ts
+*/
+
+import * as vscode from 'vscode';
+import { DdsNode } from './../dspf-edit.providers/dspf-edit.providers';
+import { DdsAttribute, fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
+import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
+import { validateRecordName } from './dspf-edit.new-record';
+import { findRecordInsertionPoint } from './dspf-edit.add-buttons';
+
+// COMMAND REGISTRATION
+
+/**
+ * Registers the "Add Commands Record" command: given a subfile control (SFLCTL) record, creates a
+ * new, empty record right after it meant to hold the subfile's function-key legend (e.g.
+ * "F3=Exit", "F12=Cancel"), which is conventionally kept on a separate record from the SFLCTL
+ * itself.
+ *
+ * When the SFLCTL declares its own WINDOW(startRow startCol rows cols) directly, that window (and
+ * any WDWTITLE()/WDWBORDER() that go with it — both only take effect on whichever record actually
+ * owns the window) is moved onto the new record instead (one set per display format, if
+ * conditioned by more than one), and the SFLCTL is left with a WINDOW(newRecordName) reference —
+ * the same "commands record owns the shared window, SFLCTL borrows it" pattern real-world DDS
+ * commonly uses, since the legend text then lives in the same window as the subfile it describes.
+ * @param context - The VS Code extension context
+ */
+export function addCommandsRecord(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand("dspf-edit.add-commands-record", async (node: DdsNode) => {
+            await handleAddCommandsRecordCommand(node);
+        })
+    );
+};
+
+// COMMAND HANDLER
+
+/**
+ * Handles the "Add Commands Record" command for a subfile control (SFLCTL) record.
+ * @param node - The DDS node the command was invoked from
+ */
+async function handleAddCommandsRecordCommand(node: DdsNode): Promise<void> {
+    const { editor, document } = checkForEditorAndDocument();
+    if (!document || !editor) {
+        return;
+    };
+
+    if (node.ddsElement.kind !== 'record') {
+        vscode.window.showWarningMessage('A commands record can only be added from a record.');
+        return;
+    };
+    const sflCtlRecordName = node.ddsElement.name;
+
+    const recordInfo = fieldsPerRecords.find(r => r.record === sflCtlRecordName);
+    const isSflCtl = recordInfo?.attributes?.some(attr => attr.value.toUpperCase().startsWith('SFLCTL(')) ?? false;
+    if (!isSflCtl) {
+        vscode.window.showWarningMessage('A commands record can only be added from a subfile control (SFLCTL) record.');
+        return;
+    };
+
+    // A reference-form WINDOW(otherRecordName) means this subfile's window is already owned by
+    // another record — nothing to move, and creating a second commands record wouldn't have a
+    // window to draw in. Only a direct, numeric WINDOW() can be moved onto the new record.
+    const windowAttrs = recordInfo?.attributes?.filter(attr => attr.value.toUpperCase().startsWith('WINDOW(')) ?? [];
+    const numericWindowAttrs = windowAttrs.filter(attr => /^WINDOW\(\s*\d+\s+\d+\s+\d+\s+\d+(?:\s+[^)]*)?\s*\)$/i.test(attr.value));
+    if (windowAttrs.length > 0 && numericWindowAttrs.length === 0) {
+        vscode.window.showWarningMessage(`This subfile's window is already owned by another record (${windowAttrs[0].value}).`);
+        return;
+    };
+
+    // WDWTITLE()/WDWBORDER() only have any effect on the record that owns the real window, so they
+    // move along with it — left behind on the SFLCTL they'd just be dead keywords once it's turned
+    // into a reference.
+    const titleAttrs = numericWindowAttrs.length > 0
+        ? (recordInfo?.attributes?.filter(attr => attr.value.toUpperCase().startsWith('WDWTITLE(')) ?? [])
+        : [];
+    const borderAttrs = numericWindowAttrs.length > 0
+        ? (recordInfo?.attributes?.filter(attr => attr.value.toUpperCase().startsWith('WDWBORDER(')) ?? [])
+        : [];
+
+    const recordName = await vscode.window.showInputBox({
+        title: 'Add Commands Record',
+        prompt: 'Enter the name for the new commands record',
+        placeHolder: 'FOOTER',
+        validateInput: validateRecordName
+    });
+    if (!recordName) {
+        return;
+    };
+    const newRecordName = recordName.toUpperCase();
+
+    const insertionLine = findRecordInsertionPoint(sflCtlRecordName);
+    if (insertionLine === null) {
+        vscode.window.showErrorMessage('Could not determine where to insert the new record.');
+        return;
+    };
+
+    await insertCommandsRecord(document, insertionLine, newRecordName, numericWindowAttrs, titleAttrs, borderAttrs);
+
+    await vscode.commands.executeCommand('cursorRight');
+    await vscode.commands.executeCommand('cursorLeft');
+
+    vscode.window.showInformationMessage(`Commands record '${newRecordName}' added. Use "Add Constant" on it to add the function-key texts.`);
+};
+
+/**
+ * All source lines an attribute spans, verbatim — more than one when it was written across
+ * continuation lines (e.g. a wrapped WDWTITLE()/WDWBORDER()).
+ * @param document - The DDS source document
+ * @param attr - The attribute to read
+ */
+function fullAttributeLines(document: vscode.TextDocument, attr: DdsAttribute): string[] {
+    const lastLine = attr.lastLineIndex ?? attr.lineIndex;
+    const lines: string[] = [];
+    for (let i = attr.lineIndex; i <= lastLine; i++) {
+        lines.push(document.lineAt(i).text);
+    };
+    return lines;
+};
+
+/**
+ * Inserts the new commands record right after the SFLCTL record it documents (whether or not
+ * that's the end of the document), carrying over the SFLCTL's own WINDOW()/WDWTITLE()/WDWBORDER()
+ * lines verbatim (one set per display format, if more than one) — and, in the same edit, rewrites
+ * the WINDOW() lines on the SFLCTL into a WINDOW(newRecordName) reference and removes its
+ * WDWTITLE()/WDWBORDER() lines entirely (they moved with the window).
+ * @param document - The DDS source document
+ * @param insertionLine - Line index to insert the new record at
+ * @param recordName - Name of the new record
+ * @param windowAttrsToMove - The SFLCTL's own numeric WINDOW() attributes, if any, to move over
+ * @param titleAttrsToMove - The SFLCTL's own WDWTITLE() attributes, if any, to move over
+ * @param borderAttrsToMove - The SFLCTL's own WDWBORDER() attributes, if any, to move over
+ */
+async function insertCommandsRecord(
+    document: vscode.TextDocument,
+    insertionLine: number,
+    recordName: string,
+    windowAttrsToMove: DdsAttribute[],
+    titleAttrsToMove: DdsAttribute[],
+    borderAttrsToMove: DdsAttribute[]
+): Promise<void> {
+    const bodyLines = [
+        ' '.repeat(5) + 'A' + ' '.repeat(10) + 'R ' + recordName.padEnd(10, ' '),
+        ' '.repeat(5) + 'A' + ' '.repeat(38) + 'OVERLAY',
+        ...windowAttrsToMove.flatMap(attr => fullAttributeLines(document, attr)),
+        ...titleAttrsToMove.flatMap(attr => fullAttributeLines(document, attr)),
+        ...borderAttrsToMove.flatMap(attr => fullAttributeLines(document, attr))
+    ];
+
+    const workspaceEdit = new vscode.WorkspaceEdit();
+    const insertPos = new vscode.Position(insertionLine, 0);
+
+    if (insertPos.line >= document.lineCount) {
+        workspaceEdit.insert(document.uri, insertPos, '\n' + bodyLines.join('\n'));
+    } else {
+        workspaceEdit.insert(document.uri, insertPos, bodyLines.join('\n') + '\n');
+    };
+
+    for (const attr of windowAttrsToMove) {
+        const line = document.lineAt(attr.lineIndex);
+        const updatedLine = line.text.replace(
+            /WINDOW\(\s*\d+\s+\d+\s+\d+\s+\d+(?:\s+[^)]*)?\s*\)/i,
+            `WINDOW(${recordName})`
+        );
+        workspaceEdit.replace(document.uri, line.range, updatedLine);
+    };
+
+    for (const attr of [...titleAttrsToMove, ...borderAttrsToMove]) {
+        const lastLine = attr.lastLineIndex ?? attr.lineIndex;
+        workspaceEdit.delete(document.uri, new vscode.Range(attr.lineIndex, 0, lastLine + 1, 0));
+    };
+
+    await vscode.workspace.applyEdit(workspaceEdit);
+};

--- a/src/dspf-edit.commands/dspf-edit.new-record.ts
+++ b/src/dspf-edit.commands/dspf-edit.new-record.ts
@@ -201,7 +201,7 @@ async function collectRecordName(): Promise<string | null> {
  * @param value - The record name to validate
  * @returns Error message or null if valid
  */
-function validateRecordName(value: string): string | null {
+export function validateRecordName(value: string): string | null {
     if (!value || value.trim() === '') {
         return "The record name cannot be empty.";
     };

--- a/src/dspf-edit.commands/register-commands.ts
+++ b/src/dspf-edit.commands/register-commands.ts
@@ -17,6 +17,7 @@ import { deleteRecord } from './dspf-edit.delete-record';
 import { newRecord } from './dspf-edit.new-record';
 import { goToLineHandler } from './dspf-edit.goto-line';
 import { addButtons } from './dspf-edit.add-buttons';
+import { addCommandsRecord } from './dspf-edit.add-commands-record';
 import { addColor } from './dspf-edit.add-color';
 import { addAttribute } from './dspf-edit.add-attribute';
 import { addKeyCommand } from './dspf-edit.add-keys';
@@ -50,6 +51,7 @@ export const commands = [
     { name: 'newRecord', handler: newRecord, needsTreeProvider: false },
     { name: 'goToLine', handler: goToLineHandler, needsTreeProvider: false },
     { name: 'addButtons', handler: addButtons, needsTreeProvider: false },
+    { name: 'addCommandsRecord', handler: addCommandsRecord, needsTreeProvider: false },
     { name: 'addColor', handler: addColor, needsTreeProvider: false },
     { name: 'addAttribute', handler: addAttribute, needsTreeProvider: false },
     { name: 'addKey', handler: addKeyCommand, needsTreeProvider: false },

--- a/src/dspf-edit.parser/dspf-edit.parser.ts
+++ b/src/dspf-edit.parser/dspf-edit.parser.ts
@@ -947,7 +947,7 @@ function propagateSubfileWindowSizes(recordElements: DdsRecord[], sizeByRecord: 
 
         const pairSize = pairName ? sizeByRecord.get(pairName) : undefined;
         if (pairSize) {
-            sizeByRecord.set(record.name, pairSize);
+            sizeByRecord.set(record.name, { ...pairSize, sharedFromRecord: pairSize.sharedFromRecord ?? pairName });
         };
     };
 };

--- a/src/dspf-edit.providers/dspf-edit.providers.ts
+++ b/src/dspf-edit.providers/dspf-edit.providers.ts
@@ -721,6 +721,11 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 	}
 }
 
+/** Whether a tree element is a record carrying an SFLCTL() keyword (a subfile control record). */
+function isSflCtlElement(ddsElement: DdsElement): boolean {
+	return ddsElement.kind === 'record' && (ddsElement.attributes?.some(attr => attr.value.toUpperCase().startsWith('SFLCTL(')) ?? false);
+};
+
 /**
  * DDS NODE CLASS
  * Represents each node in the TreeView. Configures label, tooltip, description,
@@ -731,7 +736,9 @@ export class DdsNode extends vscode.TreeItem {
 		super(label, collapsibleState);
 		this.tooltip = this.getTooltip(ddsElement);
 		this.description = this.getDescription(ddsElement);
-		this.contextValue = label.includes('📂 Records') ? 'group:records' : ddsElement.kind;
+		this.contextValue = label.includes('📂 Records')
+			? 'group:records'
+			: isSflCtlElement(ddsElement) ? 'record sflctl' : ddsElement.kind;
 
 		if (this.shouldHaveNavigationCommand(ddsElement)) {
 			this.command = { command: 'ddsEdit.goToLine', title: `Go to ${ddsElement.kind}`, arguments: [ddsElement.lineIndex + 1] };

--- a/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
@@ -5,7 +5,7 @@
 */
 
 import * as vscode from 'vscode';
-import { FieldsPerRecord, DdsSize, AttributeWithIndicators, DdsIndicator, fieldsPerRecords, records, getDefaultSize, getAvailableDisplayFormats, getSizeForFormat } from '../dspf-edit.model/dspf-edit.model';
+import { FieldsPerRecord, DdsSize, DdsAttribute, AttributeWithIndicators, DdsIndicator, fieldsPerRecords, records, getDefaultSize, getAvailableDisplayFormats, getSizeForFormat } from '../dspf-edit.model/dspf-edit.model';
 import { checkForEditorAndDocument, updateTreeProvider } from '../dspf-edit.utils/dspf-edit.helper';
 import { DdsTreeProvider } from '../dspf-edit.providers/dspf-edit.providers';
 import { resolveRecordSizeForFormat } from '../dspf-edit.parser/dspf-edit.parser';
@@ -221,6 +221,11 @@ function isSflRecordInfo(recordInfo: FieldsPerRecord): boolean {
     return recordInfo.attributes?.some(attr => attr.value === 'SFL') ?? false;
 };
 
+/** Whether a record's attributes include an SFLCTL() keyword (i.e. it's a subfile control record). */
+function isSflCtlRecordInfo(recordInfo: FieldsPerRecord): boolean {
+    return recordInfo.attributes?.some(attr => attr.value.toUpperCase().startsWith('SFLCTL(')) ?? false;
+};
+
 /**
  * Finds the control record for a subfile (SFL) record, i.e. the one carrying SFLCTL(sflRecordName).
  * @param sflRecordName - Name of the subfile (SFL) record
@@ -232,6 +237,17 @@ function findSflControlRecord(sflRecordName: string): FieldsPerRecord | undefine
             return Boolean(match && match[1].toUpperCase() === sflRecordName.toUpperCase());
         })
     );
+};
+
+/**
+ * Finds an SFLCTL record's own SFLPAG() attribute (the candidate matching activeFormat, when
+ * conditioned by more than one display format).
+ * @param recordInfo - The SFLCTL record
+ * @param activeFormat - Currently selected display format name (e.g. "*DS3"), or undefined
+ */
+function findOwnSflPagAttribute(recordInfo: FieldsPerRecord, activeFormat?: string): DdsAttribute | undefined {
+    const candidates = recordInfo.attributes?.filter(a => a.value.toUpperCase().startsWith('SFLPAG(')) ?? [];
+    return pickForActiveFormat(candidates, activeFormat);
 };
 
 /**
@@ -248,8 +264,7 @@ function findSubfilePageSize(sflRecordName: string, activeFormat?: string): numb
         return undefined;
     };
 
-    const candidates = controlRecord.attributes?.filter(a => a.value.toUpperCase().startsWith('SFLPAG(')) ?? [];
-    const pagAttr = pickForActiveFormat(candidates, activeFormat);
+    const pagAttr = findOwnSflPagAttribute(controlRecord, activeFormat);
     const match = pagAttr?.value.match(/SFLPAG\(\s*(\d+)\s*\)/i);
     return match ? parseInt(match[1], 10) : undefined;
 };
@@ -615,6 +630,9 @@ export class RecordPreviewPanel {
         const availableRecords = records.filter(name => name !== this.recordName);
         const windowTitle = isWindow ? (findWindowTitle(this.recordName, this.activeDisplayFormat) ?? null) : null;
         const errorMessage = this.resolveErrorMessage(recordInfo);
+        const sflPagAttr = isSflCtlRecordInfo(recordInfo) ? findOwnSflPagAttribute(recordInfo, this.activeDisplayFormat) : undefined;
+        const sflPagMatch = sflPagAttr?.value.match(/SFLPAG\(\s*(\d+)\s*\)/i);
+        const sflPag = sflPagMatch ? parseInt(sflPagMatch[1], 10) : null;
 
         this.panel.webview.postMessage({
             type: 'render',
@@ -625,6 +643,7 @@ export class RecordPreviewPanel {
             outerFrame,
             windowTitle,
             errorMessage,
+            sflPag,
             maxSize,
             availableRecords,
             overlayRecordName: this.overlayRecordName ?? null,
@@ -1021,6 +1040,16 @@ export class RecordPreviewPanel {
                 this.activeIndicators.add(message.number);
             };
             this.render();
+            return;
+        };
+
+        if (message?.type === 'sflpagIncrement') {
+            await this.adjustSubfilePageSize(1);
+            return;
+        };
+
+        if (message?.type === 'sflpagDecrement') {
+            await this.adjustSubfilePageSize(-1);
         };
     };
 
@@ -1310,6 +1339,59 @@ export class RecordPreviewPanel {
     };
 
     /**
+     * Increments or decrements an SFLCTL record's SFLPAG() (number of subfile rows shown at once),
+     * always keeping SFLSIZ() one more than SFLPAG — the common convention that gives the subfile
+     * one row of headroom past what's visible. Both are 4-digit zero-padded numeric literals.
+     */
+    private async adjustSubfilePageSize(delta: number): Promise<void> {
+        const { editor } = checkForEditorAndDocument();
+        if (!editor) {
+            return;
+        };
+
+        const recordInfo = fieldsPerRecords.find(r => r.record === this.recordName);
+        if (!recordInfo || !isSflCtlRecordInfo(recordInfo)) {
+            return;
+        };
+
+        const pagAttr = findOwnSflPagAttribute(recordInfo, this.activeDisplayFormat);
+        const pagMatch = pagAttr?.value.match(/SFLPAG\(\s*(\d+)\s*\)/i);
+        if (!pagAttr || !pagMatch) {
+            return;
+        };
+
+        const currentPag = parseInt(pagMatch[1], 10);
+        const newPag = Math.min(Math.max(currentPag + delta, 1), 9998);
+        if (newPag === currentPag) {
+            return;
+        };
+        const newSiz = newPag + 1;
+
+        const workspaceEdit = new vscode.WorkspaceEdit();
+
+        const pagLine = editor.document.lineAt(pagAttr.lineIndex);
+        workspaceEdit.replace(
+            editor.document.uri,
+            pagLine.range,
+            pagLine.text.replace(/SFLPAG\(\s*\d+\s*\)/i, `SFLPAG(${String(newPag).padStart(4, '0')})`)
+        );
+
+        const sizCandidates = recordInfo.attributes?.filter(a => a.value.toUpperCase().startsWith('SFLSIZ(')) ?? [];
+        const sizAttr = pickForActiveFormat(sizCandidates, this.activeDisplayFormat);
+        if (sizAttr) {
+            const sizLine = editor.document.lineAt(sizAttr.lineIndex);
+            workspaceEdit.replace(
+                editor.document.uri,
+                sizLine.range,
+                sizLine.text.replace(/SFLSIZ\(\s*\d+\s*\)/i, `SFLSIZ(${String(newSiz).padStart(4, '0')})`)
+            );
+        };
+
+        await vscode.workspace.applyEdit(workspaceEdit);
+        this.forceReparse(editor.document);
+    };
+
+    /**
      * The webview holds focus during drag/resize, so the normal onDidChangeTextDocument listener
      * (which only reacts when the edited document is the active text editor) won't fire.
      * Force the re-parse immediately instead of waiting for the user to click back into the source.
@@ -1370,7 +1452,7 @@ export class RecordPreviewPanel {
         align-items: center;
         gap: 6px;
     }
-    #actionBar button {
+    #actionBar button, #sflpagBar button {
         background: #000000;
         color: #00ff00;
         border: 1px solid #333333;
@@ -1384,11 +1466,25 @@ export class RecordPreviewPanel {
         color: #000000;
         border-color: #00ff00;
     }
+    #actionBar button:disabled, #sflpagBar button:disabled {
+        color: #666666;
+        border-color: #222222;
+        cursor: default;
+    }
     #indicatorBar {
         display: none;
         align-items: center;
         gap: 4px;
         cursor: pointer;
+    }
+    #sflpagBar {
+        display: none;
+        align-items: center;
+        gap: 4px;
+    }
+    #sflpagValue {
+        min-width: 2ch;
+        text-align: center;
     }
     #indicatorList {
         display: none;
@@ -1431,6 +1527,12 @@ export class RecordPreviewPanel {
         <select id="overlaySelect"></select>
     </span>
     <label id="indicatorBar"><input type="checkbox" id="indicatorsToggle"> Indicators</label>
+    <span id="sflpagBar">
+        <label>Page rows: </label>
+        <button id="sflpagMinusBtn" title="Decrease SFLPAG (SFLSIZ stays SFLPAG + 1)">-</button>
+        <span id="sflpagValue"></span>
+        <button id="sflpagPlusBtn" title="Increase SFLPAG (SFLSIZ stays SFLPAG + 1)">+</button>
+    </span>
     <span id="actionBar">
         <button id="addFieldBtn" title="Click, then click a point in the screen to place a new field there">+ Field</button>
         <button id="addConstantBtn" title="Click, then click a point in the screen to place a new constant there">+ Constant</button>
@@ -1451,6 +1553,10 @@ export class RecordPreviewPanel {
     const indicatorBar = document.getElementById('indicatorBar');
     const indicatorsToggle = document.getElementById('indicatorsToggle');
     const indicatorList = document.getElementById('indicatorList');
+    const sflpagBar = document.getElementById('sflpagBar');
+    const sflpagMinusBtn = document.getElementById('sflpagMinusBtn');
+    const sflpagPlusBtn = document.getElementById('sflpagPlusBtn');
+    const sflpagValue = document.getElementById('sflpagValue');
     const addConstantBtn = document.getElementById('addConstantBtn');
     const addFieldBtn = document.getElementById('addFieldBtn');
     const gridDotsBtn = document.getElementById('gridDotsBtn');
@@ -1498,7 +1604,11 @@ export class RecordPreviewPanel {
         let row = isDragged ? dragState.row : item.row;
         let col = isDragged ? dragState.col : item.col;
 
-        if (moveDelta && !item.isBackground) {
+        // A "sameWindow" background item (the other half of an SFL/SFLCTL pair, sharing this exact
+        // window) must move along with the window being dragged, same as the foreground record's
+        // own items — only a genuinely different background record (a different window, or none at
+        // all) stays put.
+        if (moveDelta && (!item.isBackground || item.sameWindow)) {
             row += moveDelta.row;
             col += moveDelta.col;
         }
@@ -1680,8 +1790,10 @@ export class RecordPreviewPanel {
             ctx.restore();
         }
 
-        // While the window is being dragged, its own fields/constants move along with its border
-        // (the background record's items stay put, since that record isn't being moved).
+        // While the window is being dragged, its own fields/constants — and any "sameWindow"
+        // background items, the other half of an SFL/SFLCTL pair sharing this exact window — move
+        // along with its border. A genuinely different background record's items stay put, since
+        // that record (and its own window, if any) isn't being moved.
         const moveDelta = (moveWindowState && currentOuterFrame)
             ? { row: currentOuterFrame.row - moveWindowState.startRow, col: currentOuterFrame.col - moveWindowState.startCol }
             : null;
@@ -1702,7 +1814,7 @@ export class RecordPreviewPanel {
             ctx.save();
             ctx.globalAlpha = 0.45;
             for (const item of sameWindowItems) {
-                drawItem(item, fontFamily, null);
+                drawItem(item, fontFamily, moveDelta);
             }
             ctx.restore();
         }
@@ -1913,6 +2025,14 @@ export class RecordPreviewPanel {
         if (currentSize) {
             draw(currentSize, currentItems, currentBackgroundItems, currentWindowFrame, currentWindowTitle, currentOuterFrame);
         }
+    });
+
+    sflpagMinusBtn.addEventListener('click', () => {
+        vscode.postMessage({ type: 'sflpagDecrement' });
+    });
+
+    sflpagPlusBtn.addEventListener('click', () => {
+        vscode.postMessage({ type: 'sflpagIncrement' });
     });
 
     document.addEventListener('keydown', (ev) => {
@@ -2222,6 +2342,14 @@ export class RecordPreviewPanel {
                 indicatorsToggle.checked = Boolean(message.indicatorsEnabled);
                 indicatorList.style.display = message.indicatorsEnabled ? 'block' : 'none';
                 rebuildIndicatorList(message.availableIndicators, message.activeIndicators || []);
+            }
+
+            const hasSflPag = typeof message.sflPag === 'number';
+            sflpagBar.style.display = hasSflPag ? 'inline-flex' : 'none';
+            if (hasSflPag) {
+                sflpagValue.textContent = String(message.sflPag);
+                sflpagMinusBtn.disabled = message.sflPag <= 1;
+                sflpagPlusBtn.disabled = message.sflPag >= 9998;
             }
 
             const baseInfo = message.size.rows + ' x ' + message.size.cols;


### PR DESCRIPTION
## [0.13.2] - 2026-07-25
### Added
- New "Add Commands Record" command (record context menu, shown only on subfile control (SFLCTL) records): creates a record right after the subfile for its function-key legend (e.g. "F3=Exit"). For window subfiles, moves the SFLCTL's own `WINDOW()` (and `WDWTITLE()`/`WDWBORDER()`) onto the new record and leaves a `WINDOW(record)` reference behind, so the legend shares the subfile's window.
- New "Page rows" +/- control in the preview toolbar for SFLCTL records: adjusts `SFLPAG()`, always keeping `SFLSIZ()` one more than `SFLPAG()`.
### Fixed
- An SFL/SFLCTL pair sharing a window (the SFLCTL declaring `WINDOW()` directly) could hide the other half's content behind the window's own opaque background in the preview.
- Dragging a window in the preview left the paired SFL/SFLCTL record's dimmed content static until the mouse was released, instead of moving live with the window.
