### PR TITLE
v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
+## [0.14.0] - 2026-07-28
+### Added
+- New "Resolve Referenced Field" action for referenced fields (`REFFLD`/position-29 `R`, which carry no type/length in the source): a button on the field — and a "Resolve All Referenced Fields" command, also reachable from a new status bar item — queries the connected IBM i, via the [Code for i](https://marketplace.visualstudio.com/items?itemName=HalcyonTechLtd.code-for-ibmi) extension, for the referenced database field's real type/length/decimals. Works for both native physical/logical files and SQL-created tables (which can have different long and short column names). Once resolved, the field shows its real type/length in both the tree and the preview (rendered like a normal field, tinted the reference color only when it carries no `COLOR()`/`DSPATR()` of its own). Cached per document until it's closed, or re-resolved on demand from the same button. Requires Code for i to be installed and connected; shows a clear message otherwise.
+- A status bar item shows how many referenced fields in the current document are still pending resolution.
+### Fixed
+- Performance: two O(n²) hotspots in the parser (linking fields/constants to their record, and duplicate-field detection) made re-parsing a document — e.g. after moving a field in the preview — get dramatically slower as it grew larger. Both are now linear.
+- Performance: checking whether a file is read-only before applying an edit did a live round-trip to the IBM i on every single edit while connected via Code for i. It's now cached per document.
+- Referenced fields were missing the usual field context menu/inline actions (delete, copy, rename, etc.), due to a stricter internal check that didn't account for their new "pending"/"resolved" state.
+
 ## [0.13.5] - 2026-07-28
 ### Added
 - Preview: a referenced field (`REFFLD`/position-29 `R`) now renders as a single marker character in a distinct color with a dashed box, instead of a guessed-width placeholder — its real type/length live in the external database field, which dspf-edit has no way to read.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
-## [0.14.0] - 2026-07-29
+## [0.14.0] - 2026-07-30
 ### Added
 - New "Resolve Referenced Field" action for referenced fields (`REFFLD`/position-29 `R`, which carry no type/length in the source): a button on the field — and a "Resolve All Referenced Fields" command, also reachable from a new status bar item — queries the connected IBM i, via the [Code for i](https://marketplace.visualstudio.com/items?itemName=HalcyonTechLtd.code-for-ibmi) extension, for the referenced database field's real type/length/decimals. Works for both native physical/logical files and SQL-created tables (which can have different long and short column names). Once resolved, the field shows its real type/length in both the tree and the preview (rendered like a normal field, tinted the reference color only when it carries no `COLOR()`/`DSPATR()` of its own). Cached per document until it's closed, or re-resolved on demand from the same button. Requires Code for i to be installed and connected; shows a clear message otherwise.
 - A status bar item shows how many referenced fields in the current document are still pending resolution.
+- Preview: support for the `CNTFLD(n)` keyword — a field too long to fit on one line now wraps across multiple rows, `n` characters each, all starting at the field's original column, matching how RDi previews it. Centering such a field (`Center`/"↔") now uses its per-line width instead of its full declared length.
 ### Fixed
 - Performance: two O(n²) hotspots in the parser (linking fields/constants to their record, and duplicate-field detection) made re-parsing a document — e.g. after moving a field in the preview — get dramatically slower as it grew larger. Both are now linear.
 - Performance: checking whether a file is read-only before applying an edit did a live round-trip to the IBM i on every single edit while connected via Code for i. It's now cached per document.
 - Referenced fields were missing the usual field context menu/inline actions (delete, copy, rename, etc.), due to a stricter internal check that didn't account for their new "pending"/"resolved" state.
+- Parser: a field/constant positioned relative (`+n`) right after a bare system keyword (`DATE`, `TIME`, `USER`, `SYSNAME`) landed several columns too far left in the preview, overlapping the keyword's own placeholder — the parser was tracking the keyword's raw source-text length instead of its actual on-screen width when resolving the following `+n` position.
+- Preview: dragging a `CNTFLD`-wrapped field failed with "the document may be read-only" — its wrapped lines all share one source line, and each was independently written back on drop, producing overlapping edits VS Code rejected outright.
+- Preview: selecting a `CNTFLD`-wrapped field showed "N fields selected" (one per wrapped line) instead of being treated as the single field it is, hiding the "↔ Center"/"⋮ Actions" buttons as a result.
 
 ## [0.13.6] - 2026-07-29
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The extension provides a **navigable schema view** of the DDS source file that i
     - Add editing keywords.
     - Add error messages.
     - Add / Remove / Change indicators.
+    - Resolve Referenced Field (for referenced fields only): fetches the real type/length/decimals from the connected IBM i, via the [Code for i](https://marketplace.visualstudio.com/items?itemName=HalcyonTechLtd.code-for-ibmi) extension. Also available as "Resolve All Referenced Fields" from the status bar, for every pending referenced field in the document at once.
 
 - **Attributes**
     - Add / Remove / Change indicators.
@@ -118,10 +119,11 @@ Some features may not work as expected. Please leave an issue if something is no
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**0.13.5** - 2026-07-28
-- Fixed: Add/Edit Field: a field length of 100 or more corrupted the generated DDS line, since the length column was only reserved 2 characters wide instead of the 5 DDS itself uses; the parser also only read back the last 2 digits of that column, showing the wrong length in the tree and preview.
-- Fixed: Add Field: a referenced field generated an invalid `REFFLD(library/file.field)` specification instead of the correct `REFFLD(field [library/]file)` format; the library is now optional, matching DDS itself (defaults to `*LIBL`).
-- Added: Preview: a referenced field now renders as a single marker character in a distinct color with a dashed box, instead of a guessed-width placeholder.
+**0.14.0** - 2026-07-28
+- Added: "Resolve Referenced Field" action (and "Resolve All Referenced Fields", from a new status bar item) fetches a referenced field's real type/length/decimals from the connected IBM i, via the [Code for i](https://marketplace.visualstudio.com/items?itemName=HalcyonTechLtd.code-for-ibmi) extension. Resolved fields show their real type/length in both the tree and the preview.
+- Fixed: Performance: re-parsing a document (e.g. after moving a field in the preview) got dramatically slower as it grew larger, due to two O(n²) hotspots in the parser. Both are now linear.
+- Fixed: Performance: checking whether a file is read-only before applying an edit did a live round-trip to the IBM i on every single edit while connected via Code for i. It's now cached per document.
+- Fixed: Referenced fields were missing the usual field context menu/inline actions (delete, copy, rename, etc.).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ The extension provides a **navigable schema view** of the DDS source file that i
 
 - **Screen Preview**
   - Visual, green-screen-style preview of a record's fields and constants (colors, DSPATR attributes, and placeholders for output/input/both fields).
+  - A field coded with `CNTFLD(n)` wraps across multiple lines in the preview, `n` characters each, all starting at its original column — matching how RDi previews it.
   - A single, compact toolbar (size, display format, overlay, indicators, add buttons) sits above the preview.
   - Drag fields/constants to reposition them directly on the preview.
   - "+ Field" / "+ Constant" buttons: click, then click a point on the screen to place a new field/constant there, using the same prompts as the tree's "Add field"/"Add constant" commands.
@@ -121,11 +122,15 @@ Some features may not work as expected. Please leave an issue if something is no
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**0.14.0** - 2026-07-29
+**0.14.0** - 2026-07-30
 - Added: "Resolve Referenced Field" action (and "Resolve All Referenced Fields", from a new status bar item) fetches a referenced field's real type/length/decimals from the connected IBM i, via the [Code for i](https://marketplace.visualstudio.com/items?itemName=HalcyonTechLtd.code-for-ibmi) extension. Resolved fields show their real type/length in both the tree and the preview.
+- Added: Preview support for the `CNTFLD(n)` keyword — a field too long for one line now wraps across multiple rows, `n` characters each, at the same column, matching RDi's preview. Centering such a field now uses its per-line width instead of its full declared length.
 - Fixed: Performance: re-parsing a document (e.g. after moving a field in the preview) got dramatically slower as it grew larger, due to two O(n²) hotspots in the parser. Both are now linear.
 - Fixed: Performance: checking whether a file is read-only before applying an edit did a live round-trip to the IBM i on every single edit while connected via Code for i. It's now cached per document.
 - Fixed: Referenced fields were missing the usual field context menu/inline actions (delete, copy, rename, etc.).
+- Fixed: Parser: a field/constant positioned relative (`+n`) right after a bare system keyword (`DATE`, `TIME`, `USER`, `SYSNAME`) landed several columns too far left in the preview, overlapping the keyword's own placeholder.
+- Fixed: Preview: dragging a `CNTFLD`-wrapped field failed with a false "document may be read-only" error, since its wrapped lines all share one source line.
+- Fixed: Preview: selecting a `CNTFLD`-wrapped field showed "N fields selected" instead of treating it as the single field it is, hiding the "Center"/"Actions" buttons.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dspf-edit",
-  "version": "0.13.5",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dspf-edit",
-      "version": "0.13.5",
+      "version": "0.14.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "0.13.5",
+  "version": "0.14.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"
@@ -30,7 +30,7 @@
     "dspf"
   ],
   "engines": {
-    "vscode": "^1.75.0" 
+    "vscode": "^1.75.0"
   },
   "license": "MIT",
   "categories": [
@@ -44,19 +44,19 @@
     "viewsContainers": {
       "activitybar": [
         {
-          "id" : "dspf-edit",
-          "title" : "DSPF Structure",
-          "icon" : "assets/dds_extension_icon_activity.svg",
-          "when" : "true"
+          "id": "dspf-edit",
+          "title": "DSPF Structure",
+          "icon": "assets/dds_extension_icon_activity.svg",
+          "when": "true"
         }
       ]
     },
     "views": {
-      "dspf-edit" : [
+      "dspf-edit": [
         {
-          "id" : "dspf-edit.schema-view",
-          "name" : "Definition",
-          "when" : "true"
+          "id": "dspf-edit.schema-view",
+          "name": "Definition",
+          "when": "true"
         }
       ]
     },
@@ -171,6 +171,16 @@
         "title": "Copy Constant"
       },
       {
+        "command": "dspf-edit.resolve-referenced-field",
+        "title": "Resolve Referenced Field",
+        "icon": "$(cloud-download)"
+      },
+      {
+        "command": "dspf-edit.resolve-all-referenced-fields",
+        "title": "Resolve All Referenced Fields",
+        "icon": "$(cloud-download)"
+      },
+      {
         "command": "dspf-edit.remove-element",
         "title": "Delete",
         "icon": "$(trash)"
@@ -262,47 +272,52 @@
         },
         {
           "command": "dspf-edit.edit-field",
-          "when": "view == dspf-edit.schema-view && viewItem == field",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\bfield\\b/",
           "group": "fields_constants_navigation1@1"
         },
         {
+          "command": "dspf-edit.resolve-referenced-field",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\breferenced-(pending|resolved)\\b/",
+          "group": "fields_constants_navigation1@0"
+        },
+        {
           "command": "dspf-edit.center",
-          "when": "view == dspf-edit.schema-view && (viewItem == constant || viewItem == field)",
+          "when": "view == dspf-edit.schema-view && (viewItem == constant || viewItem =~ /\\bfield\\b/)",
           "group": "fields_constants_navigation2@2"
         },
         {
           "command": "dspf-edit.change-position",
-          "when": "view == dspf-edit.schema-view && (viewItem == constant || viewItem == field)",
+          "when": "view == dspf-edit.schema-view && (viewItem == constant || viewItem =~ /\\bfield\\b/)",
           "group": "fields_constants_navigation2@3"
         },
         {
           "command": "dspf-edit.add-color",
-          "when": "view == dspf-edit.schema-view && (viewItem == constant || viewItem == field)",
+          "when": "view == dspf-edit.schema-view && (viewItem == constant || viewItem =~ /\\bfield\\b/)",
           "group": "fields_constants_navigation3@1"
         },
         {
           "command": "dspf-edit.add-attribute",
-          "when": "view == dspf-edit.schema-view && (viewItem == constant || viewItem == field)",
+          "when": "view == dspf-edit.schema-view && (viewItem == constant || viewItem =~ /\\bfield\\b/)",
           "group": "fields_constants_navigation3@2"
         },
         {
           "command": "dspf-edit.add-validity-check",
-          "when": "view == dspf-edit.schema-view && viewItem == field",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\bfield\\b/",
           "group": "fields_constants_navigation3@3"
         },
         {
           "command": "dspf-edit.add-editing-keywords",
-          "when": "view == dspf-edit.schema-view && viewItem == field",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\bfield\\b/",
           "group": "fields_constants_navigation3@4"
         },
         {
           "command": "dspf-edit.add-error-message",
-          "when": "view == dspf-edit.schema-view && viewItem == field",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\bfield\\b/",
           "group": "fields_constants_navigation3@5"
         },
         {
           "command": "dspf-edit.add-indicators",
-          "when": "view == dspf-edit.schema-view && (viewItem == constant || viewItem == field)",
+          "when": "view == dspf-edit.schema-view && (viewItem == constant || viewItem =~ /\\bfield\\b/)",
           "group": "fields_constants_navigation3@6"
         },
         {
@@ -387,7 +402,7 @@
         },
         {
           "command": "dspf-edit.copy-field",
-          "when": "view == dspf-edit.schema-view && viewItem == field",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\bfield\\b/",
           "group": "fields_constants_navigation1@2"
         },
         {
@@ -402,7 +417,7 @@
         },
         {
           "command": "dspf-edit.remove-element",
-          "when": "view == dspf-edit.schema-view && viewItem == field",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\bfield\\b/",
           "group": "fields_constants_navigation1@3"
         },
         {
@@ -411,19 +426,24 @@
           "group": "fields_constants_navigation1@3"
         },
         {
-          "command" : "dspf-edit.remove-element",
-          "when" : "view == dspf-edit.schema-view && (viewItem == constant || viewItem == field)",
-          "group" : "inline@99"
+          "command": "dspf-edit.resolve-referenced-field",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\breferenced-(pending|resolved)\\b/",
+          "group": "inline@1"
         },
         {
-          "command" : "dspf-edit.remove-attribute",
-          "when" : "view == dspf-edit.schema-view && (viewItem == constantAttribute || viewItem == fieldAttribute)",
-          "group" : "inline@99"
+          "command": "dspf-edit.remove-element",
+          "when": "view == dspf-edit.schema-view && (viewItem == constant || viewItem =~ /\\bfield\\b/)",
+          "group": "inline@99"
         },
         {
-          "command" : "dspf-edit.rename-record",
-          "when" : "view == dspf-edit.schema-view && viewItem =~ /\\brecord\\b/",
-          "group" : "inline@99"
+          "command": "dspf-edit.remove-attribute",
+          "when": "view == dspf-edit.schema-view && (viewItem == constantAttribute || viewItem == fieldAttribute)",
+          "group": "inline@99"
+        },
+        {
+          "command": "dspf-edit.rename-record",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\brecord\\b/",
+          "group": "inline@99"
         },
         {
           "command": "dspf-edit.preview-record",
@@ -431,9 +451,9 @@
           "group": "inline@1"
         },
         {
-          "command" : "dspf-edit.rename-field",
-          "when" : "view == dspf-edit.schema-view && viewItem == field",
-          "group" : "inline@99"
+          "command": "dspf-edit.rename-field",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\bfield\\b/",
+          "group": "inline@99"
         },
         {
           "command": "dspf-edit.moveConstantLeft5",
@@ -455,25 +475,24 @@
           "when": "view == dspf-edit.schema-view && viewItem == constant",
           "group": "inline@4"
         },
-
         {
           "command": "dspf-edit.moveFieldLeft5",
-          "when": "view == dspf-edit.schema-view && viewItem == field",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\bfield\\b/",
           "group": "inline@1"
         },
         {
           "command": "dspf-edit.moveFieldLeft1",
-          "when": "view == dspf-edit.schema-view && viewItem == field",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\bfield\\b/",
           "group": "inline@2"
         },
         {
           "command": "dspf-edit.moveFieldRight1",
-          "when": "view == dspf-edit.schema-view && viewItem == field",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\bfield\\b/",
           "group": "inline@3"
         },
         {
           "command": "dspf-edit.moveFieldRight5",
-          "when": "view == dspf-edit.schema-view && viewItem == field",
+          "when": "view == dspf-edit.schema-view && viewItem =~ /\\bfield\\b/",
           "group": "inline@4"
         }
       ]

--- a/src/dspf-edit.commands/dspf-edit.center.ts
+++ b/src/dspf-edit.commands/dspf-edit.center.ts
@@ -161,7 +161,11 @@ function calculateFieldCenterPosition(element: any, maxCols: number): number {
     // A system keyword field (DATE, USER...) always displays at its own fixed width, regardless
     // of whatever the source's own length column holds (typically blank/0 for these).
     const systemWidth = SYSTEM_FIELD_PLACEHOLDER[String(element.name).trim().toUpperCase()]?.length;
-    const width = systemWidth ?? element.length;
+    // A CNTFLD(n)-wrapped field displays only n characters per line (wrapping onto further rows
+    // below, all at this same column) — centering must use that per-line width, not the field's
+    // full declared length, or it lands miles off-screen for a long wrapped field.
+    const continuedWidth = getContinuedFieldWidth(element.attributes);
+    const width = systemWidth ?? (continuedWidth && element.length > continuedWidth ? continuedWidth : element.length);
 
     if (width) {
         return Math.floor((maxCols - width) / 2) + 1;
@@ -169,6 +173,17 @@ function calculateFieldCenterPosition(element: any, maxCols: number): number {
         // If no length is available, keep the current column position
         return element.column;
     };
+};
+
+/**
+ * Extracts a field's CNTFLD() continuation width, if it carries one — the number of characters
+ * shown per line before wrapping to the next row (same column) for a field too long to fit on one line.
+ * @param attributes - The field's DDS attributes
+ */
+function getContinuedFieldWidth(attributes: any[] | undefined): number | undefined {
+    const attr = attributes?.find((a: any) => /^CNTFLD\(/i.test(a.value));
+    const width = attr?.value.match(/^CNTFLD\(\s*(\d+)\s*\)$/i)?.[1];
+    return width ? Number(width) : undefined;
 };
 
 /**

--- a/src/dspf-edit.commands/dspf-edit.resolve-referenced-field.ts
+++ b/src/dspf-edit.commands/dspf-edit.resolve-referenced-field.ts
@@ -1,0 +1,128 @@
+/*
+    Christian Larsen, 2025
+    "RPG structure"
+    dspf-edit.resolve-referenced-field.ts
+*/
+
+import * as vscode from 'vscode';
+import { DdsNode, DdsTreeProvider } from '../dspf-edit.providers/dspf-edit.providers';
+import { DdsField, fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
+import { checkForEditorAndDocument } from '../dspf-edit.utils/dspf-edit.helper';
+import { resolveReferencedField, getPendingReferencedFields } from '../dspf-edit.ibmi/dspf-edit.ibmi-integration';
+
+/**
+ * Resolves one referenced field, looking up its record's attributes for the REF() fallback.
+ * @param documentUri - The DDS document's URI (as a string), used as the cache key
+ * @param field - The referenced field to resolve
+ * @returns An error message on failure, or undefined on success
+ */
+async function resolveOneField(documentUri: string, field: DdsField): Promise<string | undefined> {
+    const recordAttributes = fieldsPerRecords.find(r => r.record === field.recordname)?.attributes;
+    try {
+        await resolveReferencedField(documentUri, field, recordAttributes);
+        return undefined;
+    } catch (error) {
+        return error instanceof Error ? error.message : `Could not resolve field '${field.name}'.`;
+    };
+};
+
+/**
+ * Registers the command that resolves a single referenced field's real type/length/decimals
+ * against the connected IBM i (via Code for i), shown as an inline button on referenced-pending
+ * fields in the tree.
+ * @param context - The VS Code extension context
+ * @param treeProvider - The tree provider, refreshed after a successful resolution
+ */
+export function resolveReferencedFieldCommand(context: vscode.ExtensionContext, treeProvider: DdsTreeProvider): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand('dspf-edit.resolve-referenced-field', async (node: DdsNode) => {
+            await handleResolveReferencedField(node, treeProvider);
+        })
+    );
+};
+
+/**
+ * Resolves one referenced field and refreshes the tree. Errors (no connection, file/field not
+ * found, ...) are shown to the user rather than thrown further, matching the other tree commands.
+ * @param node - The tree node for the referenced field to resolve
+ * @param treeProvider - The tree provider, refreshed after a successful resolution
+ */
+async function handleResolveReferencedField(node: DdsNode, treeProvider: DdsTreeProvider): Promise<void> {
+    const element = node.ddsElement;
+    if (element.kind !== 'field' || !element.referenced) {
+        return;
+    };
+
+    const { document } = checkForEditorAndDocument();
+    if (!document) {
+        return;
+    };
+
+    await vscode.window.withProgress(
+        { location: vscode.ProgressLocation.Window, title: `Resolving ${element.name}...` },
+        async () => {
+            const error = await resolveOneField(document.uri.toString(), element);
+            treeProvider.refresh();
+            if (error) {
+                vscode.window.showErrorMessage(error);
+            };
+        }
+    );
+};
+
+/**
+ * Registers the command that resolves every referenced field still pending in the current
+ * document, shown on the "N referenced fields pending" status bar item.
+ * @param context - The VS Code extension context
+ * @param treeProvider - The tree provider, both read for pending fields and refreshed afterwards
+ */
+export function resolveAllReferencedFieldsCommand(context: vscode.ExtensionContext, treeProvider: DdsTreeProvider): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand('dspf-edit.resolve-all-referenced-fields', async () => {
+            await handleResolveAllReferencedFields(treeProvider);
+        })
+    );
+};
+
+/**
+ * Resolves every pending referenced field in the current document, one at a time, then refreshes
+ * the tree once. Reports a summary rather than one message per field.
+ * @param treeProvider - The tree provider, both read for pending fields and refreshed afterwards
+ */
+async function handleResolveAllReferencedFields(treeProvider: DdsTreeProvider): Promise<void> {
+    const { document } = checkForEditorAndDocument();
+    if (!document) {
+        return;
+    };
+
+    const documentUri = document.uri.toString();
+    const pendingFields = getPendingReferencedFields(documentUri, treeProvider.getElements());
+    if (pendingFields.length === 0) {
+        vscode.window.showInformationMessage('No pending referenced fields to resolve.');
+        return;
+    };
+
+    const errors: string[] = [];
+
+    await vscode.window.withProgress(
+        { location: vscode.ProgressLocation.Notification, title: 'Resolving referenced fields...', cancellable: false },
+        async (progress) => {
+            for (const field of pendingFields) {
+                progress.report({ message: field.name });
+                const error = await resolveOneField(documentUri, field);
+                if (error) {
+                    errors.push(error);
+                };
+            };
+        }
+    );
+
+    treeProvider.refresh();
+
+    const resolvedCount = pendingFields.length - errors.length;
+    if (errors.length === 0) {
+        vscode.window.showInformationMessage(`Resolved ${resolvedCount} referenced field${resolvedCount === 1 ? '' : 's'}.`);
+    } else {
+        vscode.window.showWarningMessage(`Resolved ${resolvedCount} of ${pendingFields.length} referenced field(s). ${errors.length} failed: ${errors.join(' ')}`);
+    };
+};

--- a/src/dspf-edit.commands/register-commands.ts
+++ b/src/dspf-edit.commands/register-commands.ts
@@ -37,6 +37,7 @@ import { renameField, renameRecord } from './dspf-edit.rename';
 import { moveConstantLeft1, moveConstantLeft5, moveConstantRight1, moveConstantRight5 } from './dspf-edit.move-constants';
 import { moveFieldLeft1, moveFieldLeft5, moveFieldRight1, moveFieldRight5 } from './dspf-edit.move-fields';
 import { previewRecord } from './dspf-edit.preview-record';
+import { resolveReferencedFieldCommand, resolveAllReferencedFieldsCommand } from './dspf-edit.resolve-referenced-field';
 
 export const commands = [
     { name: 'viewStructure', handler: viewStructure, needsTreeProvider: true },
@@ -76,7 +77,9 @@ export const commands = [
     { name: 'moveFieldLeft1', handler: moveFieldLeft1, needsTreeProvider: false },
     { name: 'moveFieldLeft5', handler: moveFieldLeft5, needsTreeProvider: false },
     { name: 'moveFieldRight1', handler: moveFieldRight1, needsTreeProvider: false },
-    { name: 'moveFieldRight5', handler: moveFieldRight5, needsTreeProvider: false }
+    { name: 'moveFieldRight5', handler: moveFieldRight5, needsTreeProvider: false },
+    { name: 'resolveReferencedField', handler: resolveReferencedFieldCommand, needsTreeProvider: true },
+    { name: 'resolveAllReferencedFields', handler: resolveAllReferencedFieldsCommand, needsTreeProvider: true }
 
 ];
 

--- a/src/dspf-edit.ibmi/dspf-edit.ibmi-integration.ts
+++ b/src/dspf-edit.ibmi/dspf-edit.ibmi-integration.ts
@@ -1,0 +1,198 @@
+/*
+    Christian Larsen, 2025
+    "RPG structure"
+    dspf-edit.ibmi-integration.ts
+*/
+
+import * as vscode from 'vscode';
+import { DdsAttribute, DdsElement, DdsField, attributesFileLevel } from '../dspf-edit.model/dspf-edit.model';
+
+/**
+ * Isolated from the rest of the extension on purpose: this is the only file that knows about the
+ * Code for i extension's API, which its own docs say may change between releases.
+ *
+ * Deliberately NOT typed against `@halcyontech/vscode-ibmi-types`: importing its `IBMi`/`CodeForIBMi`
+ * types pulls in transitive type dependencies (`@ibm/mapepire-js`, `node-ssh`, `ssh2`) that aren't
+ * installed and aren't declared by that package either, which breaks `tsc` for anything that just
+ * wants types. Instead, a minimal structural interface covers only what's actually called here.
+ */
+
+const CODE_FOR_IBMI_EXTENSION_ID = 'halcyontechltd.code-for-ibmi';
+
+/** The slice of Code for i's `IBMi` connection this module actually calls. */
+interface MinimalIBMiConnection {
+    runSQL(statements: string | string[], options?: { bindings?: (string | number | null)[] }): Promise<Record<string, string | number | null>[]>;
+};
+
+/** The slice of Code for i's exported API this module actually calls. */
+interface MinimalCodeForIBMi {
+    instance: {
+        getConnection(): MinimalIBMiConnection | undefined;
+    };
+};
+
+/** A referenced field's real type/length/decimals, as resolved from the IBM i database. */
+export interface ResolvedRefInfo {
+    type: string;
+    length: number;
+    decimals: number;
+};
+
+/**
+ * Gets the active IBM i connection from the Code for i extension, if installed and connected.
+ * Returns undefined rather than throwing: callers decide how to surface "no connection" to the user.
+ */
+export function getIBMiConnection(): MinimalIBMiConnection | undefined {
+    const codeForIBMi = vscode.extensions.getExtension<MinimalCodeForIBMi>(CODE_FOR_IBMI_EXTENSION_ID);
+    return codeForIBMi?.exports?.instance?.getConnection();
+};
+
+/**
+ * Extracts the file (and optional library) named by a REF() keyword — used as a fallback when a
+ * referenced field's own REFFLD() doesn't name a file (or there's no REFFLD at all), so the file
+ * comes from the record- or file-level REF() instead.
+ * @param attributes - The record's or file's own DDS attributes
+ */
+function findRefKeyword(attributes: DdsAttribute[] | undefined): { file: string; library?: string } | undefined {
+    const attr = attributes?.find(a => a.value.toUpperCase().startsWith('REF('));
+    if (!attr) {
+        return undefined;
+    };
+
+    const match = attr.value.match(/^REF\(\s*(\S+)\s*\)$/i);
+    if (!match) {
+        return undefined;
+    };
+
+    const qualifiedFile = match[1];
+    const [library, file] = qualifiedFile.includes('/') ? qualifiedFile.split('/') : [undefined, qualifiedFile];
+    return { file, library };
+};
+
+/**
+ * Best-effort mapping from a QSYS2.SYSCOLUMNS DATA_TYPE to a DDS single-letter field type. Covers
+ * the common DDS-creatable types; refine against real IBM i data as edge cases turn up.
+ */
+const SQL_TYPE_TO_DDS: Record<string, string> = {
+    CHARACTER: 'A',
+    CHAR: 'A',
+    VARCHAR: 'A',
+    GRAPHIC: 'A',
+    VARGRAPHIC: 'A',
+    DECIMAL: 'P',
+    NUMERIC: 'P',
+    ZONED: 'S',
+    BINARY: 'B',
+    VARBINARY: 'B',
+    SMALLINT: 'B',
+    INTEGER: 'B',
+    BIGINT: 'B',
+    FLOAT: 'F',
+    REAL: 'F',
+    DOUBLE: 'F',
+    DATE: 'L',
+    TIME: 'T',
+    TIMESTAMP: 'Z'
+};
+
+/**
+ * Maps a QSYS2.SYSCOLUMNS row to the DDS type/length/decimals convention used elsewhere in the
+ * model (e.g. `DdsField.type`/`length`/`decimals`).
+ * @param dataType - QSYS2.SYSCOLUMNS.DATA_TYPE
+ * @param length - QSYS2.SYSCOLUMNS.LENGTH
+ * @param scale - QSYS2.SYSCOLUMNS.NUMERIC_SCALE
+ */
+function mapSqlTypeToDds(dataType: string, length: number, scale: number): ResolvedRefInfo {
+    const type = SQL_TYPE_TO_DDS[dataType.toUpperCase()] ?? 'A';
+    return { type, length, decimals: scale || 0 };
+};
+
+/** Per-document cache of resolved referenced fields: uri -> "record.field" -> resolved info. */
+const resolvedRefCache: Map<string, Map<string, ResolvedRefInfo>> = new Map();
+
+/** Builds the cache key for a field within a document. */
+function fieldCacheKey(recordName: string, fieldName: string): string {
+    return `${recordName}.${fieldName}`;
+};
+
+/** Gets a previously-resolved referenced field's info, if any, for the given document. */
+export function getResolvedRef(documentUri: string, recordName: string, fieldName: string): ResolvedRefInfo | undefined {
+    return resolvedRefCache.get(documentUri)?.get(fieldCacheKey(recordName, fieldName));
+};
+
+function setResolvedRef(documentUri: string, recordName: string, fieldName: string, info: ResolvedRefInfo): void {
+    if (!resolvedRefCache.has(documentUri)) {
+        resolvedRefCache.set(documentUri, new Map());
+    };
+    resolvedRefCache.get(documentUri)!.set(fieldCacheKey(recordName, fieldName), info);
+};
+
+/** Clears every resolved referenced field cached for a document (e.g. when it's closed). */
+export function clearResolvedRef(documentUri: string): void {
+    resolvedRefCache.delete(documentUri);
+};
+
+/** Recursively collects every referenced field in a parsed DDS element tree. */
+function collectReferencedFields(elements: DdsElement[]): DdsField[] {
+    const fields: DdsField[] = [];
+    for (const element of elements) {
+        if (element.kind === 'field' && element.referenced) {
+            fields.push(element);
+        };
+        if (element.children) {
+            fields.push(...collectReferencedFields(element.children));
+        };
+    };
+    return fields;
+};
+
+/** Every referenced field in the document that hasn't been resolved yet. */
+export function getPendingReferencedFields(documentUri: string, elements: DdsElement[]): DdsField[] {
+    return collectReferencedFields(elements).filter(field => !getResolvedRef(documentUri, field.recordname, field.name));
+};
+
+/**
+ * Resolves a referenced field's real type/length/decimals against the connected IBM i, caching
+ * the result for the document. Throws a descriptive error (no connection, no file could be
+ * determined, field not found) rather than returning a sentinel — callers show it to the user.
+ * @param documentUri - The DDS document's URI (as a string), used as the cache key
+ * @param field - The referenced field to resolve
+ * @param recordAttributes - The field's own record's attributes, for a record-level REF() fallback
+ */
+export async function resolveReferencedField(documentUri: string, field: DdsField, recordAttributes: DdsAttribute[] | undefined): Promise<ResolvedRefInfo> {
+    const connection = getIBMiConnection();
+    if (!connection) {
+        throw new Error('No active IBM i connection. Connect via the Code for i extension first.');
+    };
+
+    const target = field.refTarget ?? { fieldName: field.name };
+    const fileRef = target.file
+        ? { file: target.file, library: target.library }
+        : findRefKeyword(recordAttributes) ?? findRefKeyword(attributesFileLevel);
+
+    if (!fileRef?.file) {
+        throw new Error(`Could not determine the referenced database file for field '${field.name}' (no file named in REFFLD() and no REF() keyword found).`);
+    };
+
+    // REFFLD()/REF() names are always DDS-style short "system" names (max 10 chars) — for a native
+    // physical/logical file these match the SQL long name, but for an SQL-created table they can
+    // differ (e.g. long name CUSTOMER_MASTER, system name CUSTMAST). Filtering on QSYS2.SYSCOLUMNS'
+    // own SYSTEM_* columns instead of its long-name ones handles both.
+    const bindings = [fileRef.file.toUpperCase(), target.fieldName.toUpperCase()];
+    let sql = `SELECT DATA_TYPE, LENGTH, NUMERIC_SCALE FROM QSYS2.SYSCOLUMNS WHERE SYSTEM_TABLE_NAME = ? AND SYSTEM_COLUMN_NAME = ?`;
+    if (fileRef.library) {
+        sql += ' AND SYSTEM_TABLE_SCHEMA = ?';
+        bindings.push(fileRef.library.toUpperCase());
+    };
+
+    const rows = await connection.runSQL(sql, { bindings });
+    const row = rows[0];
+    if (!row) {
+        const qualifiedFile = fileRef.library ? `${fileRef.library}/${fileRef.file}` : fileRef.file;
+        throw new Error(`Field '${target.fieldName}' not found in ${qualifiedFile}.`);
+    };
+
+    const resolved = mapSqlTypeToDds(String(row.DATA_TYPE), Number(row.LENGTH), Number(row.NUMERIC_SCALE ?? 0));
+    setResolvedRef(documentUri, field.recordname, field.name, resolved);
+    return resolved;
+};

--- a/src/dspf-edit.listeners/listeners.ts
+++ b/src/dspf-edit.listeners/listeners.ts
@@ -8,7 +8,8 @@ import * as vscode from 'vscode';
 import { DdsTreeProvider } from '../dspf-edit.providers/dspf-edit.providers';
 import { generateStructure } from '../dspf-edit.commands/dspf-edit.generate-structure';
 import { ExtensionState } from '../dspf-edit.states/state';
-import { debounceUpdate, generateIfDds } from '../dspf-edit.utils/dspf-edit.helper';
+import { debounceUpdate, generateIfDds, clearReadOnlyCache } from '../dspf-edit.utils/dspf-edit.helper';
+import { clearResolvedRef } from '../dspf-edit.ibmi/dspf-edit.ibmi-integration';
 
 export function initializeDocumentListeners(
     context: vscode.ExtensionContext,
@@ -42,6 +43,8 @@ export function initializeDocumentListeners(
             if (ExtensionState.lastDdsDocument && document === ExtensionState.lastDdsDocument) {
                 ExtensionState.clearTimeout();
                 treeProvider.cleanupDocumentFilter(document.uri.toString());
+                clearResolvedRef(document.uri.toString());
+                clearReadOnlyCache(document.uri.toString());
                 ExtensionState.lastDdsDocument = undefined;
                 ExtensionState.lastDdsEditor = undefined;
                 treeProvider.setElements([]);

--- a/src/dspf-edit.model/dspf-edit.model.ts
+++ b/src/dspf-edit.model/dspf-edit.model.ts
@@ -98,6 +98,9 @@ export interface DdsField {
   column?: number;
   hidden?: boolean;
   referenced?: boolean;
+  /** For a referenced field: the field/file/library its type/length/decimals are borrowed from,
+   * parsed from its REFFLD() keyword (or, absent one, its own name in an R-flagged field). */
+  refTarget?: { fieldName: string; file?: string; library?: string };
   lineIndex: number;
   recordname: string;
   attribute?: string;

--- a/src/dspf-edit.parser/dspf-edit.parser.ts
+++ b/src/dspf-edit.parser/dspf-edit.parser.ts
@@ -269,6 +269,35 @@ function isSubfileRecord(attributes?: DdsAttribute[]): boolean {
  */
 const FIXED_LENGTH_BY_TYPE: Record<string, number> = { L: 10, T: 8, Z: 26 };
 
+/**
+ * Extracts a referenced field's REFFLD() target: the field name (and, optionally, its qualified
+ * database file) whose type/length/decimals this field borrows. Matches the format dspf-edit
+ * itself generates (see `generateNewFieldLine` in edit-field.ts): REFFLD(field-name {library/}file-name).
+ * Falls back to the field's own name when there's no REFFLD (a bare "R" referencing a file/record
+ * -level REF() under the same field name).
+ * @param attributes - The field's own DDS attributes
+ * @param ownName - The field's own name, used as the fallback reference target
+ */
+function parseReffldTarget(attributes: DdsAttribute[] | undefined, ownName: string): { fieldName: string; file?: string; library?: string } {
+    const attr = attributes?.find(a => a.value.toUpperCase().startsWith('REFFLD('));
+    if (!attr) {
+        return { fieldName: ownName };
+    };
+
+    const match = attr.value.match(/^REFFLD\(\s*(\S+)(?:\s+(\S+))?\s*\)$/i);
+    if (!match) {
+        return { fieldName: ownName };
+    };
+
+    const [, fieldName, qualifiedFile] = match;
+    if (!qualifiedFile) {
+        return { fieldName };
+    };
+
+    const [library, file] = qualifiedFile.includes('/') ? qualifiedFile.split('/') : [undefined, qualifiedFile];
+    return { fieldName, file, library };
+};
+
 function parseFieldElement(
     lines: string[],
     lineIndex: number,
@@ -284,6 +313,7 @@ function parseFieldElement(
     const isReferenced = trimmedLine[23] === 'R';
 
     const { attributes, nextIndex } = extractAttributes('F', lines, lineIndex, true, components.indicators, components.displayFormat);
+    const refTarget = isReferenced ? parseReffldTarget(attributes, components.fieldName) : undefined;
 
     // Check if the current record (lastRecord) is a subfile by looking at its attributes
     const currentRecordEntry = fieldsPerRecords.find(r => r.record === lastRecord);
@@ -311,6 +341,7 @@ function parseFieldElement(
         column: isHidden ? undefined : finalCol,
         hidden: isHidden,
         referenced: isReferenced,
+        refTarget: refTarget,
         lineIndex: lineIndex,
         recordname: lastRecord,
         attributes: attributes || [],
@@ -593,25 +624,41 @@ function linkAttributesToParents(ddsElements: DdsElement[]): void {
  * @param ddsElements - Array of all parsed DDS elements
  */
 function linkFieldsAndConstantsToRecords(ddsElements: DdsElement[]): void {
+    // ddsElements is already in source line order (parseAllLines pushes each element as it parses
+    // lines top to bottom), so the nearest preceding record is simply the last 'record' element
+    // seen so far in a single forward pass — no need to rescan the whole array per field/constant.
+    let currentRecord: DdsRecord | undefined;
+
+    // Per-record dedup sets, keyed by the record's own fieldsPerRecords entry (a stable object
+    // reference for its lifetime here) — an O(1) alternative to rescanning recordEntry.fields/
+    // .constants (which only grow) on every single field/constant, an O(n²) hotspot at scale.
+    const seenFieldNames = new Map<any, Set<string>>();
+    const seenConstantLines = new Map<any, Set<number>>();
+
     for (const element of ddsElements) {
-        if ((element.kind === 'field') || element.kind === 'constant') {
-            // Find parent record for this field/constant
-            const parentRecord = [...ddsElements]
-                .reverse()
-                .find(p =>
-                    p.lineIndex < element.lineIndex &&
-                    p.kind === 'record'
-                ) as DdsRecord | undefined;
+        if (element.kind === 'record') {
+            currentRecord = element;
+            continue;
+        };
 
-            if (parentRecord) {
-                const recordEntry = fieldsPerRecords.find(r => r.record === parentRecord.name);
+        if ((element.kind === 'field' || element.kind === 'constant') && currentRecord) {
+            const recordEntry = fieldsPerRecords.find(r => r.record === currentRecord!.name);
 
-                if (recordEntry) {
-                    if (element.kind === 'field') {
-                        addFieldToRecord(element, recordEntry);
-                    } else if (element.kind === 'constant') {
-                        addConstantToRecord(element, recordEntry);
+            if (recordEntry) {
+                if (element.kind === 'field') {
+                    let names = seenFieldNames.get(recordEntry);
+                    if (!names) {
+                        names = new Set();
+                        seenFieldNames.set(recordEntry, names);
                     };
+                    addFieldToRecord(element, recordEntry, names);
+                } else {
+                    let lines = seenConstantLines.get(recordEntry);
+                    if (!lines) {
+                        lines = new Set();
+                        seenConstantLines.set(recordEntry, lines);
+                    };
+                    addConstantToRecord(element, recordEntry, lines);
                 };
             };
         };
@@ -619,14 +666,17 @@ function linkFieldsAndConstantsToRecords(ddsElements: DdsElement[]): void {
 };
 
 /**
- * Adds a field element to its parent record entry
+ * Adds a field element to its parent record entry, unless a field of the same name was already
+ * added to it (tracked via `seenFieldNames`, an O(1) alternative to rescanning recordEntry.fields).
  * @param field - Field element to add
  * @param recordEntry - Record entry to add field to
+ * @param seenFieldNames - Field names already added to this record entry
  */
-function addFieldToRecord(field: any, recordEntry: any): void {
+function addFieldToRecord(field: any, recordEntry: any, seenFieldNames: Set<string>): void {
     // Avoid duplicate fields
-    if (!recordEntry.fields.some((f: any) => f.name === field.name)) {
-        
+    if (!seenFieldNames.has(field.name)) {
+        seenFieldNames.add(field.name);
+
         // Process attributes preserving their indicators
         const processedAttributes = field.attributes?.map((attr: any) => ({
             value: attr.value,
@@ -654,11 +704,13 @@ function addFieldToRecord(field: any, recordEntry: any): void {
 };
 
 /**
- * Adds a constant element to its parent record entry
+ * Adds a constant element to its parent record entry, unless this exact source line was already
+ * added to it (tracked via `seenLineIndexes`, an O(1) alternative to rescanning recordEntry.constants).
  * @param constant - Constant element to add
  * @param recordEntry - Record entry to add constant to
+ * @param seenLineIndexes - Line indexes already added to this record entry
  */
-function addConstantToRecord(constant: any, recordEntry: any): void {
+function addConstantToRecord(constant: any, recordEntry: any, seenLineIndexes: Set<number>): void {
     // Remove quotes from constant name for storage — but only when it's actually a quoted
     // literal. A DDS system keyword (DATE, TIME, USER, SYSNAME) can be coded bare, in the same
     // position a quoted constant would occupy; blindly slicing it would eat its first/last letter.
@@ -680,7 +732,8 @@ function addConstantToRecord(constant: any, recordEntry: any): void {
     // identical text: DDS pixel-art constructions legitimately repeat the same blank/space text
     // (e.g. '   ' or ' ') at dozens of different positions to build a colored block pattern, and
     // comparing by text alone (as this used to) silently dropped all but the first of each.
-    if (!recordEntry.constants.some((c: any) => c.lineIndex === constant.lineIndex)) {
+    if (!seenLineIndexes.has(constant.lineIndex)) {
+        seenLineIndexes.add(constant.lineIndex);
         recordEntry.constants.push({
             name: constantName,
             type: undefined,

--- a/src/dspf-edit.parser/dspf-edit.parser.ts
+++ b/src/dspf-edit.parser/dspf-edit.parser.ts
@@ -16,7 +16,8 @@ import {
     fieldsPerRecords,
     getDefaultSize,
     getSizeForFormat,
-    attributesFileLevel
+    attributesFileLevel,
+    SYSTEM_FIELD_PLACEHOLDER
 } from '../dspf-edit.model/dspf-edit.model';
 
 
@@ -389,7 +390,11 @@ function parseFieldElement(
     };
 
     if (!isHidden && resolvedRow !== undefined && resolvedCol !== undefined) {
-        lastPositionInRecord = { row: resolvedRow, col: resolvedCol, length };
+        // A bare system keyword field (DATE/TIME/USER/SYSNAME) renders at its fixed placeholder
+        // width, not the declared DDS length (usually 0, since none is coded) — use that width here
+        // so a following "+n" relative position lands after the actual rendered text, not the source length.
+        const systemWidth = SYSTEM_FIELD_PLACEHOLDER[String(components.fieldName).trim().toUpperCase()]?.length;
+        lastPositionInRecord = { row: resolvedRow, col: resolvedCol, length: systemWidth ?? length };
     };
 
     const element = {
@@ -452,7 +457,12 @@ function parseConstantElement(
     };
 
     if (resolvedRow !== undefined && resolvedCol !== undefined) {
-        lastPositionInRecord = { row: resolvedRow, col: resolvedCol, length: stripConstantQuotes(fullValue).length };
+        // A bare system keyword constant (DATE/TIME/USER/SYSNAME) renders at its fixed placeholder
+        // width, not its raw source text length — use that width here so a following "+n" relative
+        // position lands after the actual rendered text, not the source keyword's length.
+        const strippedValue = stripConstantQuotes(fullValue);
+        const systemWidth = SYSTEM_FIELD_PLACEHOLDER[strippedValue.trim().toUpperCase()]?.length;
+        lastPositionInRecord = { row: resolvedRow, col: resolvedCol, length: systemWidth ?? strippedValue.length };
     };
 
     const element = {

--- a/src/dspf-edit.providers/dspf-edit.providers.ts
+++ b/src/dspf-edit.providers/dspf-edit.providers.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import { DdsElement, DdsGroup } from '../dspf-edit.model/dspf-edit.model';
 import { describeDdsField, describeDdsConstant, describeDdsRecord, describeDdsFile, formatDdsIndicators } from '../dspf-edit.utils/dspf-edit.helper';
 import { ExtensionState } from '../dspf-edit.states/state';
+import { getResolvedRef, getPendingReferencedFields } from '../dspf-edit.ibmi/dspf-edit.ibmi-integration';
 
 /**
  * Estructura para guardar los filtros de un documento específico
@@ -53,9 +54,20 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 	// Status bar item to show active filters
 	private statusBarItem: vscode.StatusBarItem | undefined;
 
+	// Status bar item showing how many referenced fields are still pending resolution
+	private pendingRefStatusBarItem: vscode.StatusBarItem | undefined;
+
 	// Refresh the tree view
 	refresh(): void {
 		this._onDidChangeTreeData.fire();
+		this.updatePendingRefStatusBar();
+	}
+
+	/**
+	 * Gets the currently loaded DDS elements (the parsed tree for the active document).
+	 */
+	getElements(): DdsElement[] {
+		return this.elements;
 	}
 
 	// Set all DDS elements, initialize record filter if empty for current document
@@ -105,6 +117,8 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 
 		// Actualizar el status bar después de establecer los elementos
 		// con un pequeño delay para evitar parpadeos
+		// (el status bar de campos referenciados pendientes no lo necesita: ya se actualiza en
+		// refresh(), que todo llamador de setElements() invoca justo a continuación)
 		setTimeout(() => this.updateStatusBar(), 50);
 	}
 
@@ -240,6 +254,37 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 
 		this.statusBarItem.text = `$(filter) ${statusText}`;
 		this.statusBarItem.show();
+	}
+
+	/**
+	 * Initializes the pending-referenced-fields StatusBarItem if it hasn't been created yet.
+	 */
+	private initPendingRefStatusBar() {
+		if (!this.pendingRefStatusBarItem) {
+			this.pendingRefStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 99);
+			this.pendingRefStatusBarItem.command = 'dspf-edit.resolve-all-referenced-fields';
+			this.pendingRefStatusBarItem.tooltip = 'Click to resolve all pending referenced fields from the connected IBM i';
+		}
+	}
+
+	/**
+	 * Updates the pending-referenced-fields StatusBarItem for the current document. Hidden when
+	 * there are none (nothing pending, or no document loaded).
+	 */
+	private updatePendingRefStatusBar() {
+		if (!this.pendingRefStatusBarItem) this.initPendingRefStatusBar();
+		if (!this.pendingRefStatusBarItem) return;
+
+		const documentUri = this.getCurrentDocumentUri();
+		const pending = documentUri ? getPendingReferencedFields(documentUri, this.elements) : [];
+
+		if (pending.length === 0) {
+			this.pendingRefStatusBarItem.hide();
+			return;
+		}
+
+		this.pendingRefStatusBarItem.text = `$(cloud-download) ${pending.length} referenced field${pending.length > 1 ? 's' : ''} pending`;
+		this.pendingRefStatusBarItem.show();
 	}
 
 	/**
@@ -727,6 +772,21 @@ function isSflCtlElement(ddsElement: DdsElement): boolean {
 };
 
 /**
+ * Extra contextValue word for a referenced field, distinguishing whether its real type/length has
+ * already been resolved from the IBM i (consumed by package.json's view/item/context "when" clauses
+ * via a `viewItem =~ /\bword\b/` regex, same convention as the existing "record sflctl" combo).
+ */
+function referencedFieldContextSuffix(ddsElement: DdsElement): string {
+	if (ddsElement.kind !== 'field' || !ddsElement.referenced) {
+		return '';
+	};
+
+	const documentUri = ExtensionState.lastDdsDocument?.uri.toString();
+	const resolved = documentUri ? getResolvedRef(documentUri, ddsElement.recordname, ddsElement.name) : undefined;
+	return resolved ? ' referenced-resolved' : ' referenced-pending';
+};
+
+/**
  * DDS NODE CLASS
  * Represents each node in the TreeView. Configures label, tooltip, description,
  * context menu value, and navigation command to go to the line in the editor.
@@ -738,7 +798,7 @@ export class DdsNode extends vscode.TreeItem {
 		this.description = this.getDescription(ddsElement);
 		this.contextValue = label.includes('📂 Records')
 			? 'group:records'
-			: isSflCtlElement(ddsElement) ? 'record sflctl' : ddsElement.kind;
+			: isSflCtlElement(ddsElement) ? 'record sflctl' : `${ddsElement.kind}${referencedFieldContextSuffix(ddsElement)}`;
 
 		if (this.shouldHaveNavigationCommand(ddsElement)) {
 			this.command = { command: 'ddsEdit.goToLine', title: `Go to ${ddsElement.kind}`, arguments: [ddsElement.lineIndex + 1] };

--- a/src/dspf-edit.utils/dspf-edit.helper.ts
+++ b/src/dspf-edit.utils/dspf-edit.helper.ts
@@ -11,6 +11,7 @@ import { DdsElement, DdsIndicator, DdsAttribute, records, FieldsPerRecord, Const
 import { DdsTreeProvider } from '../dspf-edit.providers/dspf-edit.providers';
 import { parseDocument } from '../dspf-edit.parser/dspf-edit.parser';
 import { ExtensionState } from '../dspf-edit.states/state';
+import { getResolvedRef } from '../dspf-edit.ibmi/dspf-edit.ibmi-integration';
 
 
 // FIELD DESCRIPTION FUNCTIONS
@@ -20,27 +21,31 @@ import { ExtensionState } from '../dspf-edit.states/state';
  * @param field - The DDS element to describe
  * @returns A formatted string describing the field's properties
  */
+function formatFieldSize(length?: number, decimals?: number): string {
+    return decimals && decimals > 0 ? `(${length}:${decimals})` : `(${length})`;
+};
+
 export function describeDdsField(field: DdsElement): string {
     if (field.kind !== 'field') return 'Not a field.';
 
-    const length = field.length;
-    const decimals = field.decimals;
-
-    // Format size string with decimals if present
-    const sizeText = decimals && decimals > 0 ? `(${length}:${decimals})` : `(${length})`;
-    const type = field.type;
+    const row = field.row?.toString().padStart(2, '0') ?? '--';
+    const col = field.column?.toString().padStart(2, '0') ?? '--';
 
     if (field.hidden) {
-        return `${sizeText}${type} (Hidden)`;
-    } else if (field.referenced) {
-        const row = field.row?.toString().padStart(2, '0') ?? '--';
-        const col = field.column?.toString().padStart(2, '0') ?? '--';
-        return `(Referenced) [${col},${row}]`;
-    } else {
-        const row = field.row?.toString().padStart(2, '0') ?? '--';
-        const col = field.column?.toString().padStart(2, '0') ?? '--';
-        return `${sizeText}${type} [${col},${row}]`;
+        return `${formatFieldSize(field.length, field.decimals)}${field.type} (Hidden)`;
     };
+
+    if (field.referenced) {
+        const documentUri = ExtensionState.lastDdsDocument?.uri.toString();
+        const resolved = documentUri ? getResolvedRef(documentUri, field.recordname, field.name) : undefined;
+
+        if (resolved) {
+            return `${formatFieldSize(resolved.length, resolved.decimals)}${resolved.type} [${col},${row}] (Ref)`;
+        };
+        return `⏳ Referenced, pending [${col},${row}]`;
+    };
+
+    return `${formatFieldSize(field.length, field.decimals)}${field.type} [${col},${row}]`;
 };
 
 /**
@@ -689,6 +694,21 @@ export function checkForEditorAndDocument() : { editor : vscode.TextEditor | und
 };
 
 /**
+ * Per-document cache of the remote (non-`file:`) read-only stat — e.g. an IBM i source member
+ * opened through Code for IBM i, where `vscode.workspace.fs.stat()` means a live round-trip over
+ * the connection. Without this, every single edit (each field move/drop, etc.) pays that round-trip
+ * again via `isReadOnlyFile()`/`applyWorkspaceEdit()` below, which is fine for a local `file:` (an
+ * instant OS call) but was a real, repeated source of latency while connected. Cleared when the
+ * document closes, so a freshly (re)opened document always re-checks.
+ */
+const remoteReadOnlyCache: Map<string, boolean> = new Map();
+
+/** Clears a document's cached remote read-only status (e.g. when it's closed). */
+export function clearReadOnlyCache(documentUri: string): void {
+    remoteReadOnlyCache.delete(documentUri);
+};
+
+/**
  * Whether a URI points at a file the current user can't write to. `vscode.workspace.fs.stat()`'s
  * `permissions` field is unreliable for this: local disk providers commonly leave it unset even
  * for an OS-level read-only file (confirmed — VS Code doesn't even show its own lock icon on such
@@ -696,7 +716,8 @@ export function checkForEditorAndDocument() : { editor : vscode.TextEditor | und
  * VS Code's read-only UI, not a live reflection of OS permission bits. For a `file:` URI, checking
  * the OS permission bits directly via Node's `fs` is the only reliable signal. For anything else
  * (a virtual filesystem provider — e.g. an IBM i source member opened through Code for IBM i),
- * `stat()` is the only option available, so it's used as a best-effort fallback.
+ * `stat()` is the only option available, so it's used as a best-effort fallback — and cached per
+ * document (see `remoteReadOnlyCache` above), since it's the one that's actually expensive.
  * @param uri - The document URI to check
  */
 async function isReadOnlyFile(uri: vscode.Uri): Promise<boolean> {
@@ -709,12 +730,22 @@ async function isReadOnlyFile(uri: vscode.Uri): Promise<boolean> {
         };
     };
 
+    const cacheKey = uri.toString();
+    const cached = remoteReadOnlyCache.get(cacheKey);
+    if (cached !== undefined) {
+        return cached;
+    };
+
+    let isReadOnly: boolean;
     try {
         const stat = await vscode.workspace.fs.stat(uri);
-        return Boolean((stat.permissions ?? 0) & vscode.FilePermission.Readonly);
+        isReadOnly = Boolean((stat.permissions ?? 0) & vscode.FilePermission.Readonly);
     } catch {
-        return false;
+        isReadOnly = false;
     };
+
+    remoteReadOnlyCache.set(cacheKey, isReadOnly);
+    return isReadOnly;
 };
 
 /**

--- a/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
@@ -8,6 +8,8 @@ import * as vscode from 'vscode';
 import { FieldsPerRecord, DdsSize, DdsAttribute, AttributeWithIndicators, DdsIndicator, fieldsPerRecords, records, getDefaultSize, getAvailableDisplayFormats, getSizeForFormat, SYSTEM_FIELD_PLACEHOLDER } from '../dspf-edit.model/dspf-edit.model';
 import { checkForEditorAndDocument, updateTreeProvider, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 import { DdsTreeProvider } from '../dspf-edit.providers/dspf-edit.providers';
+import { ExtensionState } from '../dspf-edit.states/state';
+import { getResolvedRef } from '../dspf-edit.ibmi/dspf-edit.ibmi-integration';
 import { resolveRecordSizeForFormat } from '../dspf-edit.parser/dspf-edit.parser';
 import { editWindowTitleForRecord } from '../dspf-edit.commands/dspf-edit.window-title';
 import { getConstantTextFromUser, insertNewConstant } from '../dspf-edit.commands/dspf-edit.edit-constant';
@@ -756,6 +758,7 @@ export class RecordPreviewPanel {
         // background record always uses the resting state (every indicator OFF), regardless of
         // what's toggled for the foreground record.
         const useLiveIndicators = this.indicatorsEnabled && !isBackground;
+        const documentUri = ExtensionState.lastDdsDocument?.uri.toString();
 
         for (const field of recordInfo.fields) {
             if (this.activeDisplayFormat && field.displayFormat && field.displayFormat !== this.activeDisplayFormat) {
@@ -772,9 +775,13 @@ export class RecordPreviewPanel {
                 const activeAttrs = this.getActiveAttributes(field.attributes, useLiveIndicators);
                 const usageCode = (field.usage || '').trim().toUpperCase();
                 // A referenced field (REFFLD/position-29 `R`) has no type/length of its own in the
-                // source — they live in the external database field, which dspf-edit can't read —
-                // so it's shown as a single marker character instead of a guessed-width placeholder.
-                const isReferenced = field.referenced === true;
+                // source — they live in the external database field, which dspf-edit can't read on
+                // its own — so it's shown as a single marker character instead of a guessed-width
+                // placeholder, unless its real type/length has already been resolved (via the
+                // "Resolve Referenced Field" tree command), in which case it renders like any other
+                // field, just tinted the reference color when it carries no COLOR()/DSPATR() of its own.
+                const resolvedRef = field.referenced && documentUri ? getResolvedRef(documentUri, recordInfo.record, field.name) : undefined;
+                const isReferenced = field.referenced === true && !resolvedRef;
                 // The displayed text's own length drives the item's width/hit-box (below), not the
                 // parsed field length: a system keyword field (DATE, USER...) always renders at a
                 // fixed width of its own, regardless of whatever the source's length column holds
@@ -782,7 +789,10 @@ export class RecordPreviewPanel {
                 // character (its decimal point, typically), which text.length already reflects.
                 const text = isReferenced
                     ? getFieldPlaceholderText(field.name, field.type, field.usage, 1)
-                    : getFieldPlaceholderText(field.name, field.type, field.usage, field.length, getEditWordMask(activeAttrs));
+                    : getFieldPlaceholderText(field.name, resolvedRef?.type ?? field.type, field.usage, resolvedRef?.length ?? field.length, getEditWordMask(activeAttrs));
+                const color = isReferenced || (field.referenced && activeAttrs.length === 0)
+                    ? REFERENCED_FIELD_COLOR
+                    : getDisplayColor(activeAttrs, hasDisplayAttribute(activeAttrs, 'HI'));
                 items.push({
                     kind: 'field',
                     name: field.name,
@@ -791,7 +801,7 @@ export class RecordPreviewPanel {
                     col: trueCol + colOffset,
                     length: text.length,
                     lineIndex: field.lineIndex,
-                    color: isReferenced ? REFERENCED_FIELD_COLOR : getDisplayColor(activeAttrs, hasDisplayAttribute(activeAttrs, 'HI')),
+                    color,
                     highIntensity: hasDisplayAttribute(activeAttrs, 'HI'),
                     reverseImage: hasDisplayAttribute(activeAttrs, 'RI') || this.hasActiveErrorMessage(field.attributes, useLiveIndicators),
                     blink: hasDisplayAttribute(activeAttrs, 'BL'),

--- a/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
@@ -132,6 +132,21 @@ function getEditWordMask(attributes: AttributeWithIndicators[] | undefined): str
     return attr.value.match(/^EDTWRD\(\s*'([^']*)'\s*\)$/i)?.[1] ?? null;
 };
 
+/**
+ * Extracts a field's CNTFLD() continuation width, if it carries one — the number of characters
+ * shown per line before wrapping to the next row (same column) for a field too long to fit on one line.
+ * @param attributes - The element's DDS attributes
+ */
+function getContinuedFieldWidth(attributes: AttributeWithIndicators[] | undefined): number | null {
+    const attr = attributes?.find(a => /^CNTFLD\(/i.test(a.value));
+    if (!attr) {
+        return null;
+    };
+
+    const width = attr.value.match(/^CNTFLD\(\s*(\d+)\s*\)$/i)?.[1];
+    return width ? Number(width) : null;
+};
+
 /** Default 5250-style green, used when a field/constant has no COLOR() keyword. */
 const DEFAULT_COLOR = '#00ff00';
 
@@ -793,13 +808,10 @@ export class RecordPreviewPanel {
                 const color = isReferenced || (field.referenced && activeAttrs.length === 0)
                     ? REFERENCED_FIELD_COLOR
                     : getDisplayColor(activeAttrs, hasDisplayAttribute(activeAttrs, 'HI'));
-                items.push({
-                    kind: 'field',
+                const baseItem = {
+                    kind: 'field' as const,
                     name: field.name,
-                    text,
-                    row: trueRow + rowOffset,
                     col: trueCol + colOffset,
-                    length: text.length,
                     lineIndex: field.lineIndex,
                     color,
                     highIntensity: hasDisplayAttribute(activeAttrs, 'HI'),
@@ -814,7 +826,21 @@ export class RecordPreviewPanel {
                     isInteractive: !isBackground,
                     isInputCapable: usageCode === 'I' || usageCode === 'B',
                     isReferenced
-                });
+                };
+
+                // CNTFLD(n) wraps a field too long for one line across multiple rows, n characters
+                // per row, all starting at the same column — matching how RDi previews it — instead
+                // of a single run that overflows past the record's right edge.
+                const continuedWidth = getContinuedFieldWidth(activeAttrs);
+                if (continuedWidth && continuedWidth > 0 && text.length > continuedWidth) {
+                    const chunkCount = Math.ceil(text.length / continuedWidth);
+                    for (let chunk = 0; chunk < chunkCount; chunk++) {
+                        const chunkText = text.substr(chunk * continuedWidth, continuedWidth);
+                        items.push({ ...baseItem, text: chunkText, row: trueRow + rowOffset + chunk, length: chunkText.length });
+                    };
+                } else {
+                    items.push({ ...baseItem, text, row: trueRow + rowOffset, length: text.length });
+                };
             };
         };
 
@@ -2093,15 +2119,20 @@ export class RecordPreviewPanel {
             return;
         }
 
+        // A CNTFLD-wrapped field renders as several items sharing one lineIndex (one per wrapped
+        // line) — it's still a single field for selection purposes, so count/act on distinct
+        // lineIndexes, not raw rendered items.
+        const uniqueByLine = [...new Map(items.map(i => [i.lineIndex, i])).values()];
+
         // A multi-selection only supports moving (dragging), not centering or the actions menu —
         // those stay single-item, so the buttons are hidden rather than made to act on a group.
-        const multi = items.length > 1;
+        const multi = uniqueByLine.length > 1;
         if (multi) {
-            const kinds = new Set(items.map(i => i.kind));
-            const noun = kinds.size === 1 ? items[0].kind + 's' : 'fields/constants';
-            selectionLabel.textContent = items.length + ' ' + noun + ' selected';
+            const kinds = new Set(uniqueByLine.map(i => i.kind));
+            const noun = kinds.size === 1 ? uniqueByLine[0].kind + 's' : 'fields/constants';
+            selectionLabel.textContent = uniqueByLine.length + ' ' + noun + ' selected';
         } else {
-            selectionLabel.textContent = '1 ' + items[0].kind + ' selected';
+            selectionLabel.textContent = '1 ' + uniqueByLine[0].kind + ' selected';
         }
         selectionCenterBtn.style.display = multi ? 'none' : 'inline-block';
         selectionMenuBtn.style.display = multi ? 'none' : 'inline-block';
@@ -2484,9 +2515,22 @@ export class RecordPreviewPanel {
         }
 
         if (dragState.moved) {
+            // A CNTFLD-wrapped field renders as several items sharing one lineIndex (one per
+            // wrapped line), all dragged together for a consistent visual — but the field has only
+            // one source line to write back to. Collapse each lineIndex down to a single move, using
+            // its topmost item (smallest startRow), which is the field's actual anchor row; the
+            // wrapped lines below it are re-derived from that on reparse. Without this, duplicate
+            // moves for the same line produce overlapping edits that VS Code rejects outright.
+            const primaryMoveByLine = new Map();
+            for (const d of dragState.items) {
+                const existing = primaryMoveByLine.get(d.item.lineIndex);
+                if (!existing || d.startRow < existing.startRow) {
+                    primaryMoveByLine.set(d.item.lineIndex, d);
+                }
+            }
             vscode.postMessage({
                 type: 'move',
-                moves: dragState.items.map(d => ({
+                moves: [...primaryMoveByLine.values()].map(d => ({
                     lineIndex: d.item.lineIndex,
                     newRow: d.startRow + dragState.rowDelta,
                     newCol: d.startCol + dragState.colDelta,


### PR DESCRIPTION
## [0.14.0] - 2026-07-30
### Added
- New "Resolve Referenced Field" action for referenced fields (`REFFLD`/position-29 `R`, which carry no type/length in the source): a button on the field — and a "Resolve All Referenced Fields" command, also reachable from a new status bar item — queries the connected IBM i, via the [Code for i](https://marketplace.visualstudio.com/items?itemName=HalcyonTechLtd.code-for-ibmi) extension, for the referenced database field's real type/length/decimals. Works for both native physical/logical files and SQL-created tables (which can have different long and short column names). Once resolved, the field shows its real type/length in both the tree and the preview (rendered like a normal field, tinted the reference color only when it carries no `COLOR()`/`DSPATR()` of its own). Cached per document until it's closed, or re-resolved on demand from the same button. Requires Code for i to be installed and connected; shows a clear message otherwise.
- A status bar item shows how many referenced fields in the current document are still pending resolution.
- Preview: support for the `CNTFLD(n)` keyword — a field too long to fit on one line now wraps across multiple rows, `n` characters each, all starting at the field's original column, matching how RDi previews it. Centering such a field (`Center`/"↔") now uses its per-line width instead of its full declared length.
### Fixed
- Performance: two O(n²) hotspots in the parser (linking fields/constants to their record, and duplicate-field detection) made re-parsing a document — e.g. after moving a field in the preview — get dramatically slower as it grew larger. Both are now linear.
- Performance: checking whether a file is read-only before applying an edit did a live round-trip to the IBM i on every single edit while connected via Code for i. It's now cached per document.
- Referenced fields were missing the usual field context menu/inline actions (delete, copy, rename, etc.), due to a stricter internal check that didn't account for their new "pending"/"resolved" state.
- Parser: a field/constant positioned relative (`+n`) right after a bare system keyword (`DATE`, `TIME`, `USER`, `SYSNAME`) landed several columns too far left in the preview, overlapping the keyword's own placeholder — the parser was tracking the keyword's raw source-text length instead of its actual on-screen width when resolving the following `+n` position.
- Preview: dragging a `CNTFLD`-wrapped field failed with "the document may be read-only" — its wrapped lines all share one source line, and each was independently written back on drop, producing overlapping edits VS Code rejected outright.
- Preview: selecting a `CNTFLD`-wrapped field showed "N fields selected" (one per wrapped line) instead of being treated as the single field it is, hiding the "↔ Center"/"⋮ Actions" buttons as a result.
