### PR TITLE
Many changes and fixes done

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
+## [0.13.3] - 2026-07-26
+### Added
+- Preview: selecting a field or constant now shows a "Selection actions" bar in the toolbar strip (not floating over the canvas, so it never fights the drag gesture or gets cramped by a single-character constant) — a one-click "↔ Center" button and a "⋮ Actions" menu (Add Color..., Add Attribute...), reusing the tree's own commands against the selected element.
+- Preview/Center: the DDS system keywords `DATE`, `TIME`, `USER`, and `SYSNAME` now render with their real on-screen appearance (`DD-DD-DD`, `TT:TT:TT`, `UUUUUUUUUU`, `SSSSSSSS`), whether coded as a field's name or bare (unquoted) in a constant's position; "Center" now centers them using that real display width instead of the raw, misleadingly short source length.
+- Preview: fields and constants can now be multi-selected (Ctrl/Cmd+click) and dragged together as one group, writing every new position back in a single edit; the selection bar reads "N fields/constants selected", and only offers "↔ Center"/"⋮ Actions" when exactly one item is selected.
+- "Add Field" now offers a quick flow — just kind+usage (Alphanumeric/Numeric × Output/Input-Output/Input) and a size — that generates the same field STRSDA itself would (including an automatic `EDTWRD()` for numeric fields with decimals), reusing the same name/position steps as before; the full usage/referenced-field/type flow is still available behind a "More options..." entry for anything else (Hidden/Message usage, a referenced field, or another data type).
+### Fixed
+- Editing a read-only DDS source (e.g. an IBM i member opened in browse mode, or a read-only file) silently let every edit command (add/rename/move/delete field, constant, attribute, indicator, key command, window resize/title, subfile page size, and more) report success and modify the in-memory buffer, only to fail later with no warning when actually saving. Edits are now checked against the file's read-only status upfront, showing an immediate error instead.
+- Preview: an output field with no explicit usage code (DDS's own default when left blank) showed its field name instead of the correct repeated-`O` placeholder text.
+- Preview: a Date/Time/Timestamp (`L`/`T`/`Z`) field with no explicit length (DDS determines it automatically for these types) collapsed to a single placeholder character instead of its real fixed width (10/8/26).
+- Parser: a bare system keyword (`DATE`, `TIME`, `USER`, `SYSNAME`) coded in a constant's position without quotes had its first and last character corrupted, since quote-stripping was applied unconditionally instead of only to actually-quoted text.
+- Parser: two or more constants sharing identical text at different screen positions (e.g. blank/space "pixel" blocks used to build a colored logo out of `DSPATR(RI)` blocks) were silently collapsed down to just the first one found, since duplicates were detected by text alone instead of by source line.
+- Preview: `DSPATR(HI)` with no explicit `COLOR()` rendered in the default green instead of white, unlike a real 5250 display.
+- Preview: an alphanumeric field with a blank data-type column (DDS's own default — e.g. from the quick "Add Field" flow) showed numeric placeholder digits (6/9/3) instead of the correct usage letter (O/B/I).
+- Preview: a numeric field carrying an `EDTWRD()` edit word showed a plain run of digits instead of the mask's actual picture (e.g. `99999999.99` instead of `9999999999`).
+
 ## [0.13.2] - 2026-07-25
 ### Added
 - New "Add Commands Record" command (record context menu, shown only on subfile control (SFLCTL) records): creates a record right after the subfile for its function-key legend (e.g. "F3=Exit"). For window subfiles, moves the SFLCTL's own `WINDOW()` (and `WDWTITLE()`/`WDWBORDER()`) onto the new record and leaves a `WINDOW(record)` reference behind, so the legend shares the subfile's window.

--- a/README.md
+++ b/README.md
@@ -118,11 +118,18 @@ Some features may not work as expected. Please leave an issue if something is no
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**0.13.2** - 2026-07-25
-- Added: New "Add Commands Record" command (record context menu, shown only on subfile control (SFLCTL) records) — creates a record right after the subfile for its function-key legend (e.g. "F3=Exit"). For window subfiles, moves the SFLCTL's own `WINDOW()` (and `WDWTITLE()`/`WDWBORDER()`) onto the new record and leaves a `WINDOW(record)` reference behind, so the legend shares the subfile's window.
-- Added: New "Page rows" +/- control in the preview toolbar for SFLCTL records — adjusts `SFLPAG()`, always keeping `SFLSIZ()` one more than `SFLPAG()`.
-- Fixed: An SFL/SFLCTL pair sharing a window (the SFLCTL declaring `WINDOW()` directly) could hide the other half's content behind the window's own opaque background in the preview.
-- Fixed: Dragging a window in the preview left the paired SFL/SFLCTL record's dimmed content static until the mouse was released, instead of moving live with the window.
+**0.13.3** - 2026-07-26
+- Added: Preview: selecting a field or constant now shows a "Selection actions" bar in the toolbar strip — a one-click "↔ Center" button and a "⋮ Actions" menu (Add Color..., Add Attribute...), reusing the tree's own commands against the selected element.
+- Added: Preview/Center: the DDS system keywords `DATE`, `TIME`, `USER`, and `SYSNAME` now render with their real on-screen appearance (`DD-DD-DD`, `TT:TT:TT`, `UUUUUUUUUU`, `SSSSSSSS`), whether coded as a field's name or bare in a constant's position; "Center" now uses that real display width.
+- Added: Preview: fields and constants can now be multi-selected (Ctrl/Cmd+click) and dragged together as one group; the selection bar reads "N fields/constants selected", with "↔ Center"/"⋮ Actions" only shown for a single selection.
+- Added: "Add Field" now offers a quick flow — just kind+usage and a size — that generates the same field STRSDA itself would (including an automatic `EDTWRD()` for numeric fields with decimals); the full flow is still available behind a "More options..." entry.
+- Fixed: Preview: an output field with no explicit usage code showed its field name instead of the correct repeated-`O` placeholder text.
+- Fixed: Preview: a Date/Time/Timestamp (`L`/`T`/`Z`) field with no explicit length collapsed to a single placeholder character instead of its real fixed width (10/8/26).
+- Fixed: Parser: a bare system keyword (`DATE`, `TIME`, `USER`, `SYSNAME`) coded unquoted in a constant's position had its first and last character corrupted.
+- Fixed: Parser: two or more constants sharing identical text at different screen positions (e.g. blank "pixel" blocks building a colored logo) were silently collapsed down to just the first one found.
+- Fixed: Preview: `DSPATR(HI)` with no explicit `COLOR()` rendered in the default green instead of white, unlike a real 5250 display.
+- Fixed: Preview: an alphanumeric field with a blank data-type column showed numeric placeholder digits instead of the correct usage letter (O/B/I).
+- Fixed: Preview: a numeric field carrying an `EDTWRD()` edit word showed a plain run of digits instead of the mask's actual picture (e.g. `99999999.99`).
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "0.13.2",
+  "version": "0.13.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"

--- a/src/dspf-edit.commands/dspf-edit.add-attribute.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-attribute.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from './../dspf-edit.providers/dspf-edit.providers';
-import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, parseIndicatorsFromLine, groupConsecutiveLines } from './../dspf-edit.utils/dspf-edit.helper';
+import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, parseIndicatorsFromLine, groupConsecutiveLines, applyWorkspaceEdit } from './../dspf-edit.utils/dspf-edit.helper';
 import { fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
  
 // INTERFACES AND TYPES
@@ -82,7 +82,9 @@ async function handleAddAttributeCommand(node: DdsNode): Promise<void> {
             };
 
             if (action === 'Replace all attributes') {
-                await removeAttributesFromElement(editor, node.ddsElement);
+                if (!(await removeAttributesFromElement(editor, node.ddsElement))) {
+                    return;
+                };
                 // Continue to add new attributes
                 availableAttributes = getAvailableAttributes([]);
             };
@@ -98,7 +100,9 @@ async function handleAddAttributeCommand(node: DdsNode): Promise<void> {
         };
 
         // Apply the selected attributes to the element
-        await addAttributesToElement(editor, node.ddsElement, selectedAttributes);
+        if (!(await addAttributesToElement(editor, node.ddsElement, selectedAttributes))) {
+            return;
+        };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
 
@@ -308,7 +312,7 @@ async function addAttributesToElement(
     editor: vscode.TextEditor,
     element: any,
     attrToAdd: AttributeWithIndicators[]
-): Promise<void> {
+): Promise<boolean> {
     const isConstant = element.kind === 'constant';
     const numberOfAttributes = getNumberOfAttributesForElement(element);
     const workspaceEdit = new vscode.WorkspaceEdit();
@@ -415,7 +419,7 @@ async function addAttributesToElement(
     };
 
     // Apply all the text edits to the document
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'add the attributes');
 };
 
 /**
@@ -459,9 +463,9 @@ function createAttributeLineWithIndicators(attributeWithIndicators: AttributeWit
  * @param editor - The active text editor
  * @param element - The DDS element to remove attributes from
  */
-async function removeAttributesFromElement(editor: vscode.TextEditor, element: any): Promise<void> {
+async function removeAttributesFromElement(editor: vscode.TextEditor, element: any): Promise<boolean> {
     const currentAttributes = getCurrentAttributesForElement(editor, element);
-    if (currentAttributes.length === 0) return;
+    if (currentAttributes.length === 0) return true;
 
     const document = editor.document;
     const workspaceEdit = new vscode.WorkspaceEdit();
@@ -496,7 +500,7 @@ async function removeAttributesFromElement(editor: vscode.TextEditor, element: a
         };
     };
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'remove the attributes');
 };
 
 /**

--- a/src/dspf-edit.commands/dspf-edit.add-buttons.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-buttons.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from './../dspf-edit.providers/dspf-edit.providers';
 import { getRecordSize, fieldsPerRecords, DdsSize, getDefaultSize } from '../dspf-edit.model/dspf-edit.model';
-import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 
 // TYPE DEFINITIONS
 
@@ -387,10 +387,12 @@ async function applyButtonsToRecord(
         currentCol += text.length + layout.spacing;
     };
 
-    await vscode.workspace.applyEdit(edit);
+    if (!(await applyWorkspaceEdit(edit, 'add the buttons'))) {
+        return;
+    };
     await vscode.commands.executeCommand('cursorRight');
     await vscode.commands.executeCommand('cursorLeft');
-    
+
     vscode.window.showInformationMessage(`Added ${buttons.length} buttons to record ${recordInfo.name}.`);
 };
 

--- a/src/dspf-edit.commands/dspf-edit.add-color.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-color.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, parseIndicatorsFromLine, groupConsecutiveLines } from '../dspf-edit.utils/dspf-edit.helper';
+import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, parseIndicatorsFromLine, groupConsecutiveLines, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 import { fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
 
 // INTERFACES AND TYPES
@@ -82,7 +82,9 @@ async function handleAddColorCommand(node: DdsNode): Promise<void> {
             };
 
             if (action === 'Replace all colors') {
-                await removeColorsFromElement(editor, node.ddsElement);
+                if (!(await removeColorsFromElement(editor, node.ddsElement))) {
+                    return;
+                };
                 // Continue to add new colors
                 availableColors = getAvailableColors([]);
             };
@@ -98,7 +100,9 @@ async function handleAddColorCommand(node: DdsNode): Promise<void> {
         };
 
         // Apply the selected colors to the element
-        await addColorsToElement(editor, node.ddsElement, selectedColors);
+        if (!(await addColorsToElement(editor, node.ddsElement, selectedColors))) {
+            return;
+        };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
         
@@ -283,7 +287,7 @@ async function addColorsToElement(
     editor: vscode.TextEditor,
     element: any,
     colorsToAdd: ColorWithIndicators[]
-): Promise<void> {
+): Promise<boolean> {
     const isConstant = element.kind === 'constant';
     const numberOfAttributes = getNumberOfAttributesForElement(element);
     const workspaceEdit = new vscode.WorkspaceEdit();
@@ -349,7 +353,7 @@ async function addColorsToElement(
         };
     };
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'add the colors');
 };
 
 function getNumberOfAttributesForElement(element: any): number | undefined {
@@ -422,9 +426,9 @@ function createColorLineWithIndicators(colorWithIndicators: ColorWithIndicators)
  * @param editor - The active text editor
  * @param element - The DDS element to remove colors from
  */
-async function removeColorsFromElement(editor: vscode.TextEditor, element: any): Promise<void> {
+async function removeColorsFromElement(editor: vscode.TextEditor, element: any): Promise<boolean> {
     const currentColors = getCurrentColorsForElement(editor, element);
-    if (currentColors.length === 0) return;
+    if (currentColors.length === 0) return true;
 
     const document = editor.document;
     const workspaceEdit = new vscode.WorkspaceEdit();
@@ -459,7 +463,7 @@ async function removeColorsFromElement(editor: vscode.TextEditor, element: any):
         };
     };
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'remove the colors');
 };
 
 /**

--- a/src/dspf-edit.commands/dspf-edit.add-commands-record.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-commands-record.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from './../dspf-edit.providers/dspf-edit.providers';
 import { DdsAttribute, fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 import { validateRecordName } from './dspf-edit.new-record';
 import { findRecordInsertionPoint } from './dspf-edit.add-buttons';
 
@@ -97,7 +97,9 @@ async function handleAddCommandsRecordCommand(node: DdsNode): Promise<void> {
         return;
     };
 
-    await insertCommandsRecord(document, insertionLine, newRecordName, numericWindowAttrs, titleAttrs, borderAttrs);
+    if (!(await insertCommandsRecord(document, insertionLine, newRecordName, numericWindowAttrs, titleAttrs, borderAttrs))) {
+        return;
+    };
 
     await vscode.commands.executeCommand('cursorRight');
     await vscode.commands.executeCommand('cursorLeft');
@@ -140,7 +142,7 @@ async function insertCommandsRecord(
     windowAttrsToMove: DdsAttribute[],
     titleAttrsToMove: DdsAttribute[],
     borderAttrsToMove: DdsAttribute[]
-): Promise<void> {
+): Promise<boolean> {
     const bodyLines = [
         ' '.repeat(5) + 'A' + ' '.repeat(10) + 'R ' + recordName.padEnd(10, ' '),
         ' '.repeat(5) + 'A' + ' '.repeat(38) + 'OVERLAY',
@@ -172,5 +174,5 @@ async function insertCommandsRecord(
         workspaceEdit.delete(document.uri, new vscode.Range(attr.lineIndex, 0, lastLine + 1, 0));
     };
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'add the commands record');
 };

--- a/src/dspf-edit.commands/dspf-edit.add-editing-keywords.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-editing-keywords.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, groupConsecutiveLines } from '../dspf-edit.utils/dspf-edit.helper';
+import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, groupConsecutiveLines, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
@@ -173,7 +173,9 @@ async function handleEditingKeywordsCommand(node: DdsNode): Promise<void> {
         };
 
         // Apply the selected editing to the field
-        await addEditingToField(editor, node.ddsElement, selectedEditing);
+        if (!(await addEditingToField(editor, node.ddsElement, selectedEditing))) {
+            return;
+        };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
         
@@ -536,7 +538,7 @@ async function addEditingToField(
     editor: vscode.TextEditor,
     element: any,
     editing: EditConfiguration[]
-): Promise<void> {
+): Promise<boolean> {
     const workspaceEdit = new vscode.WorkspaceEdit();
     const uri = editor.document.uri;
     const fieldLine = editor.document.lineAt(element.lineIndex);
@@ -568,7 +570,7 @@ async function addEditingToField(
         await addAdditionalEditingLines(editing, insertionPoint, workspaceEdit, uri, editor);
     };
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'apply the field editing');
 };
 
 /**
@@ -719,9 +721,9 @@ function createEditingLine(editConfig: EditConfiguration): string {
  * @param editor - The active text editor
  * @param element - The DDS field to remove editing from
  */
-async function removeEditingFromField(editor: vscode.TextEditor, element: any): Promise<void> {
+async function removeEditingFromField(editor: vscode.TextEditor, element: any): Promise<boolean> {
     const editingLines = findExistingEditingLines(editor, element);
-    if (editingLines.length === 0) return;
+    if (editingLines.length === 0) return true;
 
     const document = editor.document;
     const workspaceEdit = new vscode.WorkspaceEdit();
@@ -757,11 +759,14 @@ async function removeEditingFromField(editor: vscode.TextEditor, element: any): 
         workspaceEdit.replace(uri, line.range, cleanedText);
     };
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    if (!(await applyWorkspaceEdit(workspaceEdit, 'remove the field editing'))) {
+        return false;
+    };
     await vscode.commands.executeCommand('cursorRight');
     await vscode.commands.executeCommand('cursorLeft');
 
     vscode.window.showInformationMessage(`Removed field editing from ${element.name}.`);
+    return true;
 };
 
 /**

--- a/src/dspf-edit.commands/dspf-edit.add-error-messages.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-error-messages.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { isAttributeLine, findElementInsertionPointRecordFirstLine, checkForEditorAndDocument, groupConsecutiveLines } from '../dspf-edit.utils/dspf-edit.helper';
+import { isAttributeLine, findElementInsertionPointRecordFirstLine, checkForEditorAndDocument, groupConsecutiveLines, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
@@ -84,16 +84,20 @@ async function handleAddErrorMessageCommand(node: DdsNode): Promise<void> {
             if (!action) return;
 
             if (action === 'Remove all error messages') {
-                await removeErrorMessagesFromField(editor, field);
+                if (!(await removeErrorMessagesFromField(editor, field))) {
+                    return;
+                };
                 await vscode.commands.executeCommand('cursorRight');
                 await vscode.commands.executeCommand('cursorLeft');
-                
+
                 vscode.window.showInformationMessage(`Removed all error messages from field '${field.name}'.`);
                 return;
             };
 
             if (action === 'Replace all error messages') {
-                await removeErrorMessagesFromField(editor, field);
+                if (!(await removeErrorMessagesFromField(editor, field))) {
+                    return;
+                };
             };
             // If "Add more error messages", continue with current logic
         };
@@ -107,7 +111,9 @@ async function handleAddErrorMessageCommand(node: DdsNode): Promise<void> {
         };
 
         // Apply the selected error messages to the field
-        await addErrorMessagesToField(editor, field, selectedErrorMessages);
+        if (!(await addErrorMessagesToField(editor, field, selectedErrorMessages))) {
+            return;
+        };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
 
@@ -364,7 +370,7 @@ async function addErrorMessagesToField(
     editor: vscode.TextEditor,
     field: any,
     errorMessages: ErrorMessageConfig[]
-): Promise<void> {
+): Promise<boolean> {
     const insertionPoint = findElementInsertionPointRecordFirstLine(editor, field);
     if (insertionPoint === -1) {
         throw new Error('Could not find insertion point for error messages');
@@ -394,7 +400,7 @@ async function addErrorMessagesToField(
         currentInsertionPoint++; // Move insertion point for next error message
     };
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'add the error messages');
 };
 
 /**
@@ -462,9 +468,9 @@ function createErrorMessageLines(errorMessage: ErrorMessageConfig): string[] {
  * @param editor - The active text editor
  * @param field - The DDS field to remove error messages from
  */
-async function removeErrorMessagesFromField(editor: vscode.TextEditor, field: any): Promise<void> {
+async function removeErrorMessagesFromField(editor: vscode.TextEditor, field: any): Promise<boolean> {
     const errorMessageLines = findExistingErrorMessageLines(editor, field);
-    if (errorMessageLines.length === 0) return;
+    if (errorMessageLines.length === 0) return true;
 
     const document = editor.document;
     const workspaceEdit = new vscode.WorkspaceEdit();
@@ -480,7 +486,7 @@ async function removeErrorMessagesFromField(editor: vscode.TextEditor, field: an
         workspaceEdit.delete(uri, new vscode.Range(startPos, endPos));
     };
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'remove the error messages');
 };
 
 /**

--- a/src/dspf-edit.commands/dspf-edit.add-indicators.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-indicators.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
@@ -90,10 +90,12 @@ async function handleAddIndicatorsCommand(node: DdsNode): Promise<void> {
             if (!action) return;
 
             if (action === 'Remove all indicators') {
-                await removeIndicatorsFromElement(editor, node.ddsElement);
+                if (!(await removeIndicatorsFromElement(editor, node.ddsElement))) {
+                    return;
+                };
                 await vscode.commands.executeCommand('cursorRight');
                 await vscode.commands.executeCommand('cursorLeft');
-                
+
                 (node.ddsElement.kind === 'constant' || node.ddsElement.kind === 'field') ?
                 vscode.window.showInformationMessage(`Removed all indicators from ${node.ddsElement.name}.`) :
                 vscode.window.showInformationMessage(`Removed all indicators from attribute.`);
@@ -101,18 +103,22 @@ async function handleAddIndicatorsCommand(node: DdsNode): Promise<void> {
             };
 
             if (action === 'Replace all indicators') {
-                await removeIndicatorsFromElement(editor, node.ddsElement);
+                if (!(await removeIndicatorsFromElement(editor, node.ddsElement))) {
+                    return;
+                };
                 await vscode.commands.executeCommand('cursorRight');
                 await vscode.commands.executeCommand('cursorLeft');
-                
+
                 // Continue to add new indicators
             };
 
             if (action === 'Modify existing indicators') {
-                await modifyExistingIndicators(editor, node.ddsElement, currentIndicators);
+                if (!(await modifyExistingIndicators(editor, node.ddsElement, currentIndicators))) {
+                    return;
+                };
                 await vscode.commands.executeCommand('cursorRight');
                 await vscode.commands.executeCommand('cursorLeft');
-                
+
                 return;
             };
 
@@ -135,7 +141,9 @@ async function handleAddIndicatorsCommand(node: DdsNode): Promise<void> {
         const allIndicators = action === 'Add more indicators' ? [...currentIndicators, ...newIndicators] : newIndicators;
 
         // Apply the selected indicators to the element
-        await setIndicatorsForElement(editor, node.ddsElement, allIndicators);
+        if (!(await setIndicatorsForElement(editor, node.ddsElement, allIndicators))) {
+            return;
+        };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
 
@@ -214,8 +222,10 @@ async function handleInlineAttributeIndicators(
     };
 
     // Move the attribute to a separate line with indicators
-    await moveInlineAttributeToSeparateLine(editor, inlineInfo, indicators);
-    
+    if (!(await moveInlineAttributeToSeparateLine(editor, inlineInfo, indicators))) {
+        return;
+    };
+
     const indicatorsSummary = formatIndicatorsSummary(indicators);
     vscode.window.showInformationMessage(
         `Moved attribute to separate line and added indicators: ${indicatorsSummary}`
@@ -232,7 +242,7 @@ async function moveInlineAttributeToSeparateLine(
     editor: vscode.TextEditor,
     inlineInfo: InlineAttributeInfo,
     indicators: IndicatorAssignment[]
-): Promise<void> {
+): Promise<boolean> {
     const workspaceEdit = new vscode.WorkspaceEdit();
     const uri = editor.document.uri;
     const fieldLineIndex = inlineInfo.fieldLineIndex;
@@ -260,7 +270,7 @@ async function moveInlineAttributeToSeparateLine(
         workspaceEdit.insert(uri, insertPos, '\n');
     };
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'move the attribute');
 };
 
 /**
@@ -392,8 +402,8 @@ async function modifyExistingIndicators(
     editor: vscode.TextEditor,
     element: any,
     currentIndicators: IndicatorAssignment[]
-): Promise<void> {
-    const indicatorChoices = currentIndicators.map((indicator, index) => 
+): Promise<boolean> {
+    const indicatorChoices = currentIndicators.map((indicator, index) =>
         `Position ${index + 1}: ${indicator.isNegated ? 'N' : ''}${indicator.value}`
     );
 
@@ -405,23 +415,29 @@ async function modifyExistingIndicators(
         }
     );
 
-    if (!selectedIndicator) return;
+    if (!selectedIndicator) return true;
 
     if (selectedIndicator === 'Clear all and start over') {
-        await removeIndicatorsFromElement(editor, element);
+        if (!(await removeIndicatorsFromElement(editor, element))) {
+            return false;
+        };
         const newIndicators = await collectIndicatorsFromUser(3);
         if (newIndicators.length > 0) {
-            await setIndicatorsForElement(editor, element, newIndicators);
+            if (!(await setIndicatorsForElement(editor, element, newIndicators))) {
+                return false;
+            };
         };
     } else if (selectedIndicator === 'Add new indicator') {
         if (currentIndicators.length >= 3) {
             vscode.window.showWarningMessage('Maximum of 3 indicators per field reached.');
-            return;
+            return true;
         };
         const newIndicators = await collectIndicatorsFromUser(3 - currentIndicators.length);
         if (newIndicators.length > 0) {
             const allIndicators = [...currentIndicators, ...newIndicators];
-            await setIndicatorsForElement(editor, element, allIndicators);
+            if (!(await setIndicatorsForElement(editor, element, allIndicators))) {
+                return false;
+            };
         };
     } else {
         const indicatorIndex = indicatorChoices.indexOf(selectedIndicator);
@@ -436,7 +452,9 @@ async function modifyExistingIndicators(
 
             if (action === 'Remove this indicator') {
                 const newIndicators = currentIndicators.filter((_, index) => index !== indicatorIndex);
-                await setIndicatorsForElement(editor, element, newIndicators);
+                if (!(await setIndicatorsForElement(editor, element, newIndicators))) {
+                    return false;
+                };
                 vscode.window.showInformationMessage('Indicator removed.');
             } else if (action === 'Change indicator value') {
                 const newValue = await vscode.window.showInputBox({
@@ -464,7 +482,7 @@ async function modifyExistingIndicators(
                 if (newValue) {
                     const isNegated = newValue.startsWith('N');
                     const value = newValue.replace(/^N/, '').padStart(2, '0');
-                    
+
                     currentIndicators[indicatorIndex] = {
                         position: indicatorIndex + 1,
                         indicator: newValue.toUpperCase(),
@@ -472,12 +490,15 @@ async function modifyExistingIndicators(
                         value
                     };
 
-                    await setIndicatorsForElement(editor, element, currentIndicators);
+                    if (!(await setIndicatorsForElement(editor, element, currentIndicators))) {
+                        return false;
+                    };
                     vscode.window.showInformationMessage('Indicator updated.');
                 };
             };
         };
     };
+    return true;
 };
 
 // DDS MODIFICATION FUNCTIONS
@@ -492,7 +513,7 @@ async function setIndicatorsForElement(
     editor: vscode.TextEditor,
     element: any,
     indicators: IndicatorAssignment[]
-): Promise<void> {
+): Promise<boolean> {
     const workspaceEdit = new vscode.WorkspaceEdit();
     const uri = editor.document.uri;
     const elementLineIndex = element.lineIndex;
@@ -502,7 +523,7 @@ async function setIndicatorsForElement(
     const newLine = setIndicatorsOnLine(elementLine.text, indicators);
     workspaceEdit.replace(uri, elementLine.range, newLine);
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'set the indicators');
 };
 
 /**
@@ -510,7 +531,7 @@ async function setIndicatorsForElement(
  * @param editor - The active text editor
  * @param element - The DDS element to remove indicators from
  */
