### PR TITLE
v0.13.4 - Errors in parser with "*"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
+## [0.13.4] - 2026-07-27
+### Fixed
+- Parser: DDS comment lines with column 6 left blank (e.g. decorative `***...` banner blocks — the more common comment style, as opposed to `A*...`) were not recognized as comments. Such a line was misparsed as a field, and any file-level keyword coming after it (most notably `DSPSIZ()`) got attached to that phantom field instead of the file, silently falling back to the default screen size (24x80/*DS3) instead of the one actually declared. The same comment-detection fix was applied everywhere else it was used: locating insertion points for key commands, error messages, and file-level attributes.
+
 ## [0.13.3] - 2026-07-26
 ### Added
 - Preview: selecting a field or constant now shows a "Selection actions" bar in the toolbar strip (not floating over the canvas, so it never fights the drag gesture or gets cramped by a single-character constant) — a one-click "↔ Center" button and a "⋮ Actions" menu (Add Color..., Add Attribute...), reusing the tree's own commands against the selected element.

--- a/README.md
+++ b/README.md
@@ -118,18 +118,8 @@ Some features may not work as expected. Please leave an issue if something is no
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**0.13.3** - 2026-07-26
-- Added: Preview: selecting a field or constant now shows a "Selection actions" bar in the toolbar strip — a one-click "↔ Center" button and a "⋮ Actions" menu (Add Color..., Add Attribute...), reusing the tree's own commands against the selected element.
-- Added: Preview/Center: the DDS system keywords `DATE`, `TIME`, `USER`, and `SYSNAME` now render with their real on-screen appearance (`DD-DD-DD`, `TT:TT:TT`, `UUUUUUUUUU`, `SSSSSSSS`), whether coded as a field's name or bare in a constant's position; "Center" now uses that real display width.
-- Added: Preview: fields and constants can now be multi-selected (Ctrl/Cmd+click) and dragged together as one group; the selection bar reads "N fields/constants selected", with "↔ Center"/"⋮ Actions" only shown for a single selection.
-- Added: "Add Field" now offers a quick flow — just kind+usage and a size — that generates the same field STRSDA itself would (including an automatic `EDTWRD()` for numeric fields with decimals); the full flow is still available behind a "More options..." entry.
-- Fixed: Preview: an output field with no explicit usage code showed its field name instead of the correct repeated-`O` placeholder text.
-- Fixed: Preview: a Date/Time/Timestamp (`L`/`T`/`Z`) field with no explicit length collapsed to a single placeholder character instead of its real fixed width (10/8/26).
-- Fixed: Parser: a bare system keyword (`DATE`, `TIME`, `USER`, `SYSNAME`) coded unquoted in a constant's position had its first and last character corrupted.
-- Fixed: Parser: two or more constants sharing identical text at different screen positions (e.g. blank "pixel" blocks building a colored logo) were silently collapsed down to just the first one found.
-- Fixed: Preview: `DSPATR(HI)` with no explicit `COLOR()` rendered in the default green instead of white, unlike a real 5250 display.
-- Fixed: Preview: an alphanumeric field with a blank data-type column showed numeric placeholder digits instead of the correct usage letter (O/B/I).
-- Fixed: Preview: a numeric field carrying an `EDTWRD()` edit word showed a plain run of digits instead of the mask's actual picture (e.g. `99999999.99`).
+**0.13.4** - 2026-07-27
+- Fixed: Parser: DDS comment lines with column 6 left blank (e.g. decorative `***...` banner blocks) were not recognized as comments, causing file-level keywords like `DSPSIZ()` placed after them to be silently dropped and the display to fall back to the default size (24x80/*DS3) instead of the one actually declared.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"

--- a/src/dspf-edit.commands/dspf-edit.add-error-messages.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-error-messages.ts
@@ -506,8 +506,8 @@ function findExistingErrorMessageLines(editor: vscode.TextEditor, field: any): n
         // Skip empty lines
         if (!trimmedLine) continue;
 
-        // Skip comment lines (A*)
-        if (trimmedLine.startsWith('A*')) continue;
+        // Skip comment lines (column 7 = '*', regardless of column 6 being 'A' or blank)
+        if (lineText.length > 6 && lineText.charAt(6) === '*') continue;
 
         // Stop if we find a line that doesn't start with 'A ' or isn't an attribute line
         if (!trimmedLine.startsWith('A ') || !isAttributeLine(lineText)) {

--- a/src/dspf-edit.commands/dspf-edit.add-keys.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-keys.ts
@@ -666,8 +666,8 @@ function findExistingKeyCommandLines(editor: vscode.TextEditor, element: any): n
             continue;
         };
 
-        // Skip comment lines (A*)
-        if (trimmedLine.startsWith('A*')) {
+        // Skip comment lines (column 7 = '*', regardless of column 6 being 'A' or blank)
+        if (lineText.length > 6 && lineText.charAt(6) === '*') {
             continue;
         };
 
@@ -700,8 +700,8 @@ function findExistingKeyCommandLinesInFile(editor: vscode.TextEditor): number[] 
             continue;
         };
 
-        // Skip comment lines (A*)
-        if (lineText.trimStart().startsWith('A*')) {
+        // Skip comment lines (column 7 = '*', regardless of column 6 being 'A' or blank)
+        if (lineText.length > 6 && lineText.charAt(6) === '*') {
             continue;
         };
 

--- a/src/dspf-edit.parser/dspf-edit.parser.ts
+++ b/src/dspf-edit.parser/dspf-edit.parser.ts
@@ -130,8 +130,8 @@ function parseSingleDdsLine(
     const line = lines[lineIndex];
     const trimmedLine = line.substring(5); // Skip sequence number area
 
-    // Skip comment lines
-    if (trimmedLine.startsWith('A*')) {
+    // Skip comment lines (column 7 = '*', regardless of whether column 6 is 'A' or blank)
+    if (trimmedLine.charAt(1) === '*') {
         return { element: undefined, nextIndex: lineIndex, lastRecord };
     };
 

--- a/src/dspf-edit.utils/dspf-edit.helper.ts
+++ b/src/dspf-edit.utils/dspf-edit.helper.ts
@@ -291,8 +291,8 @@ export function findElementInsertionPoint(editor: vscode.TextEditor, element: an
     while (insertionPoint < editor.document.lineCount) {
         const line = editor.document.lineAt(insertionPoint).text;
 
-        // Skip commented lines
-        if (line.startsWith('     A*')) {
+        // Skip commented lines (column 7 = '*', regardless of column 6 being 'A' or blank)
+        if (line.length > 6 && line.charAt(6) === '*') {
             insertionPoint++;
             continue;
         };
@@ -332,7 +332,7 @@ export function findElementInsertionPointRecordFirstLine(editor: vscode.TextEdit
     // Skip existing attribute lines (lines that start with "     A" and have attributes)
     while (insertionPoint < editor.document.lineCount) {
         const line = editor.document.lineAt(insertionPoint).text;
-        if (line.trim().startsWith('A*')) {
+        if (line.length > 6 && line.charAt(6) === '*') {
             insertionPoint ++;
             continue;
         };
@@ -358,7 +358,7 @@ export function findElementInsertionPointFileFirstLine(editor: vscode.TextEditor
     // Skip existing attribute lines (lines that start with "     A" and have attributes)
     while (insertionPoint < editor.document.lineCount) {
         const line = editor.document.lineAt(insertionPoint).text;
-        if (line.trim().startsWith('A*')) {
+        if (line.length > 6 && line.charAt(6) === '*') {
             insertionPoint ++;
             continue;
         };
@@ -589,8 +589,8 @@ function findDspsizInsertionPoint(editor: vscode.TextEditor): number {
         const lineText = editor.document.lineAt(i).text;
         const trimmedLine = lineText.trim();
 
-        // Skip empty lines and comments
-        if (!trimmedLine || trimmedLine.startsWith('A*')) {
+        // Skip empty lines and comments (column 7 = '*', regardless of column 6 being 'A' or blank)
+        if (!trimmedLine || (lineText.length > 6 && lineText.charAt(6) === '*')) {
             continue;
         };
 


### PR DESCRIPTION
## [0.13.4] - 2026-07-27
### Fixed
- Parser: DDS comment lines with column 6 left blank (e.g. decorative `***...` banner blocks — the more common comment style, as opposed to `A*...`) were not recognized as comments. Such a line was misparsed as a field, and any file-level keyword coming after it (most notably `DSPSIZ()`) got attached to that phantom field instead of the file, silently falling back to the default screen size (24x80/*DS3) instead of the one actually declared. The same comment-detection fix was applied everywhere else it was used: locating insertion points for key commands, error messages, and file-level attributes.