### PR TITLE
v13.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
+## [0.13.6] - 2026-07-29
+### Fixed
+- Parser: fields and constants positioned using DDS's relative record format (`+n` in the Position field, or a blank Line/Row meaning "same row as the previous field/constant") were misparsed as attributes and silently dropped, instead of being resolved to their actual screen position relative to the preceding field/constant.
+- Move Field/Constant Left/Right (tree buttons): when a field/constant's row was inherited via the relative record format above, moving it horizontally updated the column but left the row blank in the source instead of writing it explicitly — unlike dragging in the preview panel, which already materializes both. Moving with the tree buttons now writes the row too.
+
 ## [0.13.5] - 2026-07-28
 ### Added
 - Preview: a referenced field (`REFFLD`/position-29 `R`) now renders as a single marker character in a distinct color with a dashed box, instead of a guessed-width placeholder — its real type/length live in the external database field, which dspf-edit has no way to read.

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ The extension provides a **navigable schema view** of the DDS source file that i
 This extension is currently in **preview**.  
 Some features may not work as expected. Please leave an issue if something is not working fine!
 
+- DDS indicator **OR conditioning** is not yet supported: DDS lets you OR several indicator-only continuation lines (marked with `O` in column 7) together, with the actual keyword coded on the last line of the group. Only the indicators on that last line are currently read — the preceding OR'd indicator-only lines are ignored.
+
 ---
 
 ## 📝 To Do
@@ -118,10 +120,9 @@ Some features may not work as expected. Please leave an issue if something is no
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**0.13.5** - 2026-07-28
-- Fixed: Add/Edit Field: a field length of 100 or more corrupted the generated DDS line, since the length column was only reserved 2 characters wide instead of the 5 DDS itself uses; the parser also only read back the last 2 digits of that column, showing the wrong length in the tree and preview.
-- Fixed: Add Field: a referenced field generated an invalid `REFFLD(library/file.field)` specification instead of the correct `REFFLD(field [library/]file)` format; the library is now optional, matching DDS itself (defaults to `*LIBL`).
-- Added: Preview: a referenced field now renders as a single marker character in a distinct color with a dashed box, instead of a guessed-width placeholder.
+**0.13.6** - 2026-07-29
+- Fixed: Parser: fields and constants positioned using DDS's relative record format (`+n` in the Position field, or a blank Line/Row meaning "same row as the previous field/constant") were misparsed as attributes and silently dropped, instead of being resolved to their actual screen position.
+- Fixed: Move Field/Constant Left/Right (tree buttons): moving a field/constant whose row was inherited via the relative record format above left the row blank in the source instead of writing it explicitly, unlike dragging in the preview panel. Both now behave the same way.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dspf-edit",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dspf-edit",
-      "version": "0.13.5",
+      "version": "0.13.6",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "0.13.5",
+  "version": "0.13.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"

--- a/src/dspf-edit.commands/dspf-edit.move-constants.ts
+++ b/src/dspf-edit.commands/dspf-edit.move-constants.ts
@@ -135,8 +135,17 @@ async function handleMoveConstantCommand(node: DdsNode, offset: number): Promise
             return;
         }
 
+        // The row spec (raw source columns 38-41) is written alongside the column move even though
+        // this command never changes it. Under DDS's relative record format that spec can be blank
+        // in the source (row inherited from the preceding field/constant) — leaving it blank here
+        // would be fine positionally (the parser re-derives the same inherited row on reparse), but
+        // it also means the tree can show a stale/empty row until that reparse lands, and it silently
+        // drops the relative-format hint. Materializing it as an explicit number keeps the source
+        // and the tree in sync immediately and matches what dragging in the preview panel already does.
+        const rawRow = isSflRecord ? element.column : element.row;
+
         // Apply the constant update with new position
-        if (!(await moveConstantToNewPosition(editor, element, newPosition))) {
+        if (!(await moveConstantToNewPosition(editor, element, newPosition, rawRow))) {
             return;
         };
 
@@ -165,7 +174,9 @@ async function handleMoveConstantCommand(node: DdsNode, offset: number): Promise
 // CONSTANT MOVEMENT FUNCTIONS
 
 /**
- * Moves a constant to a new column position by updating the column spec in the source line.
+ * Moves a constant to a new column position by updating the column spec in the source line, and
+ * materializes the row spec alongside it (see the call site's comment on rawRow) so a row left
+ * blank under the DDS relative record format becomes an explicit number.
  * The raw source columns 38-41 (line/row spec) and 41-44 (position/col spec) always keep that
  * same meaning regardless of record type — a subfile only swaps which of those raw values ends up
  * labeled element.row vs element.column internally (see isSubfileRecord's caller), the physical
@@ -174,11 +185,13 @@ async function handleMoveConstantCommand(node: DdsNode, offset: number): Promise
  * @param editor - The active text editor
  * @param element - The constant element to move
  * @param newPosition - The new column value
+ * @param rawRow - The row spec value to (re)write at columns 38-41, undefined to leave it as-is
  */
 async function moveConstantToNewPosition(
     editor: vscode.TextEditor,
     element: any,
-    newPosition: number
+    newPosition: number,
+    rawRow: number | undefined
 ): Promise<boolean> {
     const uri = editor.document.uri;
     const workspaceEdit = new vscode.WorkspaceEdit();
@@ -193,6 +206,11 @@ async function moveConstantToNewPosition(
     );
 
     workspaceEdit.replace(uri, range, formattedPos);
+
+    if (rawRow !== undefined) {
+        const formattedRow = String(rawRow).padStart(3, ' ');
+        workspaceEdit.replace(uri, new vscode.Range(element.lineIndex, 38, element.lineIndex, 41), formattedRow);
+    };
 
     return applyWorkspaceEdit(workspaceEdit, 'move the constant');
 }

--- a/src/dspf-edit.commands/dspf-edit.move-fields.ts
+++ b/src/dspf-edit.commands/dspf-edit.move-fields.ts
@@ -135,8 +135,17 @@ async function handleMoveFieldCommand(node: DdsNode, offset: number): Promise<vo
             return;
         }
 
+        // The row spec (raw source columns 38-41) is written alongside the column move even though
+        // this command never changes it. Under DDS's relative record format that spec can be blank
+        // in the source (row inherited from the preceding field/constant) — leaving it blank here
+        // would be fine positionally (the parser re-derives the same inherited row on reparse), but
+        // it also means the tree can show a stale/empty row until that reparse lands, and it silently
+        // drops the relative-format hint. Materializing it as an explicit number keeps the source
+        // and the tree in sync immediately and matches what dragging in the preview panel already does.
+        const rawRow = isSflRecord ? element.column : element.row;
+
         // Apply the field update with new position
-        if (!(await moveFieldToNewPosition(editor, element, newPosition))) {
+        if (!(await moveFieldToNewPosition(editor, element, newPosition, rawRow))) {
             return;
         };
 
@@ -165,7 +174,9 @@ async function handleMoveFieldCommand(node: DdsNode, offset: number): Promise<vo
 // FIELD MOVEMENT FUNCTIONS
 
 /**
- * Moves a field to a new column position by updating the column spec in the source line.
+ * Moves a field to a new column position by updating the column spec in the source line, and
+ * materializes the row spec alongside it (see the call site's comment on rawRow) so a row left
+ * blank under the DDS relative record format becomes an explicit number.
  * The raw source columns 38-41 (line/row spec) and 41-44 (position/col spec) always keep that
  * same meaning regardless of record type — a subfile only swaps which of those raw values ends up
  * labeled element.row vs element.column internally (see isSubfileRecord's caller), the physical
@@ -174,11 +185,13 @@ async function handleMoveFieldCommand(node: DdsNode, offset: number): Promise<vo
  * @param editor - The active text editor
  * @param element - The field element to move
  * @param newPosition - The new column value
+ * @param rawRow - The row spec value to (re)write at columns 38-41, undefined to leave it as-is
  */
 async function moveFieldToNewPosition(
     editor: vscode.TextEditor,
     element: any,
-    newPosition: number
+    newPosition: number,
+    rawRow: number | undefined
 ): Promise<boolean> {
     const uri = editor.document.uri;
     const workspaceEdit = new vscode.WorkspaceEdit();
@@ -193,6 +206,11 @@ async function moveFieldToNewPosition(
     );
 
     workspaceEdit.replace(uri, range, formattedPos);
+
+    if (rawRow !== undefined) {
+        const formattedRow = String(rawRow).padStart(3, ' ');
+        workspaceEdit.replace(uri, new vscode.Range(element.lineIndex, 38, element.lineIndex, 41), formattedRow);
+    };
 
     return applyWorkspaceEdit(workspaceEdit, 'move the field');
 }

--- a/src/dspf-edit.parser/dspf-edit.parser.ts
+++ b/src/dspf-edit.parser/dspf-edit.parser.ts
@@ -24,6 +24,15 @@ import {
 export let currentDdsElements: DdsElement[] = [];
 
 /**
+ * Tracks the last resolved (row, col, length) of a positioned field/constant within the current
+ * record, in source order. Needed to resolve DDS's relative record format: a blank Line (row)
+ * field means "continue on the same row as the preceding field/constant", and a Position (col)
+ * field written as "+n" means "n blank positions after the end of that preceding field/constant" —
+ * both defined relative to whatever came immediately before in this record, not to any fixed origin.
+ */
+let lastPositionInRecord: { row: number; col: number; length: number } | undefined;
+
+/**
  * Main parser function that processes DDS document text and returns structured elements
  * @param text - Raw DDS document text to parse
  * @returns Array of parsed DDS elements
@@ -71,6 +80,7 @@ function clearGlobalState(): void {
     records.length = 0;
     fieldsPerRecords.length = 0;
     attributesFileLevel.length = 0;
+    lastPositionInRecord = undefined;
 
     // Reset both display-size slots so switching to a document with fewer (or no) DSPSIZ formats
     // doesn't leak a stale second size (e.g. *DS4) left over from a previously parsed document —
@@ -170,9 +180,47 @@ function extractLineComponents(trimmedLine: string) {
     const rowText = trimmedLine.substring(33, 36).trim();
     const colText = trimmedLine.substring(36, 39).trim();
     const row = rowText ? Number(rowText) : undefined;
+    // A Position entry of "+n" (DDS relative record format) is placed n blank positions after the
+    // end of the preceding field/constant, rather than at absolute column n. Number("+1") already
+    // evaluates to 1, so the magnitude is captured the same way — this flag is what tells
+    // resolvePosition to treat it as an offset instead of an absolute column.
+    const colRelative = colText.startsWith('+');
     const col = colText ? Number(colText) : undefined;
 
-    return { indicators, fieldName, row, col, displayFormat };
+    return { indicators, fieldName, row, col, colRelative, displayFormat };
+};
+
+/**
+ * Resolves a field/constant's actual (row, col) from the raw values read off the DDS source,
+ * applying the DDS relative record format rules (see extractLineComponents): a blank Line (row)
+ * continues on the same row as the immediately preceding positioned field/constant in this record,
+ * and a Position (col) written as "+n" is placed n blank positions after that preceding element's
+ * end column. Falls back to treating "+n" as an absolute column when there is no preceding element
+ * to be relative to (malformed source).
+ * @param row - Row read from columns 39-41; undefined means the field was left blank
+ * @param col - Col read from columns 42-44; undefined means the field was left blank
+ * @param colRelative - True when the Position field was written as "+n"
+ */
+function resolvePosition(
+    row: number | undefined,
+    col: number | undefined,
+    colRelative: boolean
+): { row: number | undefined; col: number | undefined } {
+    if (row === undefined && col === undefined) {
+        return { row, col };
+    };
+
+    const resolvedRow = row !== undefined ? row : lastPositionInRecord?.row;
+
+    let resolvedCol = col;
+    if (colRelative && col !== undefined) {
+        const previousEndCol = lastPositionInRecord
+            ? lastPositionInRecord.col + lastPositionInRecord.length
+            : 0;
+        resolvedCol = previousEndCol + col;
+    };
+
+    return { row: resolvedRow, col: resolvedCol };
 };
 
 /**
@@ -194,12 +242,14 @@ function isFieldLine(fieldName: string): boolean {
 };
 
 /**
- * Checks if the line represents a constant definition
+ * Checks if the line represents a constant definition. The Line (row) entry is legitimately blank
+ * under the DDS relative record format — it means "same row as the preceding field/constant" — so
+ * only the Position (col) entry is required here; row is resolved later via resolvePosition.
  * @param components - Extracted line components
  * @returns True if line is a constant definition
  */
 function isConstantLine(components: { fieldName: string; row?: number; col?: number }): boolean {
-    return !components.fieldName && Boolean(components.row) && Boolean(components.col);
+    return !components.fieldName && Boolean(components.col);
 };
 
 /**
@@ -218,6 +268,10 @@ function parseRecordElement(
 ) {
     const name = trimmedLine.substring(13, 23).trim();
     const { attributes, nextIndex } = extractAttributes('R', lines, lineIndex, false);
+
+    // A new record always starts with an explicit absolute position — relative "+n"/blank-row
+    // notation is only relative to a preceding field/constant within the same record.
+    lastPositionInRecord = undefined;
 
     // Update global state
     records.push(name);
@@ -288,16 +342,24 @@ function parseFieldElement(
     // Check if the current record (lastRecord) is a subfile by looking at its attributes
     const currentRecordEntry = fieldsPerRecords.find(r => r.record === lastRecord);
     const isSubfile = currentRecordEntry ? isSubfileRecord(currentRecordEntry.attributes) : false;
-    
+
+    // Resolve DDS relative record format ("+n" position, blank line) against the preceding
+    // field/constant in this record, using the raw (pre-subfile-swap) row/col as written in source.
+    const { row: resolvedRow, col: resolvedCol } = resolvePosition(components.row, components.col, components.colRelative);
+
     // For subfiles, swap row and column positions
-    let finalRow = components.row;
-    let finalCol = components.col;
-    
+    let finalRow = resolvedRow;
+    let finalCol = resolvedCol;
+
     if (isSubfile && !isHidden) {
         // In subfiles, the positions are swapped: what appears in the "row" position is actually the column,
         // and what appears in the "column" position is actually the row
-        finalRow = components.col;
-        finalCol = components.row;
+        finalRow = resolvedCol;
+        finalCol = resolvedRow;
+    };
+
+    if (!isHidden && resolvedRow !== undefined && resolvedCol !== undefined) {
+        lastPositionInRecord = { row: resolvedRow, col: resolvedCol, length };
     };
 
     const element = {
@@ -344,21 +406,31 @@ function parseConstantElement(
     // Check if the current record (lastRecord) is a subfile by looking at its attributes
     const currentRecordEntry = fieldsPerRecords.find(r => r.record === lastRecord);
     const isSubfile = currentRecordEntry ? isSubfileRecord(currentRecordEntry.attributes) : false;
-        
+
+    // Resolve DDS relative record format ("+n" position, blank line) against the preceding
+    // field/constant in this record, using the raw (pre-subfile-swap) row/col as written in source.
+    const { row: resolvedRow, col: resolvedCol } = resolvePosition(components.row, components.col, components.colRelative);
+
     // For subfiles, swap row and column positions
-    let finalRow = components.row;
-    let finalCol = components.col;
-        
+    let finalRow = resolvedRow;
+    let finalCol = resolvedCol;
+
     if (isSubfile) {
-        finalRow = components.col;
-        finalCol = components.row;
+        finalRow = resolvedCol;
+        finalCol = resolvedRow;
     };
-    
+
+    if (resolvedRow !== undefined && resolvedCol !== undefined) {
+        lastPositionInRecord = { row: resolvedRow, col: resolvedCol, length: stripConstantQuotes(fullValue).length };
+    };
+
     const element = {
         kind: 'constant' as const,
         name: fullValue,
-        row: finalRow,
-        column: finalCol,
+        // Falls back to 0 only for malformed source (blank Line with no preceding field/constant
+        // in this record to inherit a row from) — DdsConstant.row/column are non-optional.
+        row: finalRow ?? 0,
+        column: finalCol ?? 0,
         lineIndex: lineIndex,
         lastLineIndex: lastLineIndex,
         recordname: lastRecord,
@@ -654,18 +726,24 @@ function addFieldToRecord(field: any, recordEntry: any): void {
 };
 
 /**
+ * Removes quotes from a constant's raw name for storage/length purposes — but only when it's
+ * actually a quoted literal. A DDS system keyword (DATE, TIME, USER, SYSNAME) can be coded bare, in
+ * the same position a quoted constant would occupy; blindly slicing it would eat its first/last letter.
+ * @param rawName - Raw constant text as read from the source (may or may not be quoted)
+ */
+function stripConstantQuotes(rawName: string): string {
+    return rawName.length >= 2 && rawName.startsWith("'") && rawName.endsWith("'")
+        ? rawName.slice(1, -1)
+        : rawName;
+};
+
+/**
  * Adds a constant element to its parent record entry
  * @param constant - Constant element to add
  * @param recordEntry - Record entry to add constant to
  */
 function addConstantToRecord(constant: any, recordEntry: any): void {
-    // Remove quotes from constant name for storage — but only when it's actually a quoted
-    // literal. A DDS system keyword (DATE, TIME, USER, SYSNAME) can be coded bare, in the same
-    // position a quoted constant would occupy; blindly slicing it would eat its first/last letter.
-    const rawName: string = constant.name;
-    const constantName = rawName.length >= 2 && rawName.startsWith("'") && rawName.endsWith("'")
-        ? rawName.slice(1, -1)
-        : rawName;
+    const constantName = stripConstantQuotes(constant.name);
 
     // Process attributes preserving their indicators
     const processedAttributes = constant.attributes?.map((attr: any) => ({


### PR DESCRIPTION
## [0.13.6] - 2026-07-29
### Fixed
- Parser: fields and constants positioned using DDS's relative record format (`+n` in the Position field, or a blank Line/Row meaning "same row as the previous field/constant") were misparsed as attributes and silently dropped, instead of being resolved to their actual screen position relative to the preceding field/constant.
- Move Field/Constant Left/Right (tree buttons): when a field/constant's row was inherited via the relative record format above, moving it horizontally updated the column but left the row blank in the source instead of writing it explicitly — unlike dragging in the preview panel, which already materializes both. Moving with the tree buttons now writes the row too.