-async function removeIndicatorsFromElement(editor: vscode.TextEditor, element: any): Promise<void> {
+async function removeIndicatorsFromElement(editor: vscode.TextEditor, element: any): Promise<boolean> {
     const workspaceEdit = new vscode.WorkspaceEdit();
     const uri = editor.document.uri;
     const elementLineIndex = element.lineIndex;
@@ -520,7 +541,7 @@ async function removeIndicatorsFromElement(editor: vscode.TextEditor, element: a
     const cleanedLine = removeIndicatorsFromLine(elementLine.text);
     workspaceEdit.replace(uri, elementLine.range, cleanedLine);
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'remove the indicators');
 };
 
 // LINE CREATION AND PARSING FUNCTIONS

--- a/src/dspf-edit.commands/dspf-edit.add-keys.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-keys.ts
@@ -11,7 +11,8 @@ import {
     isAttributeLine, findElementInsertionPointRecordFirstLine, findElementInsertionPointFileFirstLine,
     handleDspsizWorkflow, DspsizConfig,
     checkForEditorAndDocument,
-    groupConsecutiveLines
+    groupConsecutiveLines,
+    applyWorkspaceEdit
 } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
@@ -103,25 +104,33 @@ async function handleAddKeyCommandCommand(node: DdsNode): Promise<void> {
             if (!action) return;
 
             if (action === 'Remove all key commands') {
+                let removed = true;
                 switch (node.ddsElement.kind) {
                     case 'record':
-                        await removeKeyCommandsFromRecord(editor, node.ddsElement);
+                        removed = await removeKeyCommandsFromRecord(editor, node.ddsElement);
                         break;
                     case 'file':
-                        await removeKeyCommandsFromFile(editor);
+                        removed = await removeKeyCommandsFromFile(editor);
                         break;
+                };
+                if (!removed) {
+                    return;
                 };
                 return;
             };
 
             if (action === 'Replace all key commands') {
+                let removed = true;
                 switch (node.ddsElement.kind) {
                     case 'record':
-                        await removeKeyCommandsFromRecord(editor, node.ddsElement);
+                        removed = await removeKeyCommandsFromRecord(editor, node.ddsElement);
                         break;
                     case 'file':
-                        await removeKeyCommandsFromFile(editor);
+                        removed = await removeKeyCommandsFromFile(editor);
                         break;
+                };
+                if (!removed) {
+                    return;
                 };
                 // Continue to add new key commands
                 availableKeys = getAvailableKeyNumbers([]);
@@ -138,15 +147,19 @@ async function handleAddKeyCommandCommand(node: DdsNode): Promise<void> {
             return;
         };
 
+        let added = true;
         switch (node.ddsElement.kind) {
             case 'record':
                 // Apply the selected key commands to the record
-                await addKeyCommandsToRecord(editor, node.ddsElement, selectedKeyCommands);
+                added = await addKeyCommandsToRecord(editor, node.ddsElement, selectedKeyCommands);
                 break;
             case 'file':
                 // Apply the selected key commands to the file
-                await addKeyCommandsToFile(editor, selectedKeyCommands);
+                added = await addKeyCommandsToFile(editor, selectedKeyCommands);
                 break;
+        };
+        if (!added) {
+            return;
         };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
@@ -428,7 +441,7 @@ async function addKeyCommandsToRecord(
     editor: vscode.TextEditor,
     element: any,
     keyCommands: KeyCommandWithIndicators[]
-): Promise<void> {
+): Promise<boolean> {
     const insertionPoint = findElementInsertionPointRecordFirstLine(editor, element);
     if (insertionPoint === -1) {
         throw new Error('Could not find insertion point for key commands');
@@ -454,7 +467,7 @@ async function addKeyCommandsToRecord(
         };
     };
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'add the key commands');
 };
 
 /**
@@ -465,7 +478,7 @@ async function addKeyCommandsToRecord(
 async function addKeyCommandsToFile(
     editor: vscode.TextEditor,
     keyCommands: KeyCommandWithIndicators[]
-): Promise<void> {
+): Promise<boolean> {
     const insertionPoint = findElementInsertionPointFileFirstLine(editor);
     if (insertionPoint === -1) {
         throw new Error('Could not find insertion point for key commands');
@@ -491,7 +504,7 @@ async function addKeyCommandsToFile(
         };
     };
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'add the key commands');
 };
 
 /**
@@ -528,9 +541,9 @@ function createKeyCommandLineWithIndicators(keyCommandWithIndicators: KeyCommand
  * @param editor - The active text editor
  * @param element - The DDS record to remove key commands from
  */
-async function removeKeyCommandsFromRecord(editor: vscode.TextEditor, element: any): Promise<void> {
+async function removeKeyCommandsFromRecord(editor: vscode.TextEditor, element: any): Promise<boolean> {
     const keyCommandLines = findExistingKeyCommandLines(editor, element);
-    if (keyCommandLines.length === 0) return;
+    if (keyCommandLines.length === 0) return true;
 
     const document = editor.document;
     const workspaceEdit = new vscode.WorkspaceEdit();
@@ -547,7 +560,7 @@ async function removeKeyCommandsFromRecord(editor: vscode.TextEditor, element: a
         workspaceEdit.delete(uri, new vscode.Range(startPos, endPos));
     };
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'remove the key commands');
 };
 
 /**
@@ -555,9 +568,9 @@ async function removeKeyCommandsFromRecord(editor: vscode.TextEditor, element: a
  * Handles edge cases properly to avoid leaving blank lines at the end of the file.
  * @param editor - The active text editor
  */
-async function removeKeyCommandsFromFile(editor: vscode.TextEditor): Promise<void> {
+async function removeKeyCommandsFromFile(editor: vscode.TextEditor): Promise<boolean> {
     const keyCommandLines = findExistingKeyCommandLinesInFile(editor);
-    if (keyCommandLines.length === 0) return;
+    if (keyCommandLines.length === 0) return true;
 
     const document = editor.document;
     const workspaceEdit = new vscode.WorkspaceEdit();
@@ -574,7 +587,7 @@ async function removeKeyCommandsFromFile(editor: vscode.TextEditor): Promise<voi
         workspaceEdit.delete(uri, new vscode.Range(startPos, endPos));
     };
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'remove the key commands');
 };
 
 /**

--- a/src/dspf-edit.commands/dspf-edit.add-validity-check.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-validity-check.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, groupConsecutiveLines } from '../dspf-edit.utils/dspf-edit.helper';
+import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, groupConsecutiveLines, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
@@ -88,7 +88,9 @@ async function handleAddValidityCheckCommand(node: DdsNode): Promise<void> {
             };
 
             if (action === 'Replace all validity checks') {
-                await removeValidityChecksFromField(editor, node.ddsElement);
+                if (!(await removeValidityChecksFromField(editor, node.ddsElement))) {
+                    return;
+                };
                 // Continue to add new validity checks
             };
             // If "Add more validity checks", continue with current logic
@@ -110,7 +112,9 @@ async function handleAddValidityCheckCommand(node: DdsNode): Promise<void> {
         };
 
         // Apply the selected validity checks to the field
-        await addValidityChecksToField(editor, node.ddsElement, selectedValidityChecks);
+        if (!(await addValidityChecksToField(editor, node.ddsElement, selectedValidityChecks))) {
+            return;
+        };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
 
@@ -361,7 +365,7 @@ async function addValidityChecksToField(
     editor: vscode.TextEditor,
     element: any,
     validityChecks: ValidityCheck[]
-): Promise<void> {
+): Promise<boolean> {
     const insertionPoint = findElementInsertionPoint(editor, element);
     if (insertionPoint === -1) {
         throw new Error('Could not find insertion point for validity checks');
@@ -385,7 +389,7 @@ async function addValidityChecksToField(
         };
     };
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'add the validity checks');
 };
 
 /**
@@ -412,9 +416,9 @@ function createValidityCheckLine(validityCheck: ValidityCheck): string {
  * @param editor - The active text editor
  * @param element - The DDS field to remove validity checks from
  */
-async function removeValidityChecksFromField(editor: vscode.TextEditor, element: any): Promise<void> {
+async function removeValidityChecksFromField(editor: vscode.TextEditor, element: any): Promise<boolean> {
     const validityCheckLines = findExistingValidityCheckLines(editor, element);
-    if (validityCheckLines.length === 0) return;
+    if (validityCheckLines.length === 0) return true;
 
     const document = editor.document;
     const workspaceEdit = new vscode.WorkspaceEdit();
@@ -447,7 +451,7 @@ async function removeValidityChecksFromField(editor: vscode.TextEditor, element:
         workspaceEdit.replace(uri, line.range, cleanedText);
     };
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'remove the validity checks');
 };
 
 /**

--- a/src/dspf-edit.commands/dspf-edit.center.ts
+++ b/src/dspf-edit.commands/dspf-edit.center.ts
@@ -6,8 +6,8 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { getRecordSize } from '../dspf-edit.model/dspf-edit.model';
-import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
+import { getRecordSize, SYSTEM_FIELD_PLACEHOLDER } from '../dspf-edit.model/dspf-edit.model';
+import { checkForEditorAndDocument, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 
 // POSITION CENTERING FUNCTIONALITY
 
@@ -65,7 +65,9 @@ async function handleCenterCommand(node: DdsNode): Promise<void> {
         };
 
         // Apply the position change
-        await applyPositionChange(editor, element, newPosition);
+        if (!(await applyPositionChange(editor, element, newPosition))) {
+            return;
+        };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
         
@@ -145,8 +147,7 @@ function calculateCenterPosition(element: any, maxCols: number): { row: number; 
  * @returns The calculated center column position
  */
 function calculateConstantCenterPosition(element: any, maxCols: number): number {
-    // For constants, use the name length minus 2 (for quotes)
-    const contentLength = element.name.length - 2;
+    const contentLength = getElementDisplayWidth(element.name);
     return Math.floor((maxCols - contentLength) / 2) + 1;
 };
 
@@ -157,12 +158,32 @@ function calculateConstantCenterPosition(element: any, maxCols: number): number 
  * @returns The calculated center column position
  */
 function calculateFieldCenterPosition(element: any, maxCols: number): number {
-    if (element.length) {
-        return Math.floor((maxCols - element.length) / 2) + 1;
+    // A system keyword field (DATE, USER...) always displays at its own fixed width, regardless
+    // of whatever the source's own length column holds (typically blank/0 for these).
+    const systemWidth = SYSTEM_FIELD_PLACEHOLDER[String(element.name).trim().toUpperCase()]?.length;
+    const width = systemWidth ?? element.length;
+
+    if (width) {
+        return Math.floor((maxCols - width) / 2) + 1;
     } else {
         // If no length is available, keep the current column position
         return element.column;
     };
+};
+
+/**
+ * Resolves how wide a constant actually displays: a system keyword (DATE, USER...) coded bare, at
+ * its own fixed width; a quoted literal ('...'), its text without the surrounding quotes; anything
+ * else, as-is (defensive fallback — the parser always keeps constants in one of the first two forms).
+ * @param name - The constant's raw source name (as parsed, before any quote-stripping)
+ */
+function getElementDisplayWidth(name: string): number {
+    const systemPlaceholder = SYSTEM_FIELD_PLACEHOLDER[name.trim().toUpperCase()];
+    if (systemPlaceholder) {
+        return systemPlaceholder.length;
+    };
+
+    return name.length >= 2 && name.startsWith("'") && name.endsWith("'") ? name.length - 2 : name.length;
 };
 
 // FILE MODIFICATION FUNCTIONS
@@ -174,10 +195,10 @@ function calculateFieldCenterPosition(element: any, maxCols: number): number {
  * @param newPosition - The new position coordinates
  */
 async function applyPositionChange(
-    editor: vscode.TextEditor, 
-    element: any, 
+    editor: vscode.TextEditor,
+    element: any,
     newPosition: { row: number; col: number }
-): Promise<void> {
+): Promise<boolean> {
     const lineIndex = element.lineIndex;
     const line = editor.document.lineAt(lineIndex).text;
 
@@ -194,7 +215,7 @@ async function applyPositionChange(
         updatedLine
     );
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'center the element');
 };
 
 /**

--- a/src/dspf-edit.commands/dspf-edit.change-position.ts
+++ b/src/dspf-edit.commands/dspf-edit.change-position.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fileSizeAttributes } from '../dspf-edit.model/dspf-edit.model';
-import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
@@ -87,7 +87,9 @@ async function handleChangePositionCommand(node: DdsNode): Promise<void> {
         };
 
         // Update the element position in the document
-        await updateElementPosition(editor, element, newPosition);
+        if (!(await updateElementPosition(editor, element, newPosition))) {
+            return;
+        };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
 
@@ -258,10 +260,10 @@ function validatePositionBounds(position: ElementPosition): PositionValidation {
  * @param newPosition - New position coordinates
  */
 async function updateElementPosition(
-    editor: vscode.TextEditor, 
-    element: any, 
+    editor: vscode.TextEditor,
+    element: any,
     newPosition: ElementPosition
-): Promise<void> {
+): Promise<boolean> {
     // Validate the new position
     const positionValidation = validatePositionBounds(newPosition);
     if (!positionValidation.isValid) {
@@ -294,7 +296,7 @@ async function updateElementPosition(
         updatedLine
     );
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'move the element');
 };
 
 /**

--- a/src/dspf-edit.commands/dspf-edit.copy-record.ts
+++ b/src/dspf-edit.commands/dspf-edit.copy-record.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { checkForEditorAndDocument, recordExists } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, recordExists, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
@@ -94,7 +94,9 @@ async function handleCopyRecordCommand(node: DdsNode): Promise<void> {
         const modifiedLines = modifyRecordLines(recordLines, copyConfig);
 
         // Insert the copied record into the document
-        await insertCopiedRecord(editor, modifiedLines);
+        if (!(await insertCopiedRecord(editor, modifiedLines))) {
+            return;
+        };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
 
@@ -315,7 +317,7 @@ function replaceRecordReferences(line: string, originalName: string, newName: st
  * @param editor - The active text editor
  * @param recordLines - Array of record lines to insert
  */
-async function insertCopiedRecord(editor: vscode.TextEditor, recordLines: string[]): Promise<void> {
+async function insertCopiedRecord(editor: vscode.TextEditor, recordLines: string[]): Promise<boolean> {
     if (recordLines.length === 0) {
         throw new Error('No record lines to insert');
     };
@@ -323,10 +325,10 @@ async function insertCopiedRecord(editor: vscode.TextEditor, recordLines: string
     const workspaceEdit = new vscode.WorkspaceEdit();
     const uri = editor.document.uri;
     const insertPosition = new vscode.Position(editor.document.lineCount, 0);
-    
+
     // Create the complete record text with proper line breaks
     const recordText = '\n' + recordLines.join('\n');
-    
+
     workspaceEdit.insert(uri, insertPosition, recordText);
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'copy the record');
 };

--- a/src/dspf-edit.commands/dspf-edit.delete-record.ts
+++ b/src/dspf-edit.commands/dspf-edit.delete-record.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 
 // COMMAND REGISTRATION
 
@@ -62,7 +62,9 @@ async function handleDeleteRecordCommand(node: DdsNode): Promise<void> {
         };
 
         // Perform the deletion
-        await deleteRecordLines(editor, recordBoundaries);
+        if (!(await deleteRecordLines(editor, recordBoundaries))) {
+            return;
+        };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
         
@@ -226,7 +228,7 @@ async function showDeleteConfirmation(recordName: string, info: RecordDeletionIn
  * @param editor - The active text editor
  * @param boundaries - The record boundaries to delete
  */
-async function deleteRecordLines(editor: vscode.TextEditor, boundaries: RecordBoundaries): Promise<void> {
+async function deleteRecordLines(editor: vscode.TextEditor, boundaries: RecordBoundaries): Promise<boolean> {
     const document = editor.document;
     const { startOffset, endOffset } = calculateDeletionOffsets(document, boundaries);
 
@@ -240,9 +242,9 @@ async function deleteRecordLines(editor: vscode.TextEditor, boundaries: RecordBo
     const uri = document.uri;
     const startPos = document.positionAt(startOffset);
     const endPos = document.positionAt(endOffset);
-    
+
     workspaceEdit.delete(uri, new vscode.Range(startPos, endPos));
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'delete the record');
 };
 
 /**

--- a/src/dspf-edit.commands/dspf-edit.edit-constant.ts
+++ b/src/dspf-edit.commands/dspf-edit.edit-constant.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fileSizeAttributes, fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { checkForEditorAndDocument, findEndLineIndex } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, findEndLineIndex, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 
 // TYPE DEFINITIONS
 
@@ -535,10 +535,10 @@ function validateColumnInput(value: string): string | null {
  * @param newText - The new text for the constant
  */
 export async function updateExistingConstant(
-    editor: vscode.TextEditor, 
-    element: any, 
+    editor: vscode.TextEditor,
+    element: any,
     newText: string
-): Promise<void> {
+): Promise<boolean> {
     const newValue = `'${newText}'`;
     const uri = editor.document.uri;
     const workspaceEdit = new vscode.WorkspaceEdit();
@@ -552,7 +552,7 @@ export async function updateExistingConstant(
         await updateConstantMultiLine(workspaceEdit, uri, editor, element, newValue, endLineIndex);
     };
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'update the constant');
 };
 
 /**
@@ -560,7 +560,7 @@ export async function updateExistingConstant(
  * @param editor - The active text editor
  * @param constantInfo - Information about the new constant
  */
-export async function insertNewConstant(editor: vscode.TextEditor, constantInfo: NewConstantInfo): Promise<void> {
+export async function insertNewConstant(editor: vscode.TextEditor, constantInfo: NewConstantInfo): Promise<boolean> {
     const newValue = `'${constantInfo.text}'`;
     const uri = editor.document.uri;
     const workspaceEdit = new vscode.WorkspaceEdit();
@@ -581,11 +581,14 @@ export async function insertNewConstant(editor: vscode.TextEditor, constantInfo:
         workspaceEdit.insert(uri, new vscode.Position(insertionLine, 0), '\n');        
     };
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    if (!(await applyWorkspaceEdit(workspaceEdit, 'add the constant'))) {
+        return false;
+    };
     await vscode.commands.executeCommand('cursorRight');
     await vscode.commands.executeCommand('cursorLeft');
-    
+
     vscode.window.showInformationMessage(`Constant added successfully.`);
+    return true;
 };
 
 // LINE CREATION FUNCTIONS

--- a/src/dspf-edit.commands/dspf-edit.edit-field.ts
+++ b/src/dspf-edit.commands/dspf-edit.edit-field.ts
@@ -123,6 +123,20 @@ const FIELD_TYPES = {
 } as const;
 
 /**
+ * The quick "Add Field" flow's kind+usage combos — mirrors what STRSDA's own shorthand
+ * (+B/+O/+I for alphanumeric, +9/+6/+3 for numeric) actually generates, as a single pick instead
+ * of a typed code: blank type for alphanumeric, 'Y' keyboard shift for numeric.
+ */
+const QUICK_FIELD_KINDS: { label: string; isNumeric: boolean; usage: 'O' | 'B' | 'I' }[] = [
+    { label: 'Alphanumeric — Output', isNumeric: false, usage: 'O' },
+    { label: 'Alphanumeric — Input/Output', isNumeric: false, usage: 'B' },
+    { label: 'Alphanumeric — Input', isNumeric: false, usage: 'I' },
+    { label: 'Numeric — Output', isNumeric: true, usage: 'O' },
+    { label: 'Numeric — Input/Output', isNumeric: true, usage: 'B' },
+    { label: 'Numeric — Input', isNumeric: true, usage: 'I' }
+];
+
+/**
  * Constants for field editing operations
  */
 const FIELD_CONSTANTS = {
@@ -269,22 +283,20 @@ async function handleAddFieldCommand(node: DdsNode): Promise<void> {
 
         const element = node.ddsElement;
 
-        // Collect complete field configuration
-        const fieldConfig = await collectNewFieldConfiguration(editor, element);
-        if (!fieldConfig) {
+        // Collect complete field configuration (the quick kind+usage+size flow, or the full
+        // usage/referenced/type flow behind its "More options..." entry)
+        const fieldResult = await collectNewFieldConfiguration(editor, element);
+        if (!fieldResult) {
             return; // User cancelled
         };
 
-        // Generate the DDS line for the new field
-        const newFieldLine = generateNewFieldLine(fieldConfig);
-
         // Insert the new field into the document
-        await insertNewField(editor, element, newFieldLine);
+        await insertNewField(editor, element, fieldResult.line);
 
         // Show success message
         if ('name' in element) {
             vscode.window.showInformationMessage(
-                `Field '${fieldConfig.name}' successfully added to record '${element.name}'.`
+                `Field '${fieldResult.name}' successfully added to record '${element.name}'.`
             );
         };
 
@@ -298,8 +310,9 @@ async function handleAddFieldCommand(node: DdsNode): Promise<void> {
 /**
  * Adds a new field to a record at an already-known screen position (used by the preview panel's
  * "+ Field" placement mode, where the position comes from a canvas click instead of the
- * absolute/relative positioning sub-flow). Collects the same name/usage/type-or-reference
- * configuration as the tree's "Add field" command, just skipping the position-picking step.
+ * absolute/relative positioning sub-flow). Collects the same name + quick kind/usage/size (or, via
+ * "More options...", the full usage/referenced/type flow) as the tree's "Add field" command, just
+ * skipping the position-picking step.
  * @param recordName - Name of the record to add the field to
  * @param position - Row/column already determined (e.g. by a preview click); ignored for usage
  * types that don't have a screen position (Hidden, Message, Program-to-system)
@@ -316,40 +329,35 @@ export async function addFieldAtPosition(recordName: string, position: FieldPosi
         const fieldName = await promptForNewFieldName(recordElement);
         if (!fieldName) return;
 
-        const usage = await collectFieldUsage(fieldName);
-        if (!usage) return;
+        const quickKind = await collectQuickFieldKind(fieldName);
+        if (quickKind === null) return;
 
-        const isReferenced = await promptForFieldReference();
-        if (isReferenced === null) return;
+        let newFieldLine: string;
 
-        let reference: FieldReference | undefined;
-        let typeConfig: FieldTypeConfig | undefined;
+        if (quickKind !== 'advanced') {
+            const size = await collectQuickFieldSize(fieldName, quickKind.isNumeric);
+            if (!size) return;
 
-        if (isReferenced) {
-            const collectedReference = await collectFieldReference(fieldName);
-            if (!collectedReference) return;
-            reference = collectedReference;
+            newFieldLine = generateQuickFieldLines(fieldName, quickKind.isNumeric, quickKind.usage, size, position);
         } else {
-            const collectedTypeConfig = await collectFieldTypeConfiguration(fieldName);
-            if (!collectedTypeConfig) return;
-            typeConfig = collectedTypeConfig;
+            const advanced = await collectAdvancedFieldDefinition(fieldName);
+            if (!advanced) return;
+
+            // These usage types don't have screen positions, same as the tree command's own flow.
+            const finalPosition: FieldPosition = (advanced.usage.type === 'H' || advanced.usage.type === 'M' || advanced.usage.type === 'P')
+                ? { row: 0, column: 0 }
+                : position;
+
+            newFieldLine = generateNewFieldLine({
+                name: fieldName,
+                position: finalPosition,
+                usage: advanced.usage,
+                isReferenced: advanced.isReferenced,
+                reference: advanced.reference,
+                typeConfig: advanced.typeConfig
+            });
         };
 
-        // These usage types don't have screen positions, same as the tree command's own flow.
-        const finalPosition: FieldPosition = (usage.type === 'H' || usage.type === 'M' || usage.type === 'P')
-            ? { row: 0, column: 0 }
-            : position;
-
-        const fieldConfig: NewFieldConfig = {
-            name: fieldName,
-            position: finalPosition,
-            usage,
-            isReferenced,
-            reference,
-            typeConfig
-        };
-
-        const newFieldLine = generateNewFieldLine(fieldConfig);
         await insertNewField(editor, recordElement, newFieldLine);
 
         vscode.window.showInformationMessage(`Field '${fieldName}' successfully added to record '${recordName}'.`);
@@ -362,56 +370,194 @@ export async function addFieldAtPosition(recordName: string, position: FieldPosi
 };
 
 /**
- * Collects complete configuration for a new field through user interaction
- * 
- * @param recordElement - The record element where the field will be added
- * @returns Complete field configuration or null if cancelled
+ * Shows the quick "Add Field" kind picker: the six common kind+usage combos (mirroring what
+ * STRSDA's own +B/+O/+I/+9/+6/+3 shorthand generates), plus a "More options..." entry that opens
+ * the full usage/referenced-field/type flow for anything outside that common case (Hidden/Message/
+ * Program-to-system usage, a referenced field, or a data type other than plain alphanumeric/numeric).
+ * @param fieldName - The field's name, shown in the picker's title
  */
-async function collectNewFieldConfiguration(editor: vscode.TextEditor, recordElement: any): Promise<NewFieldConfig | null> {
-    // Step 1: Get field name
-    const fieldName = await promptForNewFieldName(recordElement);
-    if (!fieldName) return null;
+async function collectQuickFieldKind(fieldName: string): Promise<{ isNumeric: boolean; usage: FieldUsage } | 'advanced' | null> {
+    type KindPick = vscode.QuickPickItem & { index?: number; advanced?: boolean };
 
-    // Step 2: Get field usage (I/O/B/H/M/P)
+    const items: KindPick[] = [
+        ...QUICK_FIELD_KINDS.map((kind, index) => ({ label: kind.label, index })).slice(0, 3),
+        { label: '', kind: vscode.QuickPickItemKind.Separator },
+        ...QUICK_FIELD_KINDS.map((kind, index) => ({ label: kind.label, index })).slice(3),
+        { label: '', kind: vscode.QuickPickItemKind.Separator },
+        {
+            label: 'More options...',
+            description: 'Hidden/Message/Program-to-system usage, referenced field, or another data type',
+            advanced: true
+        }
+    ];
+
+    const selection = await vscode.window.showQuickPick(items, {
+        title: `Add field '${fieldName}' — Kind`,
+        placeHolder: 'Select the field kind, or "More options..." for the full flow',
+        ignoreFocusOut: true
+    });
+
+    if (!selection) return null;
+    if (selection.advanced) return 'advanced';
+    if (typeof selection.index !== 'number') return null;
+
+    const kind = QUICK_FIELD_KINDS[selection.index];
+    return {
+        isNumeric: kind.isNumeric,
+        usage: { type: kind.usage, description: FIELD_USAGE_TYPES[kind.usage].description }
+    };
+};
+
+/**
+ * Collects the size for the quick "Add Field" flow: just a length for an alphanumeric field, or
+ * N/N,D (total digits/decimal places) for a numeric one — reusing the same size format and
+ * validation as the full flow's own numeric size prompt.
+ * @param fieldName - The field's name, shown in the prompt's title
+ * @param isNumeric - Whether the chosen kind was numeric
+ */
+async function collectQuickFieldSize(fieldName: string, isNumeric: boolean): Promise<FieldSize | null> {
+    if (isNumeric) {
+        const sizeInput = await vscode.window.showInputBox({
+            title: `Size for field '${fieldName}'`,
+            prompt: "Enter size as: N (for integer) or N,D (for decimal where N=total digits, D=decimal places)",
+            placeHolder: "10,2",
+            validateInput: validateFieldSize
+        });
+        if (!sizeInput) return null;
+        return parseSize(sizeInput);
+    };
+
+    const lengthInput = await vscode.window.showInputBox({
+        title: `Length for field '${fieldName}'`,
+        prompt: "Enter field length (1-32766)",
+        placeHolder: "10",
+        validateInput: validateFieldLength
+    });
+    if (!lengthInput) return null;
+    return { length: Number(lengthInput), decimals: 0 };
+};
+
+/**
+ * Builds the DDS line for a field created via the quick kind+usage+size flow: the data type
+ * column stays blank for alphanumeric (DDS's own default) and gets keyboard shift 'Y' for numeric —
+ * exactly what STRSDA itself generates for +B/+O/+I and +9/+6/+3. A numeric field with decimals
+ * also gets an auto-generated EDTWRD() appended right on the same line, so the decimal point
+ * actually shows, matching STRSDA's own behavior instead of leaving the user to add it by hand.
+ * @param name - The field's name
+ * @param isNumeric - Whether the chosen kind was numeric
+ * @param usage - The field's usage (O/B/I)
+ * @param size - The field's length and (for numeric) decimal places
+ * @param position - The field's screen row/column
+ */
+function generateQuickFieldLines(name: string, isNumeric: boolean, usage: FieldUsage, size: FieldSize, position: FieldPosition): string {
+    let line = ' '.repeat(80);
+    line = replaceAt(line, 5, 'A');
+    line = replaceAt(line, 18, name.padEnd(10, ' '));
+    line = replaceAt(line, 32, size.length.toString().padStart(2, ' '));
+
+    if (isNumeric) {
+        line = replaceAt(line, 34, 'Y');
+        if (size.decimals) {
+            line = replaceAt(line, 35, size.decimals.toString().padStart(2, ' '));
+        };
+    };
+
+    if (usage.type !== 'O') {
+        line = replaceAt(line, 37, usage.type);
+    };
+
+    line = replaceAt(line, 38, position.row.toString().padStart(3, ' '));
+    line = replaceAt(line, 41, position.column.toString().padStart(3, ' '));
+
+    if (isNumeric && size.decimals) {
+        const mask = ' '.repeat(size.length - size.decimals) + '.' + ' '.repeat(size.decimals);
+        line = replaceAt(line, 44, `EDTWRD('${mask}')`);
+    };
+
+    return line.trimEnd();
+};
+
+/**
+ * Collects a field's full definition via the original, exhaustive flow — usage including Hidden/
+ * Message/Program-to-system, the referenced-field option, and the complete list of DDS field
+ * types — reached through the quick kind picker's "More options..." entry.
+ * @param fieldName - The field's name, shown in the various prompts' titles
+ */
+async function collectAdvancedFieldDefinition(fieldName: string): Promise<{
+    usage: FieldUsage;
+    isReferenced: boolean;
+    reference?: FieldReference;
+    typeConfig?: FieldTypeConfig;
+} | null> {
     const usage = await collectFieldUsage(fieldName);
     if (!usage) return null;
 
-    // Step 3: Check if field is referenced
     const isReferenced = await promptForFieldReference();
     if (isReferenced === null) return null;
 
-    // Step 4: Get reference or type configuration
-    let reference: FieldReference | undefined | null;
-    let typeConfig: FieldTypeConfig | undefined | null;
+    let reference: FieldReference | undefined;
+    let typeConfig: FieldTypeConfig | undefined;
 
     if (isReferenced) {
-        reference = await collectFieldReference(fieldName);
-        if (!reference) return null;
+        const collectedReference = await collectFieldReference(fieldName);
+        if (!collectedReference) return null;
+        reference = collectedReference;
     } else {
-        typeConfig = await collectFieldTypeConfiguration(fieldName);
-        if (!typeConfig) return null;
+        const collectedTypeConfig = await collectFieldTypeConfiguration(fieldName);
+        if (!collectedTypeConfig) return null;
+        typeConfig = collectedTypeConfig;
     };
 
-    // Step 5: Get field position (skip for Hidden, Message, and Program-to-system fields)
+    return { usage, isReferenced, reference, typeConfig };
+};
+
+/**
+ * Collects complete configuration for a new field through user interaction, and returns the DDS
+ * line ready to insert: the quick kind+usage+size flow in the common case, or (via its
+ * "More options..." entry) the full usage/referenced-field/type flow for anything else.
+ * @param recordElement - The record element where the field will be added
+ * @returns The field's name (for the success message) and its generated source line, or null if cancelled
+ */
+async function collectNewFieldConfiguration(editor: vscode.TextEditor, recordElement: any): Promise<{ name: string; line: string } | null> {
+    const fieldName = await promptForNewFieldName(recordElement);
+    if (!fieldName) return null;
+
+    const quickKind = await collectQuickFieldKind(fieldName);
+    if (quickKind === null) return null;
+
+    if (quickKind !== 'advanced') {
+        const size = await collectQuickFieldSize(fieldName, quickKind.isNumeric);
+        if (!size) return null;
+
+        const position = await collectFieldPosition(editor, fieldName, recordElement, size);
+        if (!position) return null;
+
+        return { name: fieldName, line: generateQuickFieldLines(fieldName, quickKind.isNumeric, quickKind.usage, size, position) };
+    };
+
+    const advanced = await collectAdvancedFieldDefinition(fieldName);
+    if (!advanced) return null;
+
+    // Hidden/Message/Program-to-system usage doesn't have a screen position.
     let position: FieldPosition;
-    if (usage.type === 'H' || usage.type === 'M' || usage.type === 'P') {
-        // These field types don't have screen positions
+    if (advanced.usage.type === 'H' || advanced.usage.type === 'M' || advanced.usage.type === 'P') {
         position = { row: 0, column: 0 };
     } else {
-        const fieldPosition = await collectFieldPosition(editor, fieldName, recordElement, typeConfig?.size);
+        const fieldPosition = await collectFieldPosition(editor, fieldName, recordElement, advanced.typeConfig?.size);
         if (!fieldPosition) return null;
         position = fieldPosition;
     };
-    if (reference === null) reference = undefined;
-    if (typeConfig === null) typeConfig = undefined;
-    
+
     return {
         name: fieldName,
-        position,
-        usage,
-        isReferenced,
-        reference,
-        typeConfig
+        line: generateNewFieldLine({
+            name: fieldName,
+            position,
+            usage: advanced.usage,
+            isReferenced: advanced.isReferenced,
+            reference: advanced.reference,
+            typeConfig: advanced.typeConfig
+        })
     };
 };
 

--- a/src/dspf-edit.commands/dspf-edit.fill-constant.ts
+++ b/src/dspf-edit.commands/dspf-edit.fill-constant.ts
@@ -68,8 +68,10 @@ async function handleFillConstantCommand(node: DdsNode): Promise<void> {
             return;
         };
 
-        // Fill the constant with the collected information 
-        await fillElement(editor, node.ddsElement, fillInformation);
+        // Fill the constant with the collected information
+        if (!(await fillElement(editor, node.ddsElement, fillInformation))) {
+            return;
+        };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
 
@@ -151,20 +153,19 @@ async function fillElement(
     editor: vscode.TextEditor,
     constant: DdsConstant,
     fillInformation: FillInformation
-): Promise<void> {
+): Promise<boolean> {
     const replacementPoint = constant.lineIndex;
     const constantToFill = constant.name.slice(1, -1);
-    
+
     if (replacementPoint <= 0 || replacementPoint > editor.document.lineCount) {
         throw new Error('Could not find position of the constant.');
     };
-    
+
     // Fill the constant.
     const filledConstant = fillConstantWithInfo(constantToFill, fillInformation);
-    
-    // Apply the constant update
-    await updateExistingConstant(editor, constant, filledConstant);    
 
+    // Apply the constant update
+    return updateExistingConstant(editor, constant, filledConstant);
 };
 
 // HELPER FUNCTIONS

--- a/src/dspf-edit.commands/dspf-edit.move-constants.ts
+++ b/src/dspf-edit.commands/dspf-edit.move-constants.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fileSizeAttributes, fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { checkForEditorAndDocument, findEndLineIndex } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, findEndLineIndex, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 
 /**
  * Gets the maximum columns value from fileSizeAttributes
@@ -136,7 +136,9 @@ async function handleMoveConstantCommand(node: DdsNode, offset: number): Promise
         }
 
         // Apply the constant update with new position
-        await moveConstantToNewPosition(editor, element, newPosition);
+        if (!(await moveConstantToNewPosition(editor, element, newPosition))) {
+            return;
+        };
 
         // Set focus on the editor and position cursor on the constant
         await vscode.window.showTextDocument(editor.document, {
@@ -177,7 +179,7 @@ async function moveConstantToNewPosition(
     editor: vscode.TextEditor,
     element: any,
     newPosition: number
-): Promise<void> {
+): Promise<boolean> {
     const uri = editor.document.uri;
     const workspaceEdit = new vscode.WorkspaceEdit();
 
@@ -192,5 +194,5 @@ async function moveConstantToNewPosition(
 
     workspaceEdit.replace(uri, range, formattedPos);
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'move the constant');
 }

--- a/src/dspf-edit.commands/dspf-edit.move-fields.ts
+++ b/src/dspf-edit.commands/dspf-edit.move-fields.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fileSizeAttributes, fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { checkForEditorAndDocument, findEndLineIndex } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, findEndLineIndex, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 
 /**
  * Gets the maximum columns value from fileSizeAttributes
@@ -136,7 +136,9 @@ async function handleMoveFieldCommand(node: DdsNode, offset: number): Promise<vo
         }
 
         // Apply the field update with new position
-        await moveFieldToNewPosition(editor, element, newPosition);
+        if (!(await moveFieldToNewPosition(editor, element, newPosition))) {
+            return;
+        };
 
         // Set focus on the editor and position cursor on the field
         await vscode.window.showTextDocument(editor.document, {
@@ -177,7 +179,7 @@ async function moveFieldToNewPosition(
     editor: vscode.TextEditor,
     element: any,
     newPosition: number
-): Promise<void> {
+): Promise<boolean> {
     const uri = editor.document.uri;
     const workspaceEdit = new vscode.WorkspaceEdit();
 
@@ -192,5 +194,5 @@ async function moveFieldToNewPosition(
 
     workspaceEdit.replace(uri, range, formattedPos);
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'move the field');
 }

--- a/src/dspf-edit.commands/dspf-edit.new-record.ts
+++ b/src/dspf-edit.commands/dspf-edit.new-record.ts
@@ -7,8 +7,8 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { recordExists, DspsizConfig,
-    checkIfDspsizNeeded, collectDspsizConfiguration, generateDspsizLines, 
-    checkForEditorAndDocument} from '../dspf-edit.utils/dspf-edit.helper';
+    checkIfDspsizNeeded, collectDspsizConfiguration, generateDspsizLines,
+    checkForEditorAndDocument, applyWorkspaceEdit} from '../dspf-edit.utils/dspf-edit.helper';
 import { fileSizeAttributes } from '../dspf-edit.model/dspf-edit.model';
 
 // INTERFACES AND TYPES
@@ -113,7 +113,9 @@ async function handleNewRecordCommand(node: DdsNode): Promise<void> {
         const recordLines = generateRecordLines(recordConfig);
 
         // Insert the new record into the document
-        await insertNewRecord(editor, recordLines);
+        if (!(await insertNewRecord(editor, recordLines))) {
+            return;
+        };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
 
@@ -725,7 +727,7 @@ function generateSubfileOtherLines(): string[] {
  * @param editor - The active text editor
  * @param lines - Array of DDS lines to insert
  */
-async function insertNewRecord(editor: vscode.TextEditor, lines: string[]): Promise<void> {
+async function insertNewRecord(editor: vscode.TextEditor, lines: string[]): Promise<boolean> {
     const workspaceEdit = new vscode.WorkspaceEdit();
     const uri = editor.document.uri;
     const insertPosition = new vscode.Position(editor.document.lineCount, 0);
@@ -735,9 +737,9 @@ async function insertNewRecord(editor: vscode.TextEditor, lines: string[]): Prom
     };
     // Create the complete record text with proper line breaks
     const recordText = lines.join('\n');
-    
+
     workspaceEdit.insert(uri, insertPosition, recordText);
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'create the new record');
 };
 
 // UTILITY FUNCTIONS

--- a/src/dspf-edit.commands/dspf-edit.remove-attribute.ts
+++ b/src/dspf-edit.commands/dspf-edit.remove-attribute.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 import { fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
 
 // TYPE DEFINITIONS
@@ -108,7 +108,9 @@ async function handleRemoveAttributeCommand(node: DdsNode): Promise<void> {
         };
 
         // Execute the deletion
-        await executeElementDeletion(editor, deletionPlan);
+        if (!(await executeElementDeletion(editor, deletionPlan))) {
+            return;
+        };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
 
@@ -148,10 +150,9 @@ async function showDeletionConfirmation(): Promise<boolean> {
  * @param deletionPlan - The plan containing details about what lines to delete
  */
 async function executeElementDeletion(
-    editor: vscode.TextEditor, 
+    editor: vscode.TextEditor,
     deletionPlan: ElementDeletionPlan
-): Promise<void> {
-    const workspaceEdit = new vscode.WorkspaceEdit();
+): Promise<boolean> {
     const uri = editor.document.uri;
 
     // Handle special case: first line has a field definition
@@ -163,34 +164,31 @@ async function executeElementDeletion(
         let after = lineText.length > 80 ? lineText.substring(80) : ""; // Keep any text after position 80
         let middle = " ".repeat(80 - 44); // Clear the attributes section with spaces
         let newLine = before + middle + after;
-        
+
         // Replace the entire line in the document
-        workspaceEdit.replace(
-            uri,
-            line.range,
-            newLine
-        );
-        await vscode.workspace.applyEdit(workspaceEdit);
-        
+        const fieldLineEdit = new vscode.WorkspaceEdit();
+        fieldLineEdit.replace(uri, line.range, newLine);
+        if (!(await applyWorkspaceEdit(fieldLineEdit, 'delete the attribute'))) {
+            return false;
+        };
+
         // If there are additional lines to delete, update the plan to start from next line
         if (deletionPlan.range.endLine > deletionPlan.range.startLine) {
             deletionPlan.range.startLine ++;
-            
-            // Process remaining lines in the range
-            await addDeletionRange(workspaceEdit, uri, editor, deletionPlan.range);
-            // Apply all deletions
-            await vscode.workspace.applyEdit(workspaceEdit);
 
+            // Process remaining lines in the range, as a separate edit against the now-updated document
+            const remainingLinesEdit = new vscode.WorkspaceEdit();
+            await addDeletionRange(remainingLinesEdit, uri, editor, deletionPlan.range);
+            return applyWorkspaceEdit(remainingLinesEdit, 'delete the attribute');
         } else {
             // Only one line to process, and we've already handled it
-            return;
+            return true;
         };
     } else {
         // Standard case: delete entire lines
-        // Process range
+        const workspaceEdit = new vscode.WorkspaceEdit();
         await addDeletionRange(workspaceEdit, uri, editor, deletionPlan.range);
-        // Apply all deletions
-        await vscode.workspace.applyEdit(workspaceEdit);
+        return applyWorkspaceEdit(workspaceEdit, 'delete the attribute');
     };
 };
 

--- a/src/dspf-edit.commands/dspf-edit.remove-element.ts
+++ b/src/dspf-edit.commands/dspf-edit.remove-element.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fieldsPerRecords, FieldInfo, ConstantInfo } from '../dspf-edit.model/dspf-edit.model';
-import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 
 // TYPE DEFINITIONS
 
@@ -96,7 +96,9 @@ async function handleRemoveElementCommand(node: DdsNode): Promise<void> {
         };
 
         // Execute the deletion
-        await executeElementDeletion(editor, deletionPlan);
+        if (!(await executeElementDeletion(editor, deletionPlan))) {
+            return;
+        };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
 
@@ -227,9 +229,9 @@ async function showDeletionConfirmation(deletionPlan: ElementDeletionPlan): Prom
  * @param deletionPlan - The plan for what to delete
  */
 async function executeElementDeletion(
-    editor: vscode.TextEditor, 
+    editor: vscode.TextEditor,
     deletionPlan: ElementDeletionPlan
-): Promise<void> {
+): Promise<boolean> {
     const workspaceEdit = new vscode.WorkspaceEdit();
     const uri = editor.document.uri;
 
@@ -242,7 +244,7 @@ async function executeElementDeletion(
     };
 
     // Apply all deletions
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'delete the element');
 };
 
 /**

--- a/src/dspf-edit.commands/dspf-edit.rename.ts
+++ b/src/dspf-edit.commands/dspf-edit.rename.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 import { fieldsPerRecords, records } from '../dspf-edit.model/dspf-edit.model';
 
 // TYPE DEFINITIONS
@@ -117,7 +117,9 @@ async function handleRenameFieldCommand(node: DdsNode): Promise<void> {
         };
 
         // Execute the rename
-        await executeFieldRename(editor, renameInfo);
+        if (!(await executeFieldRename(editor, renameInfo))) {
+            return;
+        };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
 
@@ -185,7 +187,9 @@ async function handleRenameRecordCommand(node: DdsNode): Promise<void> {
         };
 
         // Execute the rename
-        await executeRecordRename(editor, renameInfo);
+        if (!(await executeRecordRename(editor, renameInfo))) {
+            return;
+        };
 
         vscode.window.showInformationMessage(`Record "${oldName}" renamed to "${newName}" successfully.`);
 
@@ -347,7 +351,7 @@ async function showRecordRenameConfirmation(renameInfo: RecordRenameInfo): Promi
 async function executeFieldRename(
     editor: vscode.TextEditor,
     renameInfo: FieldRenameInfo
-): Promise<void> {
+): Promise<boolean> {
     const workspaceEdit = new vscode.WorkspaceEdit();
     const uri = editor.document.uri;
     const document = editor.document;
@@ -367,7 +371,7 @@ async function executeFieldRename(
         vscode.window.showWarningMessage(
             `Field name mismatch at line ${renameInfo.lineIndex + 1}. Expected "${renameInfo.oldName}", found "${currentFieldInLine}".`
         );
-        return;
+        return false;
     };
 
     // Create the new field name, padded to 10 characters
@@ -382,7 +386,7 @@ async function executeFieldRename(
     workspaceEdit.replace(uri, line.range, newLine);
 
     // Apply the edit
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'rename the field');
 };
 
 /**
@@ -393,7 +397,7 @@ async function executeFieldRename(
 async function executeRecordRename(
     editor: vscode.TextEditor,
     renameInfo: RecordRenameInfo
-): Promise<void> {
+): Promise<boolean> {
     const workspaceEdit = new vscode.WorkspaceEdit();
     const uri = editor.document.uri;
     const document = editor.document;
@@ -421,5 +425,5 @@ async function executeRecordRename(
     };
 
     // Apply all edits
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'rename the record');
 };

--- a/src/dspf-edit.commands/dspf-edit.sort-elements.ts
+++ b/src/dspf-edit.commands/dspf-edit.sort-elements.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fieldsPerRecords, FieldInfo, ConstantInfo, DdsRecord } from '../dspf-edit.model/dspf-edit.model';
-import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
@@ -85,7 +85,9 @@ async function handleSortElementsCommand(node: DdsNode): Promise<void> {
         const sortedElements = sortElementsByCriteria(elementsWithAttributes, sortCriteria);
 
         // Apply the sort to the document
-        await applySortToDocument(editor, sortedElements);
+        if (!(await applySortToDocument(editor, sortedElements))) {
+            return;
+        };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
 
@@ -356,8 +358,8 @@ function sortElementsByCriteria(elements: ElementWithAttributes[], criteria: Sor
  * @param editor - The active text editor
  * @param sortedElements - Array of elements in the desired order
  */
-async function applySortToDocument(editor: vscode.TextEditor, sortedElements: ElementWithAttributes[]): Promise<void> {
-    if (sortedElements.length === 0) return;
+async function applySortToDocument(editor: vscode.TextEditor, sortedElements: ElementWithAttributes[]): Promise<boolean> {
+    if (sortedElements.length === 0) return true;
 
     const document = editor.document;
     const workspaceEdit = new vscode.WorkspaceEdit();
@@ -394,9 +396,9 @@ async function applySortToDocument(editor: vscode.TextEditor, sortedElements: El
         const rangeToReplace = new vscode.Range(startPosition, endPosition);
         
         workspaceEdit.replace(uri, rangeToReplace, sortedContent);
-        
-        await vscode.workspace.applyEdit(workspaceEdit);
-        
+
+        return await applyWorkspaceEdit(workspaceEdit, 'sort the elements');
+
     } catch (error) {
         console.error('Error in applySortToDocument:', error);
         throw error;

--- a/src/dspf-edit.commands/dspf-edit.window-resize.ts
+++ b/src/dspf-edit.commands/dspf-edit.window-resize.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fileSizeAttributes, fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
@@ -122,7 +122,9 @@ async function handleWindowResizeCommand(node: DdsNode): Promise<void> {
         };
 
         // Apply the window resize
-        await applyWindowResize(editor, element, windowLine, newDimensions);
+        if (!(await applyWindowResize(editor, element, windowLine, newDimensions))) {
+            return;
+        };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
 
@@ -496,7 +498,7 @@ async function applyWindowResize(
     element: any,
     windowLine : number,
     newDimensions: CurrentWindowDimensions
-): Promise<void> {
+): Promise<boolean> {
 
 /*    const windowLine = findWindowKeywordLine(editor, element);
     if (windowLine === -1) {
@@ -517,7 +519,7 @@ async function applyWindowResize(
     );
     workspaceEdit.replace(uri, line.range, updatedLine);
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'resize the window');
 };
 
 /**

--- a/src/dspf-edit.commands/dspf-edit.window-title.ts
+++ b/src/dspf-edit.commands/dspf-edit.window-title.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { FieldsPerRecord, fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 import { generateWindowTitleLines } from './dspf-edit.new-record';
 
 type TitleAlign = 'LEFT' | 'CENTER' | 'RIGHT';
@@ -95,7 +95,9 @@ export async function editWindowTitleForRecord(recordName: string): Promise<void
                 vscode.window.showInformationMessage('No title entered.');
                 return;
             };
-            await removeWindowTitle(editor, existing);
+            if (!(await removeWindowTitle(editor, existing))) {
+                return;
+            };
             vscode.window.showInformationMessage(`Removed window title for '${recordName}'.`);
             return;
         };
@@ -111,7 +113,9 @@ export async function editWindowTitleForRecord(recordName: string): Promise<void
         };
 
         const anchorLineIndex = windowAttr.lastLineIndex ?? windowAttr.lineIndex;
-        await applyWindowTitle(editor, anchorLineIndex, existing, text, align, position);
+        if (!(await applyWindowTitle(editor, anchorLineIndex, existing, text, align, position))) {
+            return;
+        };
 
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
@@ -256,7 +260,7 @@ async function applyWindowTitle(
     text: string,
     align: TitleAlign,
     position: TitlePosition
-): Promise<void> {
+): Promise<boolean> {
     const lines = generateWindowTitleLines(text, align, position);
     const workspaceEdit = new vscode.WorkspaceEdit();
     const uri = editor.document.uri;
@@ -272,7 +276,7 @@ async function applyWindowTitle(
         workspaceEdit.insert(uri, insertPosition, lines.join('\n') + '\n');
     };
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'update the window title');
 };
 
 /**
@@ -280,7 +284,7 @@ async function applyWindowTitle(
  * @param editor - The active text editor
  * @param existing - The title to remove
  */
-async function removeWindowTitle(editor: vscode.TextEditor, existing: ExistingWindowTitle): Promise<void> {
+async function removeWindowTitle(editor: vscode.TextEditor, existing: ExistingWindowTitle): Promise<boolean> {
     const workspaceEdit = new vscode.WorkspaceEdit();
     const uri = editor.document.uri;
 
@@ -290,5 +294,5 @@ async function removeWindowTitle(editor: vscode.TextEditor, existing: ExistingWi
     );
     workspaceEdit.delete(uri, range);
 
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'remove the window title');
 };

--- a/src/dspf-edit.model/dspf-edit.model.ts
+++ b/src/dspf-edit.model/dspf-edit.model.ts
@@ -261,7 +261,22 @@ export interface FieldsPerRecord {
 
 export let records: string[] = [];
 export let fieldsPerRecords: FieldsPerRecord[] = [];
-export let attributesFileLevel: DdsAttribute[] = []; 
+export let attributesFileLevel: DdsAttribute[] = [];
+
+/**
+ * DDS system keywords whose on-screen text is fixed regardless of whatever else is parsed for the
+ * element they're coded on. Usable either as a field's name (in place of a regular
+ * type/length/usage definition — the system supplies the value) or coded bare, unquoted, in the
+ * position a constant's literal text would occupy (the more common real-world form). Shared by the
+ * preview (what text/width to draw) and the "Center" command (what width to center around) so both
+ * agree on these fields' real screen footprint instead of the raw, misleadingly short source name.
+ */
+export const SYSTEM_FIELD_PLACEHOLDER: Record<string, string> = {
+  DATE: 'DD-DD-DD',
+  TIME: 'TT:TT:TT',
+  USER: 'UUUUUUUUUU',
+  SYSNAME: 'SSSSSSSS'
+};
 
 // UTILITY FUNCTIONS
 

--- a/src/dspf-edit.parser/dspf-edit.parser.ts
+++ b/src/dspf-edit.parser/dspf-edit.parser.ts
@@ -262,6 +262,13 @@ function isSubfileRecord(attributes?: DdsAttribute[]): boolean {
  * @param lastRecord - Current record name
  * @returns Parsing result with field element
  */
+/**
+ * System-defined length for DDS data types whose length is never written in the source's length
+ * columns (position 30-31) — DDS itself derives it, so those columns are legitimately left blank.
+ * Matches the defaults `edit-field.ts`'s `getSystemDefinedLength` uses when creating one of these.
+ */
+const FIXED_LENGTH_BY_TYPE: Record<string, number> = { L: 10, T: 8, Z: 26 };
+
 function parseFieldElement(
     lines: string[],
     lineIndex: number,
@@ -270,7 +277,7 @@ function parseFieldElement(
     lastRecord: string
 ) {
     const type = trimmedLine[29];
-    const length = Number(trimmedLine.substring(27, 29).trim());
+    const length = Number(trimmedLine.substring(27, 29).trim()) || FIXED_LENGTH_BY_TYPE[type] || 0;
     const decimals = trimmedLine.substring(30, 32) !== ' ' ? Number(trimmedLine.substring(30, 32).trim()) : 0;
     const usage = trimmedLine[32] !== ' ' ? trimmedLine[32] : ' ';
     const isHidden = trimmedLine[32] === 'H';
@@ -651,8 +658,13 @@ function addFieldToRecord(field: any, recordEntry: any): void {
  * @param recordEntry - Record entry to add constant to
  */
 function addConstantToRecord(constant: any, recordEntry: any): void {
-    // Remove quotes from constant name for storage
-    const constantName = constant.name.slice(1, -1);
+    // Remove quotes from constant name for storage — but only when it's actually a quoted
+    // literal. A DDS system keyword (DATE, TIME, USER, SYSNAME) can be coded bare, in the same
+    // position a quoted constant would occupy; blindly slicing it would eat its first/last letter.
+    const rawName: string = constant.name;
+    const constantName = rawName.length >= 2 && rawName.startsWith("'") && rawName.endsWith("'")
+        ? rawName.slice(1, -1)
+        : rawName;
 
     // Process attributes preserving their indicators
     const processedAttributes = constant.attributes?.map((attr: any) => ({
@@ -663,8 +675,11 @@ function addConstantToRecord(constant: any, recordEntry: any): void {
         displayFormat: attr.displayFormat
     })).filter((attr: any) => attr.value) || [];
 
-    // Avoid duplicate constants
-    if (!recordEntry.constants.some((c: any) => c.name === constantName)) {
+    // Guards against this same source line being linked twice — not against two constants sharing
+    // identical text: DDS pixel-art constructions legitimately repeat the same blank/space text
+    // (e.g. '   ' or ' ') at dozens of different positions to build a colored block pattern, and
+    // comparing by text alone (as this used to) silently dropped all but the first of each.
+    if (!recordEntry.constants.some((c: any) => c.lineIndex === constant.lineIndex)) {
         recordEntry.constants.push({
             name: constantName,
             type: undefined,

--- a/src/dspf-edit.utils/dspf-edit.helper.ts
+++ b/src/dspf-edit.utils/dspf-edit.helper.ts
@@ -6,6 +6,7 @@
 
 
 import * as vscode from 'vscode';
+import * as fs from 'fs';
 import { DdsElement, DdsIndicator, DdsAttribute, records, FieldsPerRecord, ConstantInfo, FieldInfo, fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
 import { DdsTreeProvider } from '../dspf-edit.providers/dspf-edit.providers';
 import { parseDocument } from '../dspf-edit.parser/dspf-edit.parser';
@@ -558,20 +559,20 @@ export function generateDspsizLines(dspsizConfig: DspsizConfig): string[] {
  * @param editor - The active text editor
  * @param dspsizLines - Array of DSPSIZ lines to insert
  */
-export async function insertDspsizLines(editor: vscode.TextEditor, dspsizLines: string[]): Promise<void> {
-    if (dspsizLines.length === 0) return;
+export async function insertDspsizLines(editor: vscode.TextEditor, dspsizLines: string[]): Promise<boolean> {
+    if (dspsizLines.length === 0) return true;
 
     const workspaceEdit = new vscode.WorkspaceEdit();
     const uri = editor.document.uri;
-    
+
     // Find the correct insertion point (before first record, after any existing file-level attributes)
     const insertionPoint = findDspsizInsertionPoint(editor);
-    
+
     // Create the complete DSPSIZ text with proper line breaks
     const dspsizText = dspsizLines.join('\n') + '\n';
-    
+
     workspaceEdit.insert(uri, new vscode.Position(insertionPoint, 0), dspsizText);
-    await vscode.workspace.applyEdit(workspaceEdit);
+    return applyWorkspaceEdit(workspaceEdit, 'add the DSPSIZ specification');
 };
 
 /**
@@ -634,7 +635,9 @@ export async function handleDspsizWorkflow(editor: vscode.TextEditor, operationN
 
     // Generate and insert DSPSIZ lines
     const dspsizLines = generateDspsizLines(dspsizConfig);
-    await insertDspsizLines(editor, dspsizLines);
+    if (!(await insertDspsizLines(editor, dspsizLines))) {
+        return null;
+    };
 
     // Show informational message
     const sizesText = dspsizConfig.sizes.map(s => `${s.rows}x${s.cols}`).join(', ');
@@ -683,6 +686,66 @@ export function checkForEditorAndDocument() : { editor : vscode.TextEditor | und
     };
 
     return { editor, document };
+};
+
+/**
+ * Whether a URI points at a file the current user can't write to. `vscode.workspace.fs.stat()`'s
+ * `permissions` field is unreliable for this: local disk providers commonly leave it unset even
+ * for an OS-level read-only file (confirmed — VS Code doesn't even show its own lock icon on such
+ * a file's tab), since it's only *required* to be populated by providers that want to opt into
+ * VS Code's read-only UI, not a live reflection of OS permission bits. For a `file:` URI, checking
+ * the OS permission bits directly via Node's `fs` is the only reliable signal. For anything else
+ * (a virtual filesystem provider — e.g. an IBM i source member opened through Code for IBM i),
+ * `stat()` is the only option available, so it's used as a best-effort fallback.
+ * @param uri - The document URI to check
+ */
+async function isReadOnlyFile(uri: vscode.Uri): Promise<boolean> {
+    if (uri.scheme === 'file') {
+        try {
+            await fs.promises.access(uri.fsPath, fs.constants.W_OK);
+            return false;
+        } catch {
+            return true;
+        };
+    };
+
+    try {
+        const stat = await vscode.workspace.fs.stat(uri);
+        return Boolean((stat.permissions ?? 0) & vscode.FilePermission.Readonly);
+    } catch {
+        return false;
+    };
+};
+
+/**
+ * Applies a WorkspaceEdit and reports whether it actually succeeded. Checked in two layers:
+ *
+ * 1. Proactively, via `isReadOnlyFile()`: a file that's read-only still lets VS Code apply the
+ *    edit to the in-memory buffer — it only fails later, silently from this extension's point of
+ *    view, when the user tries to save and gets VS Code's own permission-denied error. Catching it
+ *    here means the user finds out immediately, from the edit they just made, instead of
+ *    discovering it minutes later at save time.
+ * 2. Reactively, via `applyEdit`'s own return value: VS Code returns `false` (rather than
+ *    throwing) when it rejects an edit for any other reason, which a caller that just `await`s the
+ *    call and moves on would otherwise miss entirely.
+ *
+ * Callers should check the returned boolean and skip their own follow-up (success toast,
+ * forceReparse, etc.) when it's `false`.
+ * @param workspaceEdit - The edit to apply
+ * @param context - Short description of what was being done, used in the failure message (e.g. "add the field")
+ */
+export async function applyWorkspaceEdit(workspaceEdit: vscode.WorkspaceEdit, context: string): Promise<boolean> {
+    const [uri] = workspaceEdit.entries()[0] ?? [];
+    if (uri && (await isReadOnlyFile(uri))) {
+        vscode.window.showErrorMessage(`Could not ${context} — the document is read-only.`);
+        return false;
+    };
+
+    const success = await vscode.workspace.applyEdit(workspaceEdit);
+    if (!success) {
+        vscode.window.showErrorMessage(`Could not ${context} — the document may be read-only.`);
+    };
+    return success;
 };
 
 /**

--- a/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
@@ -5,8 +5,8 @@
 */
 
 import * as vscode from 'vscode';
-import { FieldsPerRecord, DdsSize, DdsAttribute, AttributeWithIndicators, DdsIndicator, fieldsPerRecords, records, getDefaultSize, getAvailableDisplayFormats, getSizeForFormat } from '../dspf-edit.model/dspf-edit.model';
-import { checkForEditorAndDocument, updateTreeProvider } from '../dspf-edit.utils/dspf-edit.helper';
+import { FieldsPerRecord, DdsSize, DdsAttribute, AttributeWithIndicators, DdsIndicator, fieldsPerRecords, records, getDefaultSize, getAvailableDisplayFormats, getSizeForFormat, SYSTEM_FIELD_PLACEHOLDER } from '../dspf-edit.model/dspf-edit.model';
+import { checkForEditorAndDocument, updateTreeProvider, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 import { DdsTreeProvider } from '../dspf-edit.providers/dspf-edit.providers';
 import { resolveRecordSizeForFormat } from '../dspf-edit.parser/dspf-edit.parser';
 import { editWindowTitleForRecord } from '../dspf-edit.commands/dspf-edit.window-title';
@@ -77,25 +77,57 @@ const FIELD_USAGE_PLACEHOLDER: Record<'alpha' | 'numeric', Record<string, string
  * Builds the placeholder text shown across a field's width, based on its data type and usage
  * (O=output, B=both, I=input), matching the classic screen-design-aid convention.
  * Falls back to the field name if the usage code isn't one of O/B/I.
- * @param name - Field name (used as a fallback label)
- * @param type - DDS data type code ('A' = alphanumeric; anything else is treated as numeric)
+ * @param name - Field name (used as a fallback label, and to detect a system keyword field)
+ * @param type - DDS data type code; blank (DDS's own default when no decimals are given) or 'A'
+ * is alphanumeric, anything else (Y, S, L, T, Z, ...) is treated as numeric
  * @param usage - DDS usage code (O, B, I, H, ...)
  * @param length - Field length, i.e. how many placeholder characters to repeat
+ * @param editWordMask - The field's EDTWRD() mask text, if any (e.g. '   .  ') — when present, its
+ * blanks are filled with the placeholder character instead of just repeating it for `length`, so
+ * an edited numeric field previews with its decimal point (or other insert characters) in place.
  */
-function getFieldPlaceholderText(name: string, type: string | undefined, usage: string | undefined, length: number): string {
-    const isNumeric = type !== 'A';
-    const usageCode = (usage || '').trim().toUpperCase();
+function getFieldPlaceholderText(name: string, type: string | undefined, usage: string | undefined, length: number, editWordMask?: string | null): string {
+    const systemPlaceholder = SYSTEM_FIELD_PLACEHOLDER[name.trim().toUpperCase()];
+    if (systemPlaceholder) {
+        return systemPlaceholder;
+    };
+
+    const trimmedType = (type || '').trim();
+    const isNumeric = trimmedType !== '' && trimmedType !== 'A';
+    // A blank usage column means Output — DDS's own default (see generateNewFieldLine, which
+    // leaves it blank for that same reason) — not "no usage code".
+    const usageCode = (usage || '').trim().toUpperCase() || 'O';
     const placeholderChar = FIELD_USAGE_PLACEHOLDER[isNumeric ? 'numeric' : 'alpha'][usageCode];
 
     if (!placeholderChar) {
         return name;
     };
 
+    if (editWordMask) {
+        return editWordMask.split('').map(ch => ch === ' ' ? placeholderChar : ch).join('');
+    };
+
     return placeholderChar.repeat(Math.max(length, 1));
+};
+
+/**
+ * Extracts a field's EDTWRD() mask (the text between its quotes), if it carries one.
+ * @param attributes - The element's DDS attributes
+ */
+function getEditWordMask(attributes: AttributeWithIndicators[] | undefined): string | null {
+    const attr = attributes?.find(a => /^EDTWRD\(/i.test(a.value));
+    if (!attr) {
+        return null;
+    };
+
+    return attr.value.match(/^EDTWRD\(\s*'([^']*)'\s*\)$/i)?.[1] ?? null;
 };
 
 /** Default 5250-style green, used when a field/constant has no COLOR() keyword. */
 const DEFAULT_COLOR = '#00ff00';
+
+/** What DSPATR(HI) alone (no explicit COLOR()) renders as — matching a real 5250 display. */
+const HIGH_INTENSITY_COLOR = '#ffffff';
 
 /** Maps DDS COLOR() keyword codes to their on-screen color. */
 const DDS_COLOR_MAP: Record<string, string> = {
@@ -109,18 +141,21 @@ const DDS_COLOR_MAP: Record<string, string> = {
 };
 
 /**
- * Determines the display color for a field/constant based on its COLOR() DDS keyword, if any.
+ * Determines the display color for a field/constant based on its COLOR() DDS keyword, if any —
+ * falling back to white (not the default green) when DSPATR(HI) is set without an explicit color,
+ * matching a real 5250 display.
  * @param attributes - The element's DDS attributes
+ * @param highIntensity - Whether the element also carries DSPATR(HI)
  * @returns A CSS color string
  */
-function getDisplayColor(attributes: AttributeWithIndicators[] | undefined): string {
+function getDisplayColor(attributes: AttributeWithIndicators[] | undefined, highIntensity: boolean): string {
     const colorAttr = attributes?.find(attr => /^COLOR\([A-Z]{3}\)$/.test(attr.value));
     if (!colorAttr) {
-        return DEFAULT_COLOR;
+        return highIntensity ? HIGH_INTENSITY_COLOR : DEFAULT_COLOR;
     };
 
     const code = colorAttr.value.match(/^COLOR\(([A-Z]{3})\)$/)?.[1];
-    return (code && DDS_COLOR_MAP[code]) || DEFAULT_COLOR;
+    return (code && DDS_COLOR_MAP[code]) || (highIntensity ? HIGH_INTENSITY_COLOR : DEFAULT_COLOR);
 };
 
 /**
@@ -726,15 +761,21 @@ export class RecordPreviewPanel {
             if (trueRow > 0 && trueCol > 0) {
                 const activeAttrs = this.getActiveAttributes(field.attributes, useLiveIndicators);
                 const usageCode = (field.usage || '').trim().toUpperCase();
+                // The displayed text's own length drives the item's width/hit-box (below), not the
+                // parsed field length: a system keyword field (DATE, USER...) always renders at a
+                // fixed width of its own, regardless of whatever the source's length column holds
+                // — and an edited numeric field (EDTWRD) is one character wider per insert
+                // character (its decimal point, typically), which text.length already reflects.
+                const text = getFieldPlaceholderText(field.name, field.type, field.usage, field.length, getEditWordMask(activeAttrs));
                 items.push({
                     kind: 'field',
                     name: field.name,
-                    text: getFieldPlaceholderText(field.name, field.type, field.usage, field.length),
+                    text,
                     row: trueRow + rowOffset,
                     col: trueCol + colOffset,
-                    length: field.length,
+                    length: text.length,
                     lineIndex: field.lineIndex,
-                    color: getDisplayColor(activeAttrs),
+                    color: getDisplayColor(activeAttrs, hasDisplayAttribute(activeAttrs, 'HI')),
                     highIntensity: hasDisplayAttribute(activeAttrs, 'HI'),
                     reverseImage: hasDisplayAttribute(activeAttrs, 'RI') || this.hasActiveErrorMessage(field.attributes, useLiveIndicators),
                     blink: hasDisplayAttribute(activeAttrs, 'BL'),
@@ -763,15 +804,18 @@ export class RecordPreviewPanel {
 
             if (trueRow > 0 && trueCol > 0) {
                 const activeAttrs = this.getActiveAttributes(constant.attributes, useLiveIndicators);
+                // Same reasoning as the field loop above: a bare system keyword (DATE, USER...)
+                // renders at its own fixed width, not the raw constant text's length.
+                const text = SYSTEM_FIELD_PLACEHOLDER[constant.name.trim().toUpperCase()] || constant.name;
                 items.push({
                     kind: 'constant',
                     name: constant.name,
-                    text: constant.name,
+                    text,
                     row: trueRow + rowOffset,
                     col: trueCol + colOffset,
-                    length: constant.length,
+                    length: text.length,
                     lineIndex: constant.lineIndex,
-                    color: getDisplayColor(activeAttrs),
+                    color: getDisplayColor(activeAttrs, hasDisplayAttribute(activeAttrs, 'HI')),
                     highIntensity: hasDisplayAttribute(activeAttrs, 'HI'),
                     reverseImage: hasDisplayAttribute(activeAttrs, 'RI'),
                     blink: hasDisplayAttribute(activeAttrs, 'BL'),
@@ -966,17 +1010,8 @@ export class RecordPreviewPanel {
             return;
         };
 
-        if (message?.type === 'move'
-            && typeof message.lineIndex === 'number'
-            && typeof message.newRow === 'number'
-            && typeof message.newCol === 'number') {
-            await this.moveElement(
-                message.lineIndex,
-                message.newRow,
-                message.newCol,
-                typeof message.rowOffset === 'number' ? message.rowOffset : 0,
-                typeof message.colOffset === 'number' ? message.colOffset : 0
-            );
+        if (message?.type === 'move' && Array.isArray(message.moves)) {
+            await this.moveElements(message.moves);
             return;
         };
 
@@ -1002,6 +1037,16 @@ export class RecordPreviewPanel {
 
         if (message?.type === 'centerWindowHorizontally') {
             await this.centerWindowHorizontally();
+            return;
+        };
+
+        if (message?.type === 'centerElement' && typeof message.lineIndex === 'number') {
+            await this.centerElement(message.lineIndex);
+            return;
+        };
+
+        if (message?.type === 'elementMenu' && typeof message.lineIndex === 'number') {
+            await this.showElementMenu(message.lineIndex);
             return;
         };
 
@@ -1092,25 +1137,21 @@ export class RecordPreviewPanel {
     };
 
     /**
-     * Applies a drag-and-drop move from the preview: writes the new row/column back into the
-     * DDS source line, at the same fixed columns used by the move-fields/move-constants commands
-     * (raw columns 38-41 for the row/line spec, 41-44 for the column/position spec).
-     * The screen position is converted back to record-local coordinates using the offset that was
-     * applied when the item was built (non-zero only for a window's own fields/constants).
-     * @param lineIndex - Zero-based line index of the field/constant being moved
-     * @param newRow - New row, in screen coordinates (as shown in the preview grid)
-     * @param newCol - New column, in screen coordinates (as shown in the preview grid)
-     * @param rowOffset - Offset to subtract to get back to the record-local row
-     * @param colOffset - Offset to subtract to get back to the record-local column
+     * Applies a drag-and-drop move from the preview (one item, or several dragged together as a
+     * multi-selection): writes each one's new row/column back into its own DDS source line, at the
+     * same fixed columns used by the move-fields/move-constants commands (raw columns 38-41 for
+     * the row/line spec, 41-44 for the column/position spec). All moves land in a single
+     * WorkspaceEdit, so a group move is also a single undo step.
+     * Each screen position is converted back to record-local coordinates using the offset that was
+     * applied when its item was built (non-zero only for a window's own fields/constants).
+     * @param moves - One entry per moved field/constant: its line index, new screen row/col, and
+     * the row/col offset to subtract to get back to record-local coordinates
      */
-    private async moveElement(lineIndex: number, newRow: number, newCol: number, rowOffset: number, colOffset: number): Promise<void> {
+    private async moveElements(moves: Array<{ lineIndex: number; newRow: number; newCol: number; rowOffset: number; colOffset: number }>): Promise<void> {
         const { editor } = checkForEditorAndDocument();
-        if (!editor || lineIndex >= editor.document.lineCount) {
+        if (!editor) {
             return;
         };
-
-        const localRow = newRow - rowOffset;
-        const localCol = newCol - colOffset;
 
         // The raw source columns are always "Line spec" (38-41) / "Position spec" (41-44) — i.e.
         // row/col in that fixed order — for every record type. A subfile only swaps which of these
@@ -1119,10 +1160,21 @@ export class RecordPreviewPanel {
         const workspaceEdit = new vscode.WorkspaceEdit();
         const uri = editor.document.uri;
 
-        workspaceEdit.replace(uri, new vscode.Range(lineIndex, 38, lineIndex, 41), String(localRow).padStart(3, ' '));
-        workspaceEdit.replace(uri, new vscode.Range(lineIndex, 41, lineIndex, 44), String(localCol).padStart(3, ' '));
+        for (const move of moves) {
+            if (move.lineIndex >= editor.document.lineCount) {
+                continue;
+            };
 
-        await vscode.workspace.applyEdit(workspaceEdit);
+            const localRow = move.newRow - move.rowOffset;
+            const localCol = move.newCol - move.colOffset;
+
+            workspaceEdit.replace(uri, new vscode.Range(move.lineIndex, 38, move.lineIndex, 41), String(localRow).padStart(3, ' '));
+            workspaceEdit.replace(uri, new vscode.Range(move.lineIndex, 41, move.lineIndex, 44), String(localCol).padStart(3, ' '));
+        };
+
+        if (!(await applyWorkspaceEdit(workspaceEdit, moves.length > 1 ? 'move the elements' : 'move the element'))) {
+            return;
+        };
         this.forceReparse(editor.document);
     };
 
@@ -1151,7 +1203,9 @@ export class RecordPreviewPanel {
             return;
         };
 
-        await insertNewConstant(editor, { text, row, column: col, recordName: this.recordName });
+        if (!(await insertNewConstant(editor, { text, row, column: col, recordName: this.recordName }))) {
+            return;
+        };
         this.forceReparse(editor.document);
     };
 
@@ -1314,6 +1368,63 @@ export class RecordPreviewPanel {
     };
 
     /**
+     * Centers the selected field/constant horizontally, triggered from the preview's "Selection
+     * actions" bar (shown in the toolbar strip once something is selected — see the webview's
+     * `updateSelectionBar`). Runs the tree's own "Center" command (dspf-edit.center) against the
+     * matching tree node, so the exact same logic/validation is used regardless of which UI
+     * triggered it.
+     * @param lineIndex - Zero-based source line index of the selected field/constant
+     */
+    private async centerElement(lineIndex: number): Promise<void> {
+        const node = await this.treeProvider?.findFieldOrConstantNode(lineIndex);
+        if (!node) {
+            return;
+        };
+        await vscode.commands.executeCommand('dspf-edit.center', node);
+
+        const { editor } = checkForEditorAndDocument();
+        if (editor) {
+            this.forceReparse(editor.document);
+        };
+    };
+
+    /**
+     * Shows a compact actions menu for the selected field/constant (the "⋮ Actions" button in the
+     * "Selection actions" bar), offering the same color/attribute commands as the tree's context
+     * menu, run against the same tree node — kept short on purpose so the preview doesn't grow a
+     * second full context menu; anything not offered here is still reachable from the tree.
+     * @param lineIndex - Zero-based source line index of the selected field/constant
+     */
+    private async showElementMenu(lineIndex: number): Promise<void> {
+        const node = await this.treeProvider?.findFieldOrConstantNode(lineIndex);
+        if (!node || (node.ddsElement.kind !== 'field' && node.ddsElement.kind !== 'constant')) {
+            return;
+        };
+        const element = node.ddsElement;
+
+        const options: (vscode.QuickPickItem & { command: string })[] = [
+            { label: '$(paintcan) Add Color...', command: 'dspf-edit.add-color' },
+            { label: '$(symbol-color) Add Attribute...', command: 'dspf-edit.add-attribute' }
+        ];
+
+        const selection = await vscode.window.showQuickPick(options, {
+            title: `${element.name} — Actions`,
+            placeHolder: 'Select an action',
+            ignoreFocusOut: true
+        });
+        if (!selection) {
+            return;
+        };
+
+        await vscode.commands.executeCommand(selection.command, node);
+
+        const { editor } = checkForEditorAndDocument();
+        if (editor) {
+            this.forceReparse(editor.document);
+        };
+    };
+
+    /**
      * Rewrites the record's WINDOW(startRow startCol numRows numCols) keyword in place.
      */
     private async rewriteWindowKeyword(lineIndex: number, startRow: number, startCol: number, numRows: number, numCols: number): Promise<void> {
@@ -1334,7 +1445,9 @@ export class RecordPreviewPanel {
 
         const workspaceEdit = new vscode.WorkspaceEdit();
         workspaceEdit.replace(editor.document.uri, line.range, updatedLine);
-        await vscode.workspace.applyEdit(workspaceEdit);
+        if (!(await applyWorkspaceEdit(workspaceEdit, 'resize/move the window'))) {
+            return;
+        };
         this.forceReparse(editor.document);
     };
 
@@ -1387,7 +1500,9 @@ export class RecordPreviewPanel {
             );
         };
 
-        await vscode.workspace.applyEdit(workspaceEdit);
+        if (!(await applyWorkspaceEdit(workspaceEdit, 'change the subfile page size'))) {
+            return;
+        };
         this.forceReparse(editor.document);
     };
 
@@ -1452,7 +1567,7 @@ export class RecordPreviewPanel {
         align-items: center;
         gap: 6px;
     }
-    #actionBar button, #sflpagBar button {
+    #actionBar button, #sflpagBar button, #selectionBar button {
         background: #000000;
         color: #00ff00;
         border: 1px solid #333333;
@@ -1470,6 +1585,14 @@ export class RecordPreviewPanel {
         color: #666666;
         border-color: #222222;
         cursor: default;
+    }
+    #selectionBar {
+        display: none;
+        align-items: center;
+        gap: 6px;
+    }
+    #selectionLabel {
+        opacity: 0.7;
     }
     #indicatorBar {
         display: none;
@@ -1538,6 +1661,11 @@ export class RecordPreviewPanel {
         <button id="addConstantBtn" title="Click, then click a point in the screen to place a new constant there">+ Constant</button>
         <button id="gridDotsBtn" title="Show a dot in every empty character cell, to see spacing between fields/constants">⋅ Grid</button>
     </span>
+    <span id="selectionBar">
+        <span id="selectionLabel"></span>
+        <button id="selectionCenterBtn" title="Center horizontally">↔ Center</button>
+        <button id="selectionMenuBtn" title="More actions (color, attributes...)">⋮ Actions</button>
+    </span>
 </div>
 <div id="indicatorList"></div>
 <canvas id="screen"></canvas>
@@ -1560,6 +1688,10 @@ export class RecordPreviewPanel {
     const addConstantBtn = document.getElementById('addConstantBtn');
     const addFieldBtn = document.getElementById('addFieldBtn');
     const gridDotsBtn = document.getElementById('gridDotsBtn');
+    const selectionBar = document.getElementById('selectionBar');
+    const selectionLabel = document.getElementById('selectionLabel');
+    const selectionCenterBtn = document.getElementById('selectionCenterBtn');
+    const selectionMenuBtn = document.getElementById('selectionMenuBtn');
 
     const CHAR_W = 9;
     const CHAR_H = 18;
@@ -1590,7 +1722,7 @@ export class RecordPreviewPanel {
     let dragState = null;
     let resizeState = null;
     let moveWindowState = null;
-    let selectedLineIndex = null;
+    let selectedLineIndices = new Set();
     let currentRecordName = null;
     let placingKind = null; // null | 'constant' | 'field'
     let showGridDots = false;
@@ -1600,9 +1732,9 @@ export class RecordPreviewPanel {
     }
 
     function resolveItemRowCol(item, moveDelta) {
-        const isDragged = dragState && dragState.item === item;
-        let row = isDragged ? dragState.row : item.row;
-        let col = isDragged ? dragState.col : item.col;
+        const dragged = dragState && dragState.items.find(d => d.item === item);
+        let row = dragged ? dragged.startRow + dragState.rowDelta : item.row;
+        let col = dragged ? dragged.startCol + dragState.colDelta : item.col;
 
         // A "sameWindow" background item (the other half of an SFL/SFLCTL pair, sharing this exact
         // window) must move along with the window being dragged, same as the foreground record's
@@ -1624,9 +1756,9 @@ export class RecordPreviewPanel {
             return;
         }
 
-        const isSelected = item.lineIndex === selectedLineIndex;
+        const isSelected = selectedLineIndices.has(item.lineIndex);
         const { row, col } = resolveItemRowCol(item, moveDelta);
-        const isDragged = dragState && dragState.item === item;
+        const isDragged = Boolean(dragState && dragState.items.some(d => d.item === item));
 
         const x = (col - 1) * CHAR_W;
         const y = (row - 1) * CHAR_H;
@@ -1909,6 +2041,36 @@ export class RecordPreviewPanel {
             const centerY = menuY;
             currentCenterIconRect = drawIconButton(centerX, centerY, '↔', 'Center horizontally');
         }
+
+        updateSelectionBar();
+    }
+
+    // Selected field/constant's actions live in the toolbar strip, not floating over the canvas:
+    // a constant can be a single character (narrower than an icon button), and hovering it is also
+    // how a drag starts, so icons drawn on top of it would fight the drag gesture. Kept in sync
+    // from draw() itself, so it never goes stale (selection cleared, item edited/removed, etc.)
+    // relative to whatever was last rendered.
+    function updateSelectionBar() {
+        const items = currentItems.filter(i => selectedLineIndices.has(i.lineIndex) && i.isInteractive);
+
+        if (items.length === 0) {
+            selectionBar.style.display = 'none';
+            return;
+        }
+
+        // A multi-selection only supports moving (dragging), not centering or the actions menu —
+        // those stay single-item, so the buttons are hidden rather than made to act on a group.
+        const multi = items.length > 1;
+        if (multi) {
+            const kinds = new Set(items.map(i => i.kind));
+            const noun = kinds.size === 1 ? items[0].kind + 's' : 'fields/constants';
+            selectionLabel.textContent = items.length + ' ' + noun + ' selected';
+        } else {
+            selectionLabel.textContent = '1 ' + items[0].kind + ' selected';
+        }
+        selectionCenterBtn.style.display = multi ? 'none' : 'inline-block';
+        selectionMenuBtn.style.display = multi ? 'none' : 'inline-block';
+        selectionBar.style.display = 'inline-flex';
     }
 
     setInterval(() => {
@@ -2027,6 +2189,19 @@ export class RecordPreviewPanel {
         }
     });
 
+    // Both buttons are only shown (see updateSelectionBar) when exactly one item is selected.
+    selectionCenterBtn.addEventListener('click', () => {
+        if (selectedLineIndices.size === 1) {
+            vscode.postMessage({ type: 'centerElement', lineIndex: [...selectedLineIndices][0] });
+        }
+    });
+
+    selectionMenuBtn.addEventListener('click', () => {
+        if (selectedLineIndices.size === 1) {
+            vscode.postMessage({ type: 'elementMenu', lineIndex: [...selectedLineIndices][0] });
+        }
+    });
+
     sflpagMinusBtn.addEventListener('click', () => {
         vscode.postMessage({ type: 'sflpagDecrement' });
     });
@@ -2073,21 +2248,45 @@ export class RecordPreviewPanel {
         }
 
         const hit = findItemAt(ev);
-        selectedLineIndex = hit ? hit.lineIndex : null;
-        draw(currentSize, currentItems, currentBackgroundItems, currentWindowFrame, currentWindowTitle, currentOuterFrame);
+
+        // Ctrl/Cmd+click toggles an item in/out of a multi-selection, without starting a drag —
+        // the standard desktop convention for building up a selection one item at a time.
+        if (hit && (ev.ctrlKey || ev.metaKey)) {
+            if (selectedLineIndices.has(hit.lineIndex)) {
+                selectedLineIndices.delete(hit.lineIndex);
+            } else {
+                selectedLineIndices.add(hit.lineIndex);
+            }
+            draw(currentSize, currentItems, currentBackgroundItems, currentWindowFrame, currentWindowTitle, currentOuterFrame);
+            return;
+        }
 
         if (hit) {
+            // A plain click on an item already part of a multi-selection keeps the whole group
+            // selected (in case this turns into a group drag); mouseup collapses it to just this
+            // item if no drag actually happened. Clicking a different, unselected item replaces
+            // the selection immediately, same as before multi-select existed.
+            if (!selectedLineIndices.has(hit.lineIndex)) {
+                selectedLineIndices = new Set([hit.lineIndex]);
+                draw(currentSize, currentItems, currentBackgroundItems, currentWindowFrame, currentWindowTitle, currentOuterFrame);
+            }
+
             const { row, col } = cellAt(ev);
+            const draggedItems = currentItems.filter(i => selectedLineIndices.has(i.lineIndex) && i.isInteractive);
             dragState = {
-                item: hit,
+                items: draggedItems.map(i => ({ item: i, startRow: i.row, startCol: i.col })),
+                primaryLineIndex: hit.lineIndex,
                 grabRowOffset: row - hit.row,
                 grabColOffset: col - hit.col,
-                row: hit.row,
-                col: hit.col,
+                rowDelta: 0,
+                colDelta: 0,
                 moved: false
             };
             return;
         }
+
+        selectedLineIndices.clear();
+        draw(currentSize, currentItems, currentBackgroundItems, currentWindowFrame, currentWindowTitle, currentOuterFrame);
 
         // Clicked empty space inside the window's own frame (not on a field/constant): drag the window itself.
         if (isOverWindowFrame(ev)) {
@@ -2184,31 +2383,43 @@ export class RecordPreviewPanel {
         }
 
         const { row, col } = cellAt(ev);
-        const width = Math.max(dragState.item.length, dragState.item.text.length, 1);
+        const primary = dragState.items.find(d => d.item.lineIndex === dragState.primaryLineIndex);
+        const desiredRowDelta = (row - dragState.grabRowOffset) - primary.startRow;
+        const desiredColDelta = (col - dragState.grabColOffset) - primary.startCol;
 
-        // A window's own fields/constants can't be dragged past its frame; background (overlay)
-        // items, or items in a plain (non-window) record, are bounded by the whole canvas instead.
-        let minRow = 1, maxRow = currentSize.rows, minCol = 1, maxCol = currentSize.cols - width + 1;
-        if (currentWindowFrame && !dragState.item.isBackground) {
-            minRow = currentWindowFrame.row;
-            maxRow = Math.max(currentWindowFrame.row + currentWindowFrame.rows - 1, minRow);
-            // The window's own first content column can't be written to; the rest of its width,
-            // including the last column, is usable.
-            minCol = currentWindowFrame.col + 1;
-            maxCol = Math.max(currentWindowFrame.col + currentWindowFrame.cols - width, minCol);
+        // Every dragged item must stay within its own valid bounds (window frame vs. whole canvas,
+        // an SFL detail record's rows below its header, and its own width for the column limit) —
+        // computed per item, same as a single drag always did, then intersected so the group's
+        // shared delta can never push any one of them out of bounds.
+        let minRowDelta = -Infinity, maxRowDelta = Infinity, minColDelta = -Infinity, maxColDelta = Infinity;
+        for (const { item, startRow, startCol } of dragState.items) {
+            const width = Math.max(item.length, item.text.length, 1);
+            let itemMinRow = 1, itemMaxRow = currentSize.rows, itemMinCol = 1, itemMaxCol = currentSize.cols - width + 1;
+            if (currentWindowFrame && !item.isBackground) {
+                itemMinRow = currentWindowFrame.row;
+                itemMaxRow = Math.max(currentWindowFrame.row + currentWindowFrame.rows - 1, itemMinRow);
+                // The window's own first content column can't be written to; the rest of its width,
+                // including the last column, is usable.
+                itemMinCol = currentWindowFrame.col + 1;
+                itemMaxCol = Math.max(currentWindowFrame.col + currentWindowFrame.cols - width, itemMinCol);
+            }
+            // A subfile detail record's own rows can't be dragged up into its header's static content.
+            if (minDetailRow !== null && !item.isBackground) {
+                itemMinRow = Math.max(itemMinRow, minDetailRow);
+            }
+
+            minRowDelta = Math.max(minRowDelta, itemMinRow - startRow);
+            maxRowDelta = Math.min(maxRowDelta, itemMaxRow - startRow);
+            minColDelta = Math.max(minColDelta, itemMinCol - startCol);
+            maxColDelta = Math.min(maxColDelta, itemMaxCol - startCol);
         }
 
-        // A subfile detail record's own rows can't be dragged up into its header's static content.
-        if (minDetailRow !== null && !dragState.item.isBackground) {
-            minRow = Math.max(minRow, minDetailRow);
-        }
+        const newRowDelta = clamp(desiredRowDelta, minRowDelta, maxRowDelta);
+        const newColDelta = clamp(desiredColDelta, minColDelta, maxColDelta);
 
-        const newRow = clamp(row - dragState.grabRowOffset, minRow, maxRow);
-        const newCol = clamp(col - dragState.grabColOffset, minCol, maxCol);
-
-        if (newRow !== dragState.row || newCol !== dragState.col) {
-            dragState.row = newRow;
-            dragState.col = newCol;
+        if (newRowDelta !== dragState.rowDelta || newColDelta !== dragState.colDelta) {
+            dragState.rowDelta = newRowDelta;
+            dragState.colDelta = newColDelta;
             dragState.moved = true;
             draw(currentSize, currentItems, currentBackgroundItems, currentWindowFrame, currentWindowTitle, currentOuterFrame);
         }
@@ -2240,14 +2451,20 @@ export class RecordPreviewPanel {
         if (dragState.moved) {
             vscode.postMessage({
                 type: 'move',
-                lineIndex: dragState.item.lineIndex,
-                newRow: dragState.row,
-                newCol: dragState.col,
-                rowOffset: dragState.item.rowOffset,
-                colOffset: dragState.item.colOffset
+                moves: dragState.items.map(d => ({
+                    lineIndex: d.item.lineIndex,
+                    newRow: d.startRow + dragState.rowDelta,
+                    newCol: d.startCol + dragState.colDelta,
+                    rowOffset: d.item.rowOffset,
+                    colOffset: d.item.colOffset
+                }))
             });
         } else {
-            vscode.postMessage({ type: 'navigate', lineIndex: dragState.item.lineIndex });
+            // No drag happened: a plain click on an item from a multi-selection collapses it back
+            // down to just that one (the group stayed selected during mousedown only in case this
+            // turned into a group drag).
+            selectedLineIndices = new Set([dragState.primaryLineIndex]);
+            vscode.postMessage({ type: 'navigate', lineIndex: dragState.primaryLineIndex });
         }
 
         dragState = null;
@@ -2316,7 +2533,7 @@ export class RecordPreviewPanel {
         if (message.type === 'render') {
             if (message.recordName !== currentRecordName) {
                 currentRecordName = message.recordName;
-                selectedLineIndex = null;
+                selectedLineIndices.clear();
                 dragState = null;
             }
 
@@ -2364,7 +2581,7 @@ export class RecordPreviewPanel {
             info.textContent = 'Record no longer exists.';
             ctx.clearRect(0, 0, canvas.width, canvas.height);
         } else if (message.type === 'selectLine') {
-            selectedLineIndex = message.lineIndex;
+            selectedLineIndices = new Set([message.lineIndex]);
             draw(currentSize, currentItems, currentBackgroundItems, currentWindowFrame, currentWindowTitle, currentOuterFrame);
         }
     });


### PR DESCRIPTION
## [0.13.3] - 2026-07-26
### Added
- Preview: selecting a field or constant now shows a "Selection actions" bar in the toolbar strip (not floating over the canvas, so it never fights the drag gesture or gets cramped by a single-character constant) — a one-click "↔ Center" button and a "⋮ Actions" menu (Add Color..., Add Attribute...), reusing the tree's own commands against the selected element.
- Preview/Center: the DDS system keywords `DATE`, `TIME`, `USER`, and `SYSNAME` now render with their real on-screen appearance (`DD-DD-DD`, `TT:TT:TT`, `UUUUUUUUUU`, `SSSSSSSS`), whether coded as a field's name or bare (unquoted) in a constant's position; "Center" now centers them using that real display width instead of the raw, misleadingly short source length.
- Preview: fields and constants can now be multi-selected (Ctrl/Cmd+click) and dragged together as one group, writing every new position back in a single edit; the selection bar reads "N fields/constants selected", and only offers "↔ Center"/"⋮ Actions" when exactly one item is selected.
- "Add Field" now offers a quick flow — just kind+usage (Alphanumeric/Numeric × Output/Input-Output/Input) and a size — that generates the same field STRSDA itself would (including an automatic `EDTWRD()` for numeric fields with decimals), reusing the same name/position steps as before; the full usage/referenced-field/type flow is still available behind a "More options..." entry for anything else (Hidden/Message usage, a referenced field, or another data type).
### Fixed
- Editing a read-only DDS source (e.g. an IBM i member opened in browse mode, or a read-only file) silently let every edit command (add/rename/move/delete field, constant, attribute, indicator, key command, window resize/title, subfile page size, and more) report success and modify the in-memory buffer, only to fail later with no warning when actually saving. Edits are now checked against the file's read-only status upfront, showing an immediate error instead.
- Preview: an output field with no explicit usage code (DDS's own default when left blank) showed its field name instead of the correct repeated-`O` placeholder text.
- Preview: a Date/Time/Timestamp (`L`/`T`/`Z`) field with no explicit length (DDS determines it automatically for these types) collapsed to a single placeholder character instead of its real fixed width (10/8/26).
- Parser: a bare system keyword (`DATE`, `TIME`, `USER`, `SYSNAME`) coded in a constant's position without quotes had its first and last character corrupted, since quote-stripping was applied unconditionally instead of only to actually-quoted text.
- Parser: two or more constants sharing identical text at different screen positions (e.g. blank/space "pixel" blocks used to build a colored logo out of `DSPATR(RI)` blocks) were silently collapsed down to just the first one found, since duplicates were detected by text alone instead of by source line.
- Preview: `DSPATR(HI)` with no explicit `COLOR()` rendered in the default green instead of white, unlike a real 5250 display.
- Preview: an alphanumeric field with a blank data-type column (DDS's own default — e.g. from the quick "Add Field" flow) showed numeric placeholder digits (6/9/3) instead of the correct usage letter (O/B/I).
- Preview: a numeric field carrying an `EDTWRD()` edit word showed a plain run of digits instead of the mask's actual picture (e.g. `99999999.99` instead of `9999999999`).
