### PR TITLE
0.13.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
+## [0.13.5] - 2026-07-28
+### Added
+- Preview: a referenced field (`REFFLD`/position-29 `R`) now renders as a single marker character in a distinct color with a dashed box, instead of a guessed-width placeholder — its real type/length live in the external database field, which dspf-edit has no way to read.
+### Fixed
+- Add/Edit Field: problems with fields with length of 100 or more.
+- Parser: field length was read back from only the last 2 characters of the length column. It has been fixed.
+- Add Field: a referenced field (library/file/field) generated an invalid `REFFLD(library/file.field)` specification. Now generates the correct `REFFLD(field [library/]file)` format.
+- Add Field: referencing a field required a library name, even though DDS itself makes it optional (falls back to the library list, `*LIBL`, when omitted). The prompt now accepts an empty library.
+
 ## [0.13.4] - 2026-07-27
 ### Fixed
 - Parser: DDS comment lines with column 6 left blank (e.g. decorative `***...` banner blocks — the more common comment style, as opposed to `A*...`) were not recognized as comments. Such a line was misparsed as a field, and any file-level keyword coming after it (most notably `DSPSIZ()`) got attached to that phantom field instead of the file, silently falling back to the default screen size (24x80/*DS3) instead of the one actually declared. The same comment-detection fix was applied everywhere else it was used: locating insertion points for key commands, error messages, and file-level attributes.

--- a/README.md
+++ b/README.md
@@ -118,8 +118,10 @@ Some features may not work as expected. Please leave an issue if something is no
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**0.13.4** - 2026-07-27
-- Fixed: Parser: DDS comment lines with column 6 left blank (e.g. decorative `***...` banner blocks) were not recognized as comments, causing file-level keywords like `DSPSIZ()` placed after them to be silently dropped and the display to fall back to the default size (24x80/*DS3) instead of the one actually declared.
+**0.13.5** - 2026-07-28
+- Fixed: Add/Edit Field: a field length of 100 or more corrupted the generated DDS line, since the length column was only reserved 2 characters wide instead of the 5 DDS itself uses; the parser also only read back the last 2 digits of that column, showing the wrong length in the tree and preview.
+- Fixed: Add Field: a referenced field generated an invalid `REFFLD(library/file.field)` specification instead of the correct `REFFLD(field [library/]file)` format; the library is now optional, matching DDS itself (defaults to `*LIBL`).
+- Added: Preview: a referenced field now renders as a single marker character in a distinct color with a dashed box, instead of a guessed-width placeholder.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dspf-edit",
-  "version": "0.12.3",
+  "version": "0.13.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dspf-edit",
-      "version": "0.12.3",
+      "version": "0.13.5",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "0.13.4",
+  "version": "0.13.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"

--- a/src/dspf-edit.commands/dspf-edit.edit-field.ts
+++ b/src/dspf-edit.commands/dspf-edit.edit-field.ts
@@ -143,7 +143,7 @@ const FIELD_CONSTANTS = {
     MAX_NAME_LENGTH: 10,
     NAME_COLUMN_START: 18,
     NAME_COLUMN_END: 28,
-    SIZE_COLUMN_START: 32,
+    SIZE_COLUMN_START: 29,
     SIZE_COLUMN_END: 34,
     TYPE_COLUMN: 34,
     DECIMAL_COLUMN_START: 35,
@@ -453,7 +453,7 @@ function generateQuickFieldLines(name: string, isNumeric: boolean, usage: FieldU
     let line = ' '.repeat(80);
     line = replaceAt(line, 5, 'A');
     line = replaceAt(line, 18, name.padEnd(10, ' '));
-    line = replaceAt(line, 32, size.length.toString().padStart(2, ' '));
+    line = replaceAt(line, FIELD_CONSTANTS.SIZE_COLUMN_START, size.length.toString().padStart(5, ' '));
 
     if (isNumeric) {
         line = replaceAt(line, 34, 'Y');
@@ -646,14 +646,14 @@ async function collectFieldUsage(fieldName: string): Promise<FieldUsage | null> 
 };
 
 async function collectFieldReference(fieldName: string): Promise<FieldReference | null> {
-    // Get library name
+    // Get library name (optional — DDS uses the current library list, *LIBL, when omitted)
     const library = await vscode.window.showInputBox({
         title: `Reference for field '${fieldName}' - Step 1/3`,
-        prompt: "Enter library name (max 10 characters)",
-        placeHolder: "LIBRARY",
-        validateInput: (value) => validateLibraryFileName(value, "Library")
+        prompt: "Enter library name (max 10 characters), or leave empty to use the library list (*LIBL)",
+        placeHolder: "LIBRARY (optional)",
+        validateInput: (value) => validateLibraryFileName(value, "Library", false)
     });
-    if (!library) return null;
+    if (library === undefined) return null;
 
     // Get file name
     const file = await vscode.window.showInputBox({
@@ -684,13 +684,13 @@ async function collectFieldReference(fieldName: string): Promise<FieldReference 
 /**
  * Validates library and file names
  */
-function validateLibraryFileName(value: string, type: string): string | null {
+function validateLibraryFileName(value: string, type: string, required: boolean = true): string | null {
     const trimmedValue = value.trim();
-    
+
     if (trimmedValue === '') {
-        return `${type} name cannot be empty.`;
+        return required ? `${type} name cannot be empty.` : null;
     };
-    
+
     if (trimmedValue.length > 10) {
         return `${type} name must be 10 characters or fewer.`;
     };
@@ -1165,8 +1165,9 @@ function generateNewFieldLine(config: NewFieldConfig): string {
         // Referenced field - use R and reference specification
         line = replaceAt(line, 28, 'R');
         
-        // Reference specification: REFFLD(library/file.field)
-        const refSpec = `REFFLD(${config.reference.library}/${config.reference.file}.${config.reference.field})`;
+        // Reference specification: REFFLD(referenced-field-name [library-name/]database-file-name)
+        const qualifiedFile = config.reference.library ? `${config.reference.library}/${config.reference.file}` : config.reference.file;
+        const refSpec = `REFFLD(${config.reference.field} ${qualifiedFile})`;
         line = replaceAt(line, 44, refSpec);
     } else if (config.typeConfig) {
         // New field with type specification
@@ -1175,8 +1176,8 @@ function generateNewFieldLine(config: NewFieldConfig): string {
         
         // Only specify length for fields that require it
         if (fieldType.hasLength) {
-            const sizeStr = config.typeConfig.size.length.toString().padStart(2, ' ');
-            line = replaceAt(line, 32, sizeStr);
+            const sizeStr = config.typeConfig.size.length.toString().padStart(5, ' ');
+            line = replaceAt(line, FIELD_CONSTANTS.SIZE_COLUMN_START, sizeStr);
         }
         
         line = replaceAt(line, 34, fieldType.keyboardShift);
@@ -1495,7 +1496,7 @@ function buildUpdatedLine(originalLine: string, newName: string, newSize: FieldS
            paddedName + 
            line.substring(FIELD_CONSTANTS.NAME_COLUMN_END);
     
-    const sizeString = newSize.length.toString().padStart(2, ' ').substring(0, 2);
+    const sizeString = newSize.length.toString().padStart(5, ' ').substring(0, 5);
     line = line.substring(0, FIELD_CONSTANTS.SIZE_COLUMN_START) + 
            sizeString + 
            line.substring(FIELD_CONSTANTS.SIZE_COLUMN_END);

--- a/src/dspf-edit.model/dspf-edit.model.ts
+++ b/src/dspf-edit.model/dspf-edit.model.ts
@@ -213,6 +213,8 @@ export interface FieldInfo {
   row: number;
   col: number;
   length: number;
+  /** True for a referenced field (REFFLD/position-29 `R`): its type/length live in the external database field, not in this source. */
+  referenced?: boolean;
   attributes: AttributeWithIndicators[];
   indicators?: DdsIndicator[];
   lineIndex: number;

--- a/src/dspf-edit.parser/dspf-edit.parser.ts
+++ b/src/dspf-edit.parser/dspf-edit.parser.ts
@@ -264,7 +264,7 @@ function isSubfileRecord(attributes?: DdsAttribute[]): boolean {
  */
 /**
  * System-defined length for DDS data types whose length is never written in the source's length
- * columns (position 30-31) — DDS itself derives it, so those columns are legitimately left blank.
+ * columns (position 30-34) — DDS itself derives it, so those columns are legitimately left blank.
  * Matches the defaults `edit-field.ts`'s `getSystemDefinedLength` uses when creating one of these.
  */
 const FIXED_LENGTH_BY_TYPE: Record<string, number> = { L: 10, T: 8, Z: 26 };
@@ -277,7 +277,7 @@ function parseFieldElement(
     lastRecord: string
 ) {
     const type = trimmedLine[29];
-    const length = Number(trimmedLine.substring(27, 29).trim()) || FIXED_LENGTH_BY_TYPE[type] || 0;
+    const length = Number(trimmedLine.substring(24, 29).trim()) || FIXED_LENGTH_BY_TYPE[type] || 0;
     const decimals = trimmedLine.substring(30, 32) !== ' ' ? Number(trimmedLine.substring(30, 32).trim()) : 0;
     const usage = trimmedLine[32] !== ' ' ? trimmedLine[32] : ' ';
     const isHidden = trimmedLine[32] === 'H';
@@ -643,6 +643,7 @@ function addFieldToRecord(field: any, recordEntry: any): void {
             row: field.row || 0,
             col: field.column || 0,
             length: field.length || 0,
+            referenced: field.referenced,
             attributes: processedAttributes,
             indicators: field.indicators || [],
             lineIndex: field.lineIndex,

--- a/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
@@ -48,6 +48,13 @@ interface PreviewItem {
      * must be drawn on top of that frame fill, since they're part of the window's own content.
      */
     sameWindow?: boolean;
+    /**
+     * True for a referenced field (REFFLD/position-29 `R`): its real type/length live in the
+     * external database field, which dspf-edit has no way to read, so it can't be previewed at its
+     * real width. Rendered as a single placeholder character in a distinct color with a dashed box,
+     * instead of pretending to know its size.
+     */
+    isReferenced?: boolean;
 };
 
 /** A rectangle in the coordinates of the canvas being drawn (the full display size). */
@@ -128,6 +135,9 @@ const DEFAULT_COLOR = '#00ff00';
 
 /** What DSPATR(HI) alone (no explicit COLOR()) renders as — matching a real 5250 display. */
 const HIGH_INTENSITY_COLOR = '#ffffff';
+
+/** Marker color for a referenced field (REFFLD), distinct from every DDS_COLOR_MAP value. */
+const REFERENCED_FIELD_COLOR = '#ff8800';
 
 /** Maps DDS COLOR() keyword codes to their on-screen color. */
 const DDS_COLOR_MAP: Record<string, string> = {
@@ -761,12 +771,18 @@ export class RecordPreviewPanel {
             if (trueRow > 0 && trueCol > 0) {
                 const activeAttrs = this.getActiveAttributes(field.attributes, useLiveIndicators);
                 const usageCode = (field.usage || '').trim().toUpperCase();
+                // A referenced field (REFFLD/position-29 `R`) has no type/length of its own in the
+                // source — they live in the external database field, which dspf-edit can't read —
+                // so it's shown as a single marker character instead of a guessed-width placeholder.
+                const isReferenced = field.referenced === true;
                 // The displayed text's own length drives the item's width/hit-box (below), not the
                 // parsed field length: a system keyword field (DATE, USER...) always renders at a
                 // fixed width of its own, regardless of whatever the source's length column holds
                 // — and an edited numeric field (EDTWRD) is one character wider per insert
                 // character (its decimal point, typically), which text.length already reflects.
-                const text = getFieldPlaceholderText(field.name, field.type, field.usage, field.length, getEditWordMask(activeAttrs));
+                const text = isReferenced
+                    ? getFieldPlaceholderText(field.name, field.type, field.usage, 1)
+                    : getFieldPlaceholderText(field.name, field.type, field.usage, field.length, getEditWordMask(activeAttrs));
                 items.push({
                     kind: 'field',
                     name: field.name,
@@ -775,7 +791,7 @@ export class RecordPreviewPanel {
                     col: trueCol + colOffset,
                     length: text.length,
                     lineIndex: field.lineIndex,
-                    color: getDisplayColor(activeAttrs, hasDisplayAttribute(activeAttrs, 'HI')),
+                    color: isReferenced ? REFERENCED_FIELD_COLOR : getDisplayColor(activeAttrs, hasDisplayAttribute(activeAttrs, 'HI')),
                     highIntensity: hasDisplayAttribute(activeAttrs, 'HI'),
                     reverseImage: hasDisplayAttribute(activeAttrs, 'RI') || this.hasActiveErrorMessage(field.attributes, useLiveIndicators),
                     blink: hasDisplayAttribute(activeAttrs, 'BL'),
@@ -786,7 +802,8 @@ export class RecordPreviewPanel {
                     colOffset,
                     isBackground,
                     isInteractive: !isBackground,
-                    isInputCapable: usageCode === 'I' || usageCode === 'B'
+                    isInputCapable: usageCode === 'I' || usageCode === 'B',
+                    isReferenced
                 });
             };
         };
@@ -1793,6 +1810,14 @@ export class RecordPreviewPanel {
             ctx.moveTo(x, y + CHAR_H - 2.5);
             ctx.lineTo(x + w, y + CHAR_H - 2.5);
             ctx.stroke();
+        }
+
+        if (item.isReferenced) {
+            ctx.save();
+            ctx.strokeStyle = item.color;
+            ctx.setLineDash([2, 2]);
+            ctx.strokeRect(x + 0.5, y + 0.5, w - 1, CHAR_H - 1);
+            ctx.restore();
         }
 
         if (item.columnSeparator) {


### PR DESCRIPTION
## [0.13.5] - 2026-07-28
### Added
- Preview: a referenced field (`REFFLD`/position-29 `R`) now renders as a single marker character in a distinct color with a dashed box, instead of a guessed-width placeholder — its real type/length live in the external database field, which dspf-edit has no way to read.
### Fixed
- Add/Edit Field: problems with fields with length of 100 or more.
- Parser: field length was read back from only the last 2 characters of the length column. It has been fixed.
- Add Field: a referenced field (library/file/field) generated an invalid `REFFLD(library/file.field)` specification. Now generates the correct `REFFLD(field [library/]file)` format.
- Add Field: referencing a field required a library name, even though DDS itself makes it optional (falls back to the library list, `*LIBL`, when omitted). The prompt now accepts an empty library.