### PR TITLE
v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
+## [0.15.0] - 2026-08-09
+### Added
+- Indicators: full support for DDS's AND/OR conditioning — previously only a single line's worth (up to 3 ANDed) was read or editable, and OR'd conditions were silently ignored.
+  - Parser: reads indicator-only continuation lines (position 7 `A`/blank to extend an AND group beyond 3, `O` to start a new OR'd group), up to DDS's own limits (9 ANDed indicators per condition, 9 OR'd conditions).
+  - Tree view: an OR'd condition is now shown grouped into its ANDed sub-conditions instead of one flat, misleading list; hovering a conditioned field/constant/attribute shows the full condition as a tooltip (e.g. `51 AND NOT 61 AND 53  OR  52`).
+  - Preview: indicator simulation (on/off toggles) now evaluates AND/OR conditions correctly instead of treating every indicator as ANDed together.
+  - "Indicators" command: add a 4th+ ANDed indicator (continuation lines are generated/removed automatically), add or remove a whole OR'd condition, or edit indicators within a specific one when there's more than one.
+
 ## [0.14.2] - 2026-08-09
 ### Fixed
 - Tree view: a record created in a brand-new DSPF source (one that started out with zero records) didn't show up in the records list until the source was closed and reopened — the per-document record filter seeded itself empty on that first parse and never learned to include anything added afterward.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
-## [0.15.0] - 2026-08-09
+## [0.15.0] - 2026-08-11
 ### Added
 - Indicators: full support for DDS's AND/OR conditioning — previously only a single line's worth (up to 3 ANDed) was read or editable, and OR'd conditions were silently ignored.
   - Parser: reads indicator-only continuation lines (position 7 `A`/blank to extend an AND group beyond 3, `O` to start a new OR'd group), up to DDS's own limits (9 ANDed indicators per condition, 9 OR'd conditions).

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ The extension provides a **navigable schema view** of the DDS source file that i
     - Center constant on screen.
     - Change position (absolute position/relative to existing constant).
     - Apply colors/attributes.
-    - Add / Remove / Change indicators.
+    - Add / Remove / Change indicators, including more than 3 ANDed indicators (up to DDS's limit of 9, spilling onto continuation lines automatically) and OR'd conditions (add/remove whole OR'd groups, or edit indicators within one).
     - Fill constant with characters.
 
 - **Fields**
   - Show name, length, type, position (row/column), and flags (referenced/hidden).
-  - Indicators and attributes are expandable.
+  - Indicators and attributes are expandable; an OR'd condition is grouped into its ANDed sub-conditions ("Group 1 (AND)" / "OR" / "Group 2 (AND)" / ...) instead of one flat list. Hovering a conditioned field/constant/attribute shows the full condition (e.g. `51 AND NOT 61 AND 53  OR  52`) as a tooltip.
   - Right-click options:
     - Edit field.
     - Copy field (to the same or different record).
@@ -63,11 +63,11 @@ The extension provides a **navigable schema view** of the DDS source file that i
     - Add validity checks.
     - Add editing keywords.
     - Add error messages.
-    - Add / Remove / Change indicators.
+    - Add / Remove / Change indicators, including more than 3 ANDed indicators (up to DDS's limit of 9, spilling onto continuation lines automatically) and OR'd conditions (add/remove whole OR'd groups, or edit indicators within one).
     - Resolve Referenced Field (for referenced fields only): fetches the real type/length/decimals from the connected IBM i, via the [Code for i](https://marketplace.visualstudio.com/items?itemName=HalcyonTechLtd.code-for-ibmi) extension. Also available as "Resolve All Referenced Fields" from the status bar, for every pending referenced field in the document at once.
 
 - **Attributes**
-    - Add / Remove / Change indicators.
+    - Add / Remove / Change indicators, with the same AND/OR support as fields and constants.
     - Remove attribute.
 
 - **Screen Preview**
@@ -106,8 +106,6 @@ The extension provides a **navigable schema view** of the DDS source file that i
 This extension is currently in **preview**.  
 Some features may not work as expected. Please leave an issue if something is not working fine!
 
-- DDS indicator **OR conditioning** is not yet supported: DDS lets you OR several indicator-only continuation lines (marked with `O` in column 7) together, with the actual keyword coded on the last line of the group. Only the indicators on that last line are currently read — the preceding OR'd indicator-only lines are ignored.
-
 ---
 
 ## 📝 To Do
@@ -122,18 +120,8 @@ Some features may not work as expected. Please leave an issue if something is no
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**0.14.2** - 2026-08-09
-- Fixed: Tree view: a record created in a brand-new DSPF source (zero records to start) didn't show up in the records list until the source was closed and reopened.
-- Fixed: Parser/Preview: subfile record formats where `SFL` sits on its own line (common in SDA/RDI-generated sources) rendered their fields stacked vertically instead of side-by-side as subfile columns.
-
-**0.14.1** - 2026-08-01
-- Fixed: Parser: `REFFLD()`'s field name can be qualified with a record format (`REFFLD(record-format-name/field-name [library-name/]file-name)`), needed to disambiguate a field name that exists in more than one format of the referenced file. This qualification wasn't parsed correctly, breaking resolution against IBM i entirely. Add/Edit Field's "Referenced Field" flow now also has a dedicated (optional) step for the record format.
-- Fixed: Add Editing Keywords: `EDTCDE`/`EDTWRD`/`EDTMSK` were always rejected as "not a numeric field" on a referenced field, even after its real type had been resolved from IBM i. It now uses the resolved type/length/decimals when available.
-- Fixed: Preview: a field with `EDTCDE()` rendered as a plain, unformatted placeholder instead of showing the thousands separators/decimal point/sign a real edited numeric field displays.
-- Fixed: Parser: multi-line constants (text continued across several source lines with a `-`) could be parsed incorrectly, missing or leaving the continuation character embedded in the resulting text.
-- Fixed: Delete Field/Constant: a following field/constant positioned relative to the deleted one (DDS's relative record format) silently moved on screen instead of staying put — its position is now materialized to an explicit absolute value first.
-- Fixed: Preview: deleting the only field/constant in a record that carried conditioning indicators left stale toggle buttons for them in the preview's indicator bar.
-- Adjusted: Preview: the `COLOR(BLU)` shade, to match the IBM i Access Client Solutions (ACS) 5250 terminal more closely.
+**0.15.0** - 2026-08-09
+- Added: Indicators: full support for DDS's AND/OR conditioning — more than 3 ANDed indicators (up to DDS's limit of 9, spilling onto continuation lines automatically), and OR'd conditions (add/remove a whole OR'd group, or edit indicators within a specific one). Tree view shows an OR'd condition grouped by AND sub-condition, with a readable tooltip; preview's indicator simulation now evaluates AND/OR correctly instead of treating every indicator as ANDed together.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Some features may not work as expected. Please leave an issue if something is no
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**0.15.0** - 2026-08-09
+**0.15.0** - 2026-08-11
 - Added: Indicators: full support for DDS's AND/OR conditioning — more than 3 ANDed indicators (up to DDS's limit of 9, spilling onto continuation lines automatically), and OR'd conditions (add/remove a whole OR'd group, or edit indicators within a specific one). Tree view shows an OR'd condition grouped by AND sub-condition, with a readable tooltip; preview's indicator simulation now evaluates AND/OR correctly instead of treating every indicator as ANDed together.
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dspf-edit",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dspf-edit",
-      "version": "0.14.2",
+      "version": "0.15.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "0.14.2",
+  "version": "0.15.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"

--- a/src/dspf-edit.commands/dspf-edit.add-indicators.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-indicators.ts
@@ -23,12 +23,39 @@ interface InlineAttributeInfo {
     isInline: boolean;
 };
 
+/** One physical DDS line's worth of indicators, plus its column-7 marker. */
+interface IndicatorLineSpec {
+    indicators: IndicatorAssignment[];
+    marker: ' ' | 'O';
+};
+
+// CONSTANTS
+
+/** DDS indicator slots per line (positions 8-16: three 3-character slots). */
+const INDICATORS_PER_LINE = 3;
+
+/**
+ * Maximum ANDed indicators DDS allows for a single condition (see "Condition for display files
+ * (positions 7 through 16)" in the DDS reference: "a maximum of nine indicators for each
+ * condition"). Beyond 3 (one line's worth), the extra indicators are written on continuation
+ * lines above the element's own line, marked with a blank/'A' in position 7 — see
+ * createIndicatorContinuationLine / applyGroupsToElement.
+ */
+const MAX_AND_INDICATORS = 9;
+
+/**
+ * Maximum OR'd conditions DDS allows for a single field/constant/keyword (see the DDS reference:
+ * "nine conditions for each field or keyword"). Each condition is itself an AND-group of up to
+ * MAX_AND_INDICATORS indicators — position 7 'O' starts a new one.
+ */
+const MAX_OR_CONDITIONS = 9;
+
 // COMMAND REGISTRATION
 
 /**
  * Registers the manage indicators command for DDS fields and constants (and attributes of them)
- * Allows users to interactively manage conditioning indicators for elements.
- * Limited to maximum 3 indicators per field.
+ * Allows users to interactively manage conditioning indicators for elements: up to
+ * MAX_AND_INDICATORS ANDed per condition, and up to MAX_OR_CONDITIONS OR'd conditions.
  * @param context - The VS Code extension context
  */
 export function addIndicators(context: vscode.ExtensionContext): void {
@@ -42,9 +69,10 @@ export function addIndicators(context: vscode.ExtensionContext): void {
 // COMMAND HANDLER
 
 /**
- * Handles the manage indicators command for a DDS field or constant (and attributes of them)
- * Manages existing indicators and allows adding/removing/modifying indicators.
- * Limited to maximum 3 indicators per field (positions 8-16 in DDS).
+ * Handles the manage indicators command for a DDS field or constant (and attributes of them).
+ * Reads the element's full condition — every OR'd AND-group, spanning continuation lines above the
+ * element's own line — and lets the user add/remove indicators or whole OR'd conditions, or modify
+ * individual ones.
  * @param node - The DDS node containing the field or constant
  */
 async function handleAddIndicatorsCommand(node: DdsNode): Promise<void> {
@@ -71,94 +99,145 @@ async function handleAddIndicatorsCommand(node: DdsNode): Promise<void> {
             };
         };
 
-        // Get current indicators from the element
-        const currentIndicators = getCurrentIndicatorsForElement(editor, node.ddsElement);
+        const elementName = elementDisplayName(node.ddsElement);
 
-        // Show current indicators if any exist
+        // Read the element's full condition: every OR'd AND-group, including continuation lines
+        const { groups } = findIndicatorConditionBlock(editor, node.ddsElement.lineIndex);
+
         let action: string | undefined;
-        if (currentIndicators.length > 0) {
-            const currentIndicatorsSummary = formatIndicatorsSummary(currentIndicators);
+        if (groups.length > 0) {
+            const options = ['Add AND indicator', 'Add OR condition', 'Modify existing indicators'];
+            if (groups.length > 1) {
+                options.push('Remove a group');
+            };
+            options.push('Replace all indicators', 'Remove all indicators');
 
-            action = await vscode.window.showQuickPick(
-                ['Add more indicators', 'Replace all indicators', 'Remove all indicators', 'Modify existing indicators'],
-                {
-                    title: `Current indicators: ${currentIndicatorsSummary}`,
-                    placeHolder: 'Choose how to manage indicators'
-                }
-            );
+            action = await vscode.window.showQuickPick(options, {
+                title: `Current condition: ${formatGroupsSummary(groups)}`,
+                placeHolder: 'Choose how to manage indicators'
+            });
 
             if (!action) return;
 
             if (action === 'Remove all indicators') {
-                if (!(await removeIndicatorsFromElement(editor, node.ddsElement))) {
+                if (!(await applyGroupsToElement(editor, node.ddsElement, []))) {
                     return;
                 };
-                await vscode.commands.executeCommand('cursorRight');
-                await vscode.commands.executeCommand('cursorLeft');
-
-                (node.ddsElement.kind === 'constant' || node.ddsElement.kind === 'field') ?
-                vscode.window.showInformationMessage(`Removed all indicators from ${node.ddsElement.name}.`) :
-                vscode.window.showInformationMessage(`Removed all indicators from attribute.`);
+                await refreshEditorView();
+                vscode.window.showInformationMessage(`Removed all indicators from ${elementName}.`);
                 return;
             };
 
-            if (action === 'Replace all indicators') {
-                if (!(await removeIndicatorsFromElement(editor, node.ddsElement))) {
+            if (action === 'Remove a group') {
+                const groupToRemove = await pickGroupIndex(groups, 'Select the OR condition to remove');
+                if (groupToRemove === undefined) return;
+
+                const remaining = groups.filter((_, i) => i !== groupToRemove);
+                if (!(await applyGroupsToElement(editor, node.ddsElement, remaining))) {
                     return;
                 };
-                await vscode.commands.executeCommand('cursorRight');
-                await vscode.commands.executeCommand('cursorLeft');
-
-                // Continue to add new indicators
+                await refreshEditorView();
+                vscode.window.showInformationMessage(`Removed OR condition from ${elementName}.`);
+                return;
             };
 
             if (action === 'Modify existing indicators') {
-                if (!(await modifyExistingIndicators(editor, node.ddsElement, currentIndicators))) {
+                if (!(await modifyExistingIndicators(editor, node.ddsElement, groups))) {
                     return;
                 };
-                await vscode.commands.executeCommand('cursorRight');
-                await vscode.commands.executeCommand('cursorLeft');
-
+                await refreshEditorView();
                 return;
             };
 
-            if (action === 'Add more indicators' && currentIndicators.length >= 3) {
-                vscode.window.showWarningMessage('Maximum of 3 indicators per field reached.');
+            if (action === 'Add OR condition') {
+                if (groups.length >= MAX_OR_CONDITIONS) {
+                    vscode.window.showWarningMessage(`Maximum of ${MAX_OR_CONDITIONS} OR'd conditions reached (DDS limit).`);
+                    return;
+                };
+                const newGroup = await collectIndicatorsFromUser(MAX_AND_INDICATORS);
+                if (newGroup.length === 0) {
+                    vscode.window.showInformationMessage('No indicators selected.');
+                    return;
+                };
+                if (!(await applyGroupsToElement(editor, node.ddsElement, [...groups, newGroup]))) {
+                    return;
+                };
+                await refreshEditorView();
+                vscode.window.showInformationMessage(`Added OR condition (${formatIndicatorsSummary(newGroup)}) to ${elementName}.`);
                 return;
             };
+
+            if (action === 'Add AND indicator') {
+                const groupIndex = groups.length === 1 ? 0 : await pickGroupIndex(groups, 'Add to which OR condition?');
+                if (groupIndex === undefined) return;
+
+                if (groups[groupIndex].length >= MAX_AND_INDICATORS) {
+                    vscode.window.showWarningMessage(`Maximum of ${MAX_AND_INDICATORS} ANDed indicators reached (DDS limit).`);
+                    return;
+                };
+                const newIndicators = await collectIndicatorsFromUser(MAX_AND_INDICATORS - groups[groupIndex].length);
+                if (newIndicators.length === 0) {
+                    vscode.window.showInformationMessage('No indicators selected.');
+                    return;
+                };
+                const updatedGroups = groups.map((g, i) => i === groupIndex ? [...g, ...newIndicators] : g);
+                if (!(await applyGroupsToElement(editor, node.ddsElement, updatedGroups))) {
+                    return;
+                };
+                await refreshEditorView();
+                vscode.window.showInformationMessage(`Added indicators (${formatIndicatorsSummary(newIndicators)}) to ${elementName}.`);
+                return;
+            };
+
+            // action === 'Replace all indicators': falls through to collect a fresh condition below,
+            // replacing whatever was there in a single edit (nothing is touched until it's confirmed).
         };
 
-        // Collect new indicators to add
-        const maxNewIndicators = 3 - (action === 'Add more indicators' ? currentIndicators.length : 0);
-        const newIndicators = await collectIndicatorsFromUser(maxNewIndicators);
-
-        if (newIndicators.length === 0) {
+        // No condition yet, or replacing: collect a single fresh AND group.
+        const newGroup = await collectIndicatorsFromUser(MAX_AND_INDICATORS);
+        if (newGroup.length === 0) {
             vscode.window.showInformationMessage('No indicators selected.');
             return;
         };
 
-        // Combine with existing indicators if adding more
-        const allIndicators = action === 'Add more indicators' ? [...currentIndicators, ...newIndicators] : newIndicators;
-
-        // Apply the selected indicators to the element
-        if (!(await setIndicatorsForElement(editor, node.ddsElement, allIndicators))) {
+        if (!(await applyGroupsToElement(editor, node.ddsElement, [newGroup]))) {
             return;
         };
-        await vscode.commands.executeCommand('cursorRight');
-        await vscode.commands.executeCommand('cursorLeft');
-
-        const indicatorsSummary = formatIndicatorsSummary(allIndicators);
-        const actionText = action === 'Add more indicators' ? 'Added' : 'Set';
-        vscode.window.showInformationMessage(
-            (node.ddsElement.kind === 'constant' || node.ddsElement.kind === 'field') ?
-            `${actionText} indicators ${indicatorsSummary} for ${node.ddsElement.name}.` :
-            `${actionText} indicators ${indicatorsSummary} for attribute`
-        );
+        await refreshEditorView();
+        vscode.window.showInformationMessage(`Set indicators (${formatIndicatorsSummary(newGroup)}) for ${elementName}.`);
 
     } catch (error) {
         console.error('Error managing indicators:', error);
         vscode.window.showErrorMessage('An error occurred while managing indicators.');
     };
+};
+
+// SMALL SHARED HELPERS
+
+/** Refreshes the tree/preview after an edit — the cheapest way to force a re-parse of the document. */
+async function refreshEditorView(): Promise<void> {
+    await vscode.commands.executeCommand('cursorRight');
+    await vscode.commands.executeCommand('cursorLeft');
+};
+
+/** A short name for an element to use in user-facing messages. */
+function elementDisplayName(element: any): string {
+    return (element.kind === 'constant' || element.kind === 'field') ? element.name : 'attribute';
+};
+
+/**
+ * Asks the user to pick one of an element's OR'd AND-groups.
+ * @param groups - The element's current OR'd AND-groups
+ * @param title - QuickPick title
+ * @returns The chosen group's index, or undefined if cancelled
+ */
+async function pickGroupIndex(groups: IndicatorAssignment[][], title: string): Promise<number | undefined> {
+    const items = groups.map((group, index) => ({
+        label: `Condition ${index + 1}: ${formatIndicatorsSummary(group)}`,
+        index
+    }));
+    const picked = await vscode.window.showQuickPick(items, { title, placeHolder: 'Choose a condition' });
+    return picked?.index;
 };
 
 // INLINE ATTRIBUTE HANDLING
@@ -175,7 +254,7 @@ function getInlineAttributeInfo(editor: vscode.TextEditor, element: any): Inline
     const fieldLineIndex = element.fieldLineIndex || element.lineIndex;
     const fieldLine = editor.document.lineAt(fieldLineIndex);
     const fieldLineText = fieldLine.text;
-    
+
     // Check if there's an attribute at position 44+
     if (fieldLineText.length > 44) {
         const attributePart = fieldLineText.substring(44).trim();
@@ -187,7 +266,7 @@ function getInlineAttributeInfo(editor: vscode.TextEditor, element: any): Inline
             };
         };
     };
-        
+
     return {
         attributeText: '',
         fieldLineIndex: fieldLineIndex,
@@ -196,14 +275,17 @@ function getInlineAttributeInfo(editor: vscode.TextEditor, element: any): Inline
 };
 
 /**
- * Handles indicators for inline field attributes by moving them to separate lines.
+ * Handles indicators for inline field attributes by moving them to separate lines. Once on its own
+ * line, the attribute gains full OR support too — this initial move only sets up a single AND
+ * condition (up to MAX_AND_INDICATORS); use the main "Indicators" action again afterward to add an
+ * OR'd condition to it.
  * @param editor - The active text editor
  * @param element - The field attribute element
  * @param inlineInfo - Information about the inline attribute
  */
 async function handleInlineAttributeIndicators(
-    editor: vscode.TextEditor, 
-    element: any, 
+    editor: vscode.TextEditor,
+    element: any,
     inlineInfo: InlineAttributeInfo
 ): Promise<void> {
     // Inform the user about what will happen
@@ -215,7 +297,7 @@ async function handleInlineAttributeIndicators(
     if (proceed !== 'Continue') return;
 
     // Get indicators to add
-    const indicators = await collectIndicatorsFromUser(3);
+    const indicators = await collectIndicatorsFromUser(MAX_AND_INDICATORS);
     if (indicators.length === 0) {
         vscode.window.showInformationMessage('No indicators selected.');
         return;
@@ -251,20 +333,24 @@ async function moveInlineAttributeToSeparateLine(
     const fieldLine = editor.document.lineAt(fieldLineIndex);
     const fieldLineText = fieldLine.text;
     const truncatedFieldLine = fieldLineText.substring(0, 44).trimRight();
-    
+
     workspaceEdit.replace(uri, fieldLine.range, truncatedFieldLine);
 
-    // 2. Create new attribute line with indicators
-    const attributeLine = createAttributeLineWithIndicators(inlineInfo.attributeText, indicators);
+    // 2. Create the new attribute line, preceded by any AND-continuation lines needed for
+    // indicators beyond INDICATORS_PER_LINE (the attribute line itself always carries the last,
+    // terminal chunk — see splitIndicatorsIntoLineChunks).
+    const { continuationChunks, terminalChunk } = splitIndicatorsIntoLineChunks(indicators);
+    const continuationText = continuationChunks.map(chunk => createIndicatorContinuationLine(chunk) + '\n').join('');
+    const attributeLine = continuationText + createAttributeLineWithIndicators(inlineInfo.attributeText, terminalChunk);
     const insertPos = new vscode.Position(fieldLineIndex + 1, 0);
-    
+
     // Check if we need to add a newline at the end of the file
     if (insertPos.line >= editor.document.lineCount) {
         workspaceEdit.insert(uri, insertPos, '\n');
     };
-    
+
     workspaceEdit.insert(uri, insertPos, attributeLine);
-    
+
     // Add newline after the attribute if we're not at the end
     if (insertPos.line < editor.document.lineCount) {
         workspaceEdit.insert(uri, insertPos, '\n');
@@ -283,7 +369,7 @@ function createAttributeLineWithIndicators(attributeText: string, indicators: In
     let line = '     A '; // Start with 'A' and spaces up to position 7
 
     // Add indicators in positions 8-16 (0-based: 7-15)
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < INDICATORS_PER_LINE; i++) {
         const startPos = 7 + (i * 3);
         if (i < indicators.length) {
             const indicator = indicators[i];
@@ -305,24 +391,95 @@ function createAttributeLineWithIndicators(attributeText: string, indicators: In
     return line;
 };
 
+/**
+ * Creates a pure indicator continuation line: just up to INDICATORS_PER_LINE indicators in
+ * positions 8-16, nothing else. Position 7 carries the marker: blank continues the current AND
+ * group (DDS treats it the same as an explicit 'A'), 'O' starts a new OR'd group. See "Condition
+ * for display files (positions 7 through 16)" in the DDS reference.
+ * @param indicators - Up to INDICATORS_PER_LINE indicators for this line
+ * @param marker - Blank to continue the AND group, 'O' to start a new OR'd one
+ * @returns Formatted DDS continuation line
+ */
+function createIndicatorContinuationLine(indicators: IndicatorAssignment[], marker: ' ' | 'O' = ' '): string {
+    let line = '     A' + marker; // Sequence number area + form type (col 6) + condition marker (col 7)
+
+    for (let i = 0; i < INDICATORS_PER_LINE; i++) {
+        if (i < indicators.length) {
+            const indicator = indicators[i];
+            line += (indicator.isNegated ? 'N' : ' ') + indicator.value.padStart(2, '0');
+        } else {
+            line += '   ';
+        };
+    };
+
+    return line.trimEnd();
+};
+
 // INDICATORS EXTRACTION FUNCTIONS
 
 /**
- * Extracts current indicators from a DDS element.
- * Only looks at the main element line (no continuation lines).
- * @param editor - The active text editor
- * @param element - The DDS element (field or constant)
- * @returns Array of current indicators
+ * True when a line is a pure indicator continuation line: it carries its own indicators
+ * (positions 8-16) but nothing else at all — no name, no position, no keyword. This is stricter
+ * than the DDS rule technically requires (it only cares about the keyword zone, columns 45-80),
+ * but matches exactly what createIndicatorContinuationLine generates, and is the same minimal
+ * style any hand-written continuation line follows in practice.
+ * @param lineText - The line's raw text
  */
-function getCurrentIndicatorsForElement(editor: vscode.TextEditor, element: any): IndicatorAssignment[] {
-    const elementLineIndex = element.lineIndex;
-    const lineText = editor.document.lineAt(elementLineIndex).text;
-    
-    return parseIndicatorsFromLine(lineText);
+function isPureIndicatorContinuationLine(lineText: string): boolean {
+    // A short/blank line's substring(16) is just '', same as a longer line with nothing but
+    // trailing blanks past column 16 — no separate length check needed (see parseIndicatorsFromLine).
+    if (lineText[6] === '*') return false;
+    if (parseIndicatorsFromLine(lineText).length === 0) return false;
+    return lineText.substring(16).trim() === '';
 };
 
 /**
- * Formats indicators into a readable summary string.
+ * Reads an element's full indicator condition: its own line plus any indicator-only continuation
+ * lines directly above it (see isPureIndicatorContinuationLine), resolved into OR'd AND-groups
+ * exactly as DDS defines them — position 7 'O' starts a new group, blank/'A' continues the current
+ * one. An 'O' on what would be the very first line of the whole block is invalid DDS and treated as
+ * blank, matching the parser's own resolver (see dspf-edit.parser.ts's resolveLineIndicators).
+ * @param editor - The active text editor
+ * @param elementLineIndex - Line index of the field/constant/keyword the condition applies to
+ * @returns Where the block starts (elementLineIndex itself when there's no continuation), and the
+ * condition as an array of OR'd AND-groups (empty when unconditioned)
+ */
+function findIndicatorConditionBlock(
+    editor: vscode.TextEditor,
+    elementLineIndex: number
+): { startLine: number; groups: IndicatorAssignment[][] } {
+    const entries: { marker: string; indicators: IndicatorAssignment[] }[] = [];
+    let startLine = elementLineIndex;
+
+    for (let i = elementLineIndex - 1; i >= 0; i--) {
+        const lineText = editor.document.lineAt(i).text;
+        if (!isPureIndicatorContinuationLine(lineText)) break;
+
+        entries.unshift({ marker: lineText[6], indicators: parseIndicatorsFromLine(lineText) });
+        startLine = i;
+    };
+
+    const ownLineText = editor.document.lineAt(elementLineIndex).text;
+    entries.push({
+        marker: ownLineText.length > 6 ? ownLineText[6] : ' ',
+        indicators: parseIndicatorsFromLine(ownLineText)
+    });
+
+    const groups: IndicatorAssignment[][] = [];
+    for (const entry of entries) {
+        if (entry.marker === 'O' && groups.length > 0) {
+            groups.push([...entry.indicators]);
+        } else {
+            if (groups.length === 0) groups.push([]);
+            groups[groups.length - 1].push(...entry.indicators);
+        };
+    };
+
+    return { startLine, groups: groups.filter(group => group.length > 0) };
+};
+
+/**
+ * Formats a single AND-group into a readable summary string.
  * @param indicators - Array of indicators
  * @returns Formatted summary string
  */
@@ -332,15 +489,25 @@ function formatIndicatorsSummary(indicators: IndicatorAssignment[]): string {
     return indicators.map(ind => `${ind.isNegated ? 'N' : ''}${ind.value}`).join(', ');
 };
 
+/**
+ * Formats a full condition — one or more OR'd AND-groups — into a readable summary string.
+ * @param groups - The element's OR'd AND-groups
+ * @returns Formatted summary string, e.g. "51, N61, 53  OR  52  OR  81, 82"
+ */
+function formatGroupsSummary(groups: IndicatorAssignment[][]): string {
+    if (groups.length === 0) return 'None';
+
+    return groups.map(formatIndicatorsSummary).join('  OR  ');
+};
+
 // USER INTERACTION FUNCTIONS
 
 /**
  * Collects indicators from user through interactive selection.
- * Limited to maximum 3 indicators total.
  * @param maxIndicators - Maximum number of indicators that can be added
  * @returns Array of selected indicators
  */
-async function collectIndicatorsFromUser(maxIndicators: number = 3): Promise<IndicatorAssignment[]> {
+async function collectIndicatorsFromUser(maxIndicators: number = MAX_AND_INDICATORS): Promise<IndicatorAssignment[]> {
     const indicators: IndicatorAssignment[] = [];
 
     while (indicators.length < maxIndicators) {
@@ -393,16 +560,22 @@ async function collectIndicatorsFromUser(maxIndicators: number = 3): Promise<Ind
 };
 
 /**
- * Modifies existing indicators for an element.
+ * Modifies an element's existing indicator condition. When it spans more than one OR'd group, asks
+ * which one to work on first; a single group (the common case) skips straight to the per-indicator
+ * flow below, unchanged from before OR support existed.
  * @param editor - The active text editor
  * @param element - The DDS element
- * @param currentIndicators - Current indicators
+ * @param groups - The element's current OR'd AND-groups
  */
 async function modifyExistingIndicators(
     editor: vscode.TextEditor,
     element: any,
-    currentIndicators: IndicatorAssignment[]
+    groups: IndicatorAssignment[][]
 ): Promise<boolean> {
+    const groupIndex = groups.length === 1 ? 0 : await pickGroupIndex(groups, 'Which OR condition do you want to modify?');
+    if (groupIndex === undefined) return true;
+
+    const currentIndicators = groups[groupIndex];
     const indicatorChoices = currentIndicators.map((indicator, index) =>
         `Position ${index + 1}: ${indicator.isNegated ? 'N' : ''}${indicator.value}`
     );
@@ -417,25 +590,28 @@ async function modifyExistingIndicators(
 
     if (!selectedIndicator) return true;
 
+    // Applies a new indicator list for just this one OR'd group. Emptying a group removes the
+    // whole OR condition, rather than leaving a dangling AND group with nothing in it.
+    const applyGroupChange = (newIndicatorsForGroup: IndicatorAssignment[]): Promise<boolean> => {
+        const updatedGroups = newIndicatorsForGroup.length > 0
+            ? groups.map((g, i) => i === groupIndex ? newIndicatorsForGroup : g)
+            : groups.filter((_, i) => i !== groupIndex);
+        return applyGroupsToElement(editor, element, updatedGroups);
+    };
+
     if (selectedIndicator === 'Clear all and start over') {
-        if (!(await removeIndicatorsFromElement(editor, element))) {
+        const newIndicators = await collectIndicatorsFromUser(MAX_AND_INDICATORS);
+        if (!(await applyGroupChange(newIndicators))) {
             return false;
         };
-        const newIndicators = await collectIndicatorsFromUser(3);
-        if (newIndicators.length > 0) {
-            if (!(await setIndicatorsForElement(editor, element, newIndicators))) {
-                return false;
-            };
-        };
     } else if (selectedIndicator === 'Add new indicator') {
-        if (currentIndicators.length >= 3) {
-            vscode.window.showWarningMessage('Maximum of 3 indicators per field reached.');
+        if (currentIndicators.length >= MAX_AND_INDICATORS) {
+            vscode.window.showWarningMessage(`Maximum of ${MAX_AND_INDICATORS} ANDed indicators reached (DDS limit).`);
             return true;
         };
-        const newIndicators = await collectIndicatorsFromUser(3 - currentIndicators.length);
+        const newIndicators = await collectIndicatorsFromUser(MAX_AND_INDICATORS - currentIndicators.length);
         if (newIndicators.length > 0) {
-            const allIndicators = [...currentIndicators, ...newIndicators];
-            if (!(await setIndicatorsForElement(editor, element, allIndicators))) {
+            if (!(await applyGroupChange([...currentIndicators, ...newIndicators]))) {
                 return false;
             };
         };
@@ -452,7 +628,7 @@ async function modifyExistingIndicators(
 
             if (action === 'Remove this indicator') {
                 const newIndicators = currentIndicators.filter((_, index) => index !== indicatorIndex);
-                if (!(await setIndicatorsForElement(editor, element, newIndicators))) {
+                if (!(await applyGroupChange(newIndicators))) {
                     return false;
                 };
                 vscode.window.showInformationMessage('Indicator removed.');
@@ -483,14 +659,15 @@ async function modifyExistingIndicators(
                     const isNegated = newValue.startsWith('N');
                     const value = newValue.replace(/^N/, '').padStart(2, '0');
 
-                    currentIndicators[indicatorIndex] = {
+                    const updatedIndicators = [...currentIndicators];
+                    updatedIndicators[indicatorIndex] = {
                         position: indicatorIndex + 1,
                         indicator: newValue.toUpperCase(),
                         isNegated,
                         value
                     };
 
-                    if (!(await setIndicatorsForElement(editor, element, currentIndicators))) {
+                    if (!(await applyGroupChange(updatedIndicators))) {
                         return false;
                     };
                     vscode.window.showInformationMessage('Indicator updated.');
@@ -504,66 +681,114 @@ async function modifyExistingIndicators(
 // DDS MODIFICATION FUNCTIONS
 
 /**
- * Sets indicators for a DDS element by modifying the element line.
- * @param editor - The active text editor
- * @param element - The DDS element to set indicators for
- * @param indicators - Array of indicators to set (max 3)
+ * Splits a single AND-group into the continuation lines needed above the element's own line
+ * (INDICATORS_PER_LINE each) plus the terminal chunk that goes on the element's own line — per
+ * DDS rules, the field/constant/keyword itself must be on the same line as the last set of
+ * indicators. Front-loads full lines first, so e.g. 5 indicators become a 3-indicator
+ * continuation line plus a 2-indicator terminal line. Used only by the inline-attribute path,
+ * which manages a single condition — applyGroupsToElement uses flattenGroupsIntoLineSpecs instead,
+ * to also place OR markers between groups.
+ * @param indicators - The AND-group (already capped at MAX_AND_INDICATORS)
  */
-async function setIndicatorsForElement(
+function splitIndicatorsIntoLineChunks(
+    indicators: IndicatorAssignment[]
+): { continuationChunks: IndicatorAssignment[][]; terminalChunk: IndicatorAssignment[] } {
+    if (indicators.length <= INDICATORS_PER_LINE) {
+        return { continuationChunks: [], terminalChunk: indicators };
+    };
+
+    const lastChunkSize = indicators.length % INDICATORS_PER_LINE || INDICATORS_PER_LINE;
+    const splitAt = indicators.length - lastChunkSize;
+
+    const continuationChunks: IndicatorAssignment[][] = [];
+    for (let i = 0; i < splitAt; i += INDICATORS_PER_LINE) {
+        continuationChunks.push(indicators.slice(i, i + INDICATORS_PER_LINE));
+    };
+
+    return { continuationChunks, terminalChunk: indicators.slice(splitAt) };
+};
+
+/**
+ * Lays out a full condition — one or more OR'd AND-groups — as the sequence of physical lines it
+ * needs: each group is chunked into its own lines of up to INDICATORS_PER_LINE, and the first line
+ * of every group after the first is marked 'O' (all others stay blank, DDS's default AND-continue)
+ * — a new OR'd group can never share a physical line with the one before it.
+ * @param groups - Non-empty OR'd AND-groups (each itself non-empty)
+ */
+function flattenGroupsIntoLineSpecs(groups: IndicatorAssignment[][]): IndicatorLineSpec[] {
+    const specs: IndicatorLineSpec[] = [];
+
+    groups.forEach((group, groupIndex) => {
+        for (let i = 0; i < group.length; i += INDICATORS_PER_LINE) {
+            specs.push({
+                indicators: group.slice(i, i + INDICATORS_PER_LINE),
+                marker: (groupIndex > 0 && i === 0) ? 'O' : ' '
+            });
+        };
+    });
+
+    return specs;
+};
+
+/**
+ * Sets an element's full indicator condition — one or more OR'd AND-groups — rewriting whatever
+ * indicator block currently precedes it (if any — see findIndicatorConditionBlock) to match. An
+ * empty `groups` array removes all conditioning, continuation lines included.
+ * @param editor - The active text editor
+ * @param element - The DDS element to set the condition for
+ * @param groups - The full OR'd AND-groups to apply (empty groups are dropped)
+ */
+async function applyGroupsToElement(
     editor: vscode.TextEditor,
     element: any,
-    indicators: IndicatorAssignment[]
+    groups: IndicatorAssignment[][]
 ): Promise<boolean> {
     const workspaceEdit = new vscode.WorkspaceEdit();
     const uri = editor.document.uri;
     const elementLineIndex = element.lineIndex;
+    const { startLine } = findIndicatorConditionBlock(editor, elementLineIndex);
 
-    // Modify the element line with new indicators
+    const specs = flattenGroupsIntoLineSpecs(groups.filter(group => group.length > 0));
+    const continuationSpecs = specs.slice(0, -1);
+    const terminalSpec = specs[specs.length - 1];
+
+    // Replace whatever indicator block currently precedes the element (a zero-length range when
+    // there isn't one) with the freshly-generated one — naturally also removes a now-unneeded block.
+    const blockRange = new vscode.Range(new vscode.Position(startLine, 0), new vscode.Position(elementLineIndex, 0));
+    const continuationText = continuationSpecs.map(spec => createIndicatorContinuationLine(spec.indicators, spec.marker) + '\n').join('');
+    workspaceEdit.replace(uri, blockRange, continuationText);
+
     const elementLine = editor.document.lineAt(elementLineIndex);
-    const newLine = setIndicatorsOnLine(elementLine.text, indicators);
+    const newLine = setIndicatorsOnLine(elementLine.text, terminalSpec?.indicators ?? [], terminalSpec?.marker ?? ' ');
     workspaceEdit.replace(uri, elementLine.range, newLine);
 
     return applyWorkspaceEdit(workspaceEdit, 'set the indicators');
 };
 
-/**
- * Removes all indicators from a DDS element.
- * @param editor - The active text editor
- * @param element - The DDS element to remove indicators from
- */
-async function removeIndicatorsFromElement(editor: vscode.TextEditor, element: any): Promise<boolean> {
-    const workspaceEdit = new vscode.WorkspaceEdit();
-    const uri = editor.document.uri;
-    const elementLineIndex = element.lineIndex;
-
-    // Remove indicators from the main element line
-    const elementLine = editor.document.lineAt(elementLineIndex);
-    const cleanedLine = removeIndicatorsFromLine(elementLine.text);
-    workspaceEdit.replace(uri, elementLine.range, cleanedLine);
-
-    return applyWorkspaceEdit(workspaceEdit, 'remove the indicators');
-};
-
 // LINE CREATION AND PARSING FUNCTIONS
 
 /**
- * Sets indicators on a DDS line, replacing any existing indicators.
+ * Sets indicators (and the column-7 marker) on a DDS line, replacing whatever was there. Only ever
+ * called with a single line's worth (at most INDICATORS_PER_LINE) — anything beyond that belongs on
+ * continuation lines instead (see createIndicatorContinuationLine / applyGroupsToElement).
  * @param lineText - The existing line text
- * @param indicators - The indicators to set (max 3)
+ * @param indicators - The indicators to set on this line (at most INDICATORS_PER_LINE)
+ * @param marker - Blank for an unconditioned/AND-continuing line, 'O' when this line starts a new
+ * OR'd group and happens to also be the element's own (terminal) line
  * @returns Modified line text
  */
-function setIndicatorsOnLine(lineText: string, indicators: IndicatorAssignment[]): string {
+function setIndicatorsOnLine(lineText: string, indicators: IndicatorAssignment[], marker: ' ' | 'O' = ' '): string {
     let line = lineText.padEnd(80, ' ');
-    
-    // Clear existing indicators first (positions 7-16, 0-based: 6-15)
-    line = line.substring(0, 6) + '          ' + line.substring(16);
+
+    // Clear existing marker + indicators first (positions 7-16, 0-based: 6-15), then write the marker.
+    line = line.substring(0, 6) + marker + '         ' + line.substring(16);
 
     // Set new indicators in positions 8-16 (0-based: 7-15)
-    for (let i = 0; i < Math.min(indicators.length, 3); i++) {
+    for (let i = 0; i < Math.min(indicators.length, INDICATORS_PER_LINE); i++) {
         const startPos = 7 + (i * 3); // Positions 8-10, 11-13, 14-16 (0-based: 7-9, 10-12, 13-15)
         const indicator = indicators[i];
         const indicatorText = (indicator.isNegated ? 'N' : ' ') + indicator.value.padStart(2, '0');
-        
+
         if (line.length > startPos + 2) {
             line = line.substring(0, startPos) + indicatorText + line.substring(startPos + 3);
         };
@@ -573,35 +798,25 @@ function setIndicatorsOnLine(lineText: string, indicators: IndicatorAssignment[]
 };
 
 /**
- * Removes indicators from a DDS line.
- * @param lineText - The line text to clean
- * @returns Cleaned line text
- */
-function removeIndicatorsFromLine(lineText: string): string {
-    if (lineText.length < 17) return lineText;
-    
-    // Clear positions 7-16 (condition and indicators, 0-based: 6-15)
-    return (lineText.substring(0, 6) + '          ' + lineText.substring(16)).trimEnd();
-};
-
-/**
  * Parses indicators from a DDS line.
  * @param lineText - The DDS line text
  * @returns Array of parsed indicators
  */
 function parseIndicatorsFromLine(lineText: string): IndicatorAssignment[] {
     const indicators: IndicatorAssignment[] = [];
-    
-    if (lineText.length < 17) return indicators;
 
+    // No upfront length check: a real DDS source line is only as long as it needs to be — a plain
+    // indicator-only continuation line (e.g. "     A  51N61") can be as short as 13 characters, and
+    // the per-slot length check below already safely skips whichever slots that line is too short
+    // to contain.
     // Parse positions 8-16 (0-based: 7-15)
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < INDICATORS_PER_LINE; i++) {
         const startPos = 7 + (i * 3);
         if (lineText.length > startPos + 2) {
             const indicatorText = lineText.substring(startPos, startPos + 3);
             const isNegated = indicatorText[0] === 'N';
             const value = indicatorText.substring(1).trim();
-            
+
             if (value && /^\d{1,2}$/.test(value)) {
                 indicators.push({
                     position: i + 1,

--- a/src/dspf-edit.model/dspf-edit.model.ts
+++ b/src/dspf-edit.model/dspf-edit.model.ts
@@ -40,6 +40,36 @@ export interface DdsAttribute {
 export interface DdsIndicator {
   active: boolean;
   number: number;
+  /**
+   * Zero-based index of the AND-group this indicator belongs to, when the element/keyword is
+   * conditioned by more than 3 ANDed indicators (continued across lines with 'A' in position 7)
+   * and/or several OR'd conditions (each starting with 'O' in position 7) — see "Condition for
+   * display files (positions 7 through 16)" in the DDS reference. All indicators sharing the same
+   * `group` are ANDed together; different groups are ORed. Undefined (or 0) is the common case: a
+   * single AND group, exactly as coded on the element's own line.
+   */
+  group?: number;
+};
+
+/**
+ * Splits a flat, group-tagged indicator array (as produced by the parser — see `DdsIndicator.group`)
+ * back into its OR'd AND-groups, in group order. Indicators with no `group` all fall into the same
+ * (first) group, so a plain, non-continued element's indicators come back as a single group.
+ * Shared by every consumer that needs to evaluate or display the AND/OR structure (indicator
+ * simulation, tree labels, tooltips) so they all agree on the same grouping.
+ * @param indicators - The element's indicators, possibly spanning several OR'd AND-groups
+ */
+export function groupIndicatorsByCondition(indicators?: DdsIndicator[]): DdsIndicator[][] {
+  if (!indicators || indicators.length === 0) return [];
+
+  const groups = new Map<number, DdsIndicator[]>();
+  for (const ind of indicators) {
+    const key = ind.group ?? 0;
+    const group = groups.get(key);
+    if (group) group.push(ind); else groups.set(key, [ind]);
+  };
+
+  return [...groups.entries()].sort((a, b) => a[0] - b[0]).map(([, group]) => group);
 };
 
 /**

--- a/src/dspf-edit.parser/dspf-edit.parser.ts
+++ b/src/dspf-edit.parser/dspf-edit.parser.ts
@@ -34,6 +34,75 @@ export let currentDdsElements: DdsElement[] = [];
 let lastPositionInRecord: { row: number; col: number; length: number } | undefined;
 
 /**
+ * AND-groups accumulated so far from indicator-only continuation lines (position 7 = 'A'/blank,
+ * or 'O' to start a new OR'd group — see "Condition for display files (positions 7 through 16)"
+ * in the DDS reference), waiting to be attached to the next field/constant/keyword line that
+ * actually names something. Per that same rule, the field/constant/keyword itself only ever
+ * appears on the last line of such a group, so this buffer is folded into (and cleared by)
+ * whichever real element line follows — see resolveLineIndicators.
+ */
+let pendingIndicatorGroups: DdsIndicator[][] = [];
+
+/**
+ * Clears any indicator-continuation lines collected so far without a terminating element line
+ * (either a fresh parse, or a malformed/dangling group — e.g. before a record line, which this
+ * conditioning mechanism doesn't apply to).
+ */
+function resetPendingIndicatorGroups(): void {
+    pendingIndicatorGroups = [];
+};
+
+/**
+ * True when a line is a pure indicator continuation line: it carries its own conditioning
+ * indicators (columns 8-16) but no keyword text (columns 45-80) — meaning it doesn't stand on its
+ * own and instead extends whichever field/constant/keyword line follows. (A field/constant name or
+ * position already rules this out at the call site, via isFieldLine/isConstantLine.)
+ * @param trimmedLine - Line with the sequence number area removed
+ * @param indicators - This line's own indicators, already parsed from columns 8-16
+ */
+function isIndicatorOnlyLine(trimmedLine: string, indicators: DdsIndicator[]): boolean {
+    if (indicators.length === 0) return false;
+    return trimmedLine.substring(39, 75).trim() === '';
+};
+
+/**
+ * Folds a line's own indicators into the pending buffer according to its column-7 marker: 'O'
+ * starts a new OR'd group, 'A' (or blank, the default) extends the AND group currently being built.
+ * @param marker - The line's column-7 character
+ * @param indicators - The line's own indicators (columns 8-16)
+ */
+function accumulatePendingIndicators(marker: string, indicators: DdsIndicator[]): void {
+    if (marker === 'O' && pendingIndicatorGroups.length > 0) {
+        pendingIndicatorGroups.push([...indicators]);
+    } else {
+        if (pendingIndicatorGroups.length === 0) pendingIndicatorGroups.push([]);
+        pendingIndicatorGroups[pendingIndicatorGroups.length - 1].push(...indicators);
+    };
+};
+
+/**
+ * Resolves the final, group-tagged indicator set for a terminating element line (one that names a
+ * field/constant or carries keyword text): folds its own indicators into any pending continuation
+ * groups per its own column-7 marker, then flattens the result — each indicator tagged with its
+ * (zero-based) OR-group index — and clears the pending buffer. When there's nothing pending (the
+ * overwhelming majority of lines), this is just the line's own indicators, all in group 0,
+ * identical to the pre-continuation-support behavior.
+ * @param marker - The terminating line's column-7 character
+ * @param ownIndicators - The terminating line's own indicators (columns 8-16)
+ */
+function resolveLineIndicators(marker: string, ownIndicators: DdsIndicator[]): DdsIndicator[] {
+    if (pendingIndicatorGroups.length === 0) {
+        return ownIndicators.map(ind => ({ ...ind, group: 0 }));
+    };
+
+    accumulatePendingIndicators(marker, ownIndicators);
+    const groups = pendingIndicatorGroups;
+    resetPendingIndicatorGroups();
+
+    return groups.flatMap((group, groupIndex) => group.map(ind => ({ ...ind, group: groupIndex })));
+};
+
+/**
  * Main parser function that processes DDS document text and returns structured elements
  * @param text - Raw DDS document text to parse
  * @returns Array of parsed DDS elements
@@ -82,6 +151,7 @@ function clearGlobalState(): void {
     fieldsPerRecords.length = 0;
     attributesFileLevel.length = 0;
     lastPositionInRecord = undefined;
+    resetPendingIndicatorGroups();
 
     // Reset both display-size slots so switching to a document with fewer (or no) DSPSIZ formats
     // doesn't leak a stale second size (e.g. *DS4) left over from a previously parsed document —
@@ -159,22 +229,40 @@ function parseSingleDdsLine(
 
     // Extract common line components
     const lineComponents = extractLineComponents(trimmedLine);
+    // Column 7: blank/'A' continues (or starts) an AND group, 'O' starts a new OR'd group — see
+    // resolveLineIndicators/accumulatePendingIndicators.
+    const conditionMarker = trimmedLine.charAt(1);
 
     // Determine element type and parse accordingly
     if (isRecordLine(trimmedLine)) {
+        // This conditioning mechanism applies to fields/constants/keywords, not record lines —
+        // drop any dangling continuation group rather than let it leak into whatever comes next.
+        resetPendingIndicatorGroups();
         return parseRecordElement(lines, lineIndex, trimmedLine, lastRecord);
     };
 
     if (isFieldLine(lineComponents.fieldName)) {
-        return parseFieldElement(lines, lineIndex, trimmedLine, lineComponents, lastRecord);
+        const indicators = resolveLineIndicators(conditionMarker, lineComponents.indicators);
+        return parseFieldElement(lines, lineIndex, trimmedLine, { ...lineComponents, indicators }, lastRecord);
     };
 
     if (isConstantLine(lineComponents)) {
-        return parseConstantElement(lines, lineIndex, trimmedLine, lineComponents, lastRecord);
+        const indicators = resolveLineIndicators(conditionMarker, lineComponents.indicators);
+        return parseConstantElement(lines, lineIndex, trimmedLine, { ...lineComponents, indicators }, lastRecord);
     };
 
-    // Default to attribute parsing
-    return parseAttributeElement(lines, lineIndex, trimmedLine, lineComponents, lastRecord, hasFieldInCurrentRecord);
+    // Neither record, field, nor constant: either a pure indicator-only continuation line (no name,
+    // no keyword text — buffer it for whichever real line follows) or a keyword-only attribute line.
+    if (isIndicatorOnlyLine(trimmedLine, lineComponents.indicators)) {
+        accumulatePendingIndicators(conditionMarker, lineComponents.indicators);
+        return { element: undefined, nextIndex: lineIndex, lastRecord };
+    };
+
+    // Default to attribute parsing. Whether this line actually carries keyword text (and so should
+    // consume the pending buffer) is only known once extractAttributes runs, so the merge happens
+    // inside parseAttributeElement itself — a blank/malformed line here must NOT swallow indicators
+    // that are still waiting for a later line.
+    return parseAttributeElement(lines, lineIndex, trimmedLine, lineComponents, lastRecord, hasFieldInCurrentRecord, conditionMarker);
 };
 
 /**
@@ -556,11 +644,21 @@ function parseAttributeElement(
     trimmedLine: string,
     components: any,
     lastRecord: string,
-    hasFieldInCurrentRecord: boolean
+    hasFieldInCurrentRecord: boolean,
+    conditionMarker: string
 ) {
+    // Extract with the line's own (unmerged) indicators first — extractAttributes returns an empty
+    // array whenever there's no actual keyword text, and only then do we know whether this line is
+    // real or a blank/malformed one. Only a real line may consume the pending continuation buffer
+    // (see the comment at this function's call site).
     const { attributes, nextIndex } = extractAttributes('A', lines, lineIndex, true, components.indicators, components.displayFormat);
 
     if (attributes.length > 0) {
+        // Now that we know this line carries a real keyword, fold it (and any pending
+        // continuation groups) into the attribute's final, group-tagged indicator set.
+        const indicators = resolveLineIndicators(conditionMarker, components.indicators);
+        attributes.forEach(attr => { attr.indicators = indicators; });
+
         // A keyword-only line with no field/constant seen yet since the record line belongs to the
         // record itself (e.g. SFL placed on its own line by SDA/RDI instead of the record name's
         // own line). linkAttributesToParents() links it into the record element too, but only after
@@ -584,7 +682,7 @@ function parseAttributeElement(
             lineIndex: lineIndex,
             lastLineIndex: maxLastLineIndex,
             value: '',
-            indicators: components.indicators,
+            indicators: indicators,
             displayFormat: components.displayFormat,
             attributes: attributes
         };

--- a/src/dspf-edit.providers/dspf-edit.providers.ts
+++ b/src/dspf-edit.providers/dspf-edit.providers.ts
@@ -6,8 +6,8 @@
 
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { DdsElement, DdsGroup } from '../dspf-edit.model/dspf-edit.model';
-import { describeDdsField, describeDdsConstant, describeDdsRecord, describeDdsFile, formatDdsIndicators } from '../dspf-edit.utils/dspf-edit.helper';
+import { DdsElement, DdsGroup, DdsIndicator, groupIndicatorsByCondition } from '../dspf-edit.model/dspf-edit.model';
+import { describeDdsField, describeDdsConstant, describeDdsRecord, describeDdsFile, formatDdsIndicators, formatIndicatorCondition } from '../dspf-edit.utils/dspf-edit.helper';
 import { ExtensionState } from '../dspf-edit.states/state';
 import { getResolvedRef, getPendingReferencedFields } from '../dspf-edit.ibmi/dspf-edit.ibmi-integration';
 
@@ -650,6 +650,11 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 	 */
 	private getGroupChildren(element: DdsNode): Thenable<DdsNode[]> {
 		const groupAttr = element.ddsElement.attribute ?? '';
+		// One AND-group of an OR'd indicator condition (see getIndicatorsGroupChildren) — carries its
+		// own group index as a suffix, so it can't be a fixed switch case like the others below.
+		if (groupAttr.startsWith('IndicatorGroup:')) {
+			return this.getIndicatorLeafNodes((element.ddsElement as DdsGroup).indicators ?? []);
+		}
 		switch (groupAttr) {
 			case 'Attributes': return this.getAttributesGroupChildren(element);
 			case 'ConstantAttributes': return this.getConstantAttributesGroupChildren(element);
@@ -677,10 +682,40 @@ export class DdsTreeProvider implements vscode.TreeDataProvider<DdsNode> {
 		return Promise.resolve(attrs.map(attr => new DdsNode(`⚙️ ${'value' in attr ? attr.value : 'Attribute'} `, vscode.TreeItemCollapsibleState.None, { ...attr, kind: 'fieldAttribute', lineIndex: attr.lineIndex ?? group.lineIndex, lastLineIndex: attr.lastLineIndex ?? group.lineIndex })));
 	}
 
+	/**
+	 * Indicator leaf nodes for a single AND-group (each one a plain "51: ON" row) — shared by the
+	 * flat single-group case and each OR'd sub-group below.
+	 */
+	private getIndicatorLeafNodes(indis: DdsIndicator[]): Thenable<DdsNode[]> {
+		return Promise.resolve(indis.map(indi => new DdsNode(`${indi.number.toString().padStart(2, '0')}: ${indi.active ? 'ON' : 'OFF'}`, vscode.TreeItemCollapsibleState.None, { kind: 'indicatornode', indicator: indi, attributes: [], indicators: [], lineIndex: 0 })));
+	}
+
+	/**
+	 * Children of the "📶 Indicators" node. When the condition is a single AND-group (the
+	 * overwhelming common case: one line, up to 3 indicators, no continuation), this stays a flat
+	 * list exactly as before. When it spans several OR'd AND-groups (continuation lines — see
+	 * DdsIndicator.group), each group gets its own expandable node, with a plain "OR" row between
+	 * them so the boolean structure is visible at a glance.
+	 */
 	private getIndicatorsGroupChildren(element: DdsNode): Thenable<DdsNode[]> {
 		const group = element.ddsElement as DdsGroup;
 		const indis = group.indicators ?? [];
-		return Promise.resolve(indis.map(indi => new DdsNode(`${indi.number.toString().padStart(2, '0')}: ${indi.active ? 'ON' : 'OFF'}`, vscode.TreeItemCollapsibleState.None, { kind: 'indicatornode', indicator: indi, attributes: [], indicators: [], lineIndex: 0 })));
+		const conditionGroups = groupIndicatorsByCondition(indis);
+
+		if (conditionGroups.length <= 1) {
+			return this.getIndicatorLeafNodes(indis);
+		}
+
+		const nodes: DdsNode[] = [];
+		conditionGroups.forEach((conditionGroup, i) => {
+			if (i > 0) {
+				nodes.push(new DdsNode('──── OR ────', vscode.TreeItemCollapsibleState.None,
+					{ kind: 'group', attribute: '', lineIndex: group.lineIndex, children: [], attributes: [], indicators: [] }));
+			};
+			nodes.push(new DdsNode(`Group ${i + 1} (AND)`, vscode.TreeItemCollapsibleState.Expanded,
+				{ kind: 'group', attribute: `IndicatorGroup:${i}`, lineIndex: group.lineIndex, children: [], attributes: [], indicators: conditionGroup } as DdsGroup));
+		});
+		return Promise.resolve(nodes);
 	}
 
 	private getDefaultGroupChildren(element: DdsNode): Thenable<DdsNode[]> {
@@ -827,13 +862,20 @@ export class DdsNode extends vscode.TreeItem {
 	}
 
 	private getTooltip(ddsElement: DdsElement): string {
-		switch (ddsElement.kind) {
-			case 'record':
-			case 'field':
-			case 'constant':
-			case 'attribute':
-			case 'file': return ddsElement.kind;
-			default: return '';
-		}
+		const base = (() => {
+			switch (ddsElement.kind) {
+				case 'record':
+				case 'field':
+				case 'constant':
+				case 'attribute':
+				case 'constantAttribute':
+				case 'fieldAttribute':
+				case 'file': return ddsElement.kind;
+				default: return '';
+			}
+		})();
+
+		const condition = 'indicators' in ddsElement ? formatIndicatorCondition(ddsElement.indicators) : '';
+		return condition ? `${base}\nActive when: ${condition}` : base;
 	}
 }

--- a/src/dspf-edit.utils/dspf-edit.helper.ts
+++ b/src/dspf-edit.utils/dspf-edit.helper.ts
@@ -7,7 +7,7 @@
 
 import * as vscode from 'vscode';
 import * as fs from 'fs';
-import { DdsElement, DdsIndicator, DdsAttribute, records, FieldsPerRecord, ConstantInfo, FieldInfo, fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
+import { DdsElement, DdsIndicator, DdsAttribute, records, FieldsPerRecord, ConstantInfo, FieldInfo, fieldsPerRecords, groupIndicatorsByCondition } from '../dspf-edit.model/dspf-edit.model';
 import { DdsTreeProvider } from '../dspf-edit.providers/dspf-edit.providers';
 import { parseDocument } from '../dspf-edit.parser/dspf-edit.parser';
 import { ExtensionState } from '../dspf-edit.states/state';
@@ -84,20 +84,42 @@ export function describeDdsFile(field: DdsElement): string {
 // FORMATTING FUNCTIONS
 
 /**
- * Formats DDS indicators into a readable string representation.
+ * Formats DDS indicators into a readable string representation. Indicators sharing the same
+ * `group` (ANDed together, e.g. via an 'A'-continuation line) are shown side by side; different
+ * groups (ORed, started by an 'O'-continuation line) are separated by " OR ". Indicators with no
+ * `group` (the common case) are all treated as a single group, so this is identical to before for
+ * every non-continued element.
  * @param indicators - Array of DDS indicators to format
  * @returns A formatted string showing indicators with their active/inactive status
  */
 export function formatDdsIndicators(indicators?: DdsIndicator[]): string {
     if (!indicators || indicators.length === 0) return '';
 
-    const indicatorStr = `[${indicators.map(ind => {
+    const formatGroup = (group: DdsIndicator[]) => group.map(ind => {
         const status = ind.active ? ' ' : 'N';
         const number = ind.number.toString().padStart(2, '0');
         return `${status}${number}`;
-    }).join('')}]`;
+    }).join('');
+
+    const indicatorStr = `[${groupIndicatorsByCondition(indicators).map(formatGroup).join(' OR ')}]`;
 
     return indicatorStr;
+};
+
+/**
+ * Spells out a full indicator condition as a human-readable boolean expression, e.g.
+ * "51 AND NOT 61 AND 53  OR  52  OR  81 AND 82" — the same AND/OR structure formatDdsIndicators
+ * encodes compactly, for use in tooltips.
+ * @param indicators - Array of DDS indicators to describe
+ * @returns A human-readable condition string, or '' when unconditioned
+ */
+export function formatIndicatorCondition(indicators?: DdsIndicator[]): string {
+    if (!indicators || indicators.length === 0) return '';
+
+    const describeIndicator = (ind: DdsIndicator) => `${ind.active ? '' : 'NOT '}${ind.number.toString().padStart(2, '0')}`;
+    const describeGroup = (group: DdsIndicator[]) => group.map(describeIndicator).join(' AND ');
+
+    return groupIndicatorsByCondition(indicators).map(describeGroup).join('  OR  ');
 };
 
 /**

--- a/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
@@ -5,7 +5,7 @@
 */
 
 import * as vscode from 'vscode';
-import { FieldsPerRecord, DdsSize, DdsAttribute, AttributeWithIndicators, DdsIndicator, fieldsPerRecords, records, getDefaultSize, getAvailableDisplayFormats, getSizeForFormat, SYSTEM_FIELD_PLACEHOLDER } from '../dspf-edit.model/dspf-edit.model';
+import { FieldsPerRecord, DdsSize, DdsAttribute, AttributeWithIndicators, DdsIndicator, fieldsPerRecords, records, getDefaultSize, getAvailableDisplayFormats, getSizeForFormat, SYSTEM_FIELD_PLACEHOLDER, groupIndicatorsByCondition } from '../dspf-edit.model/dspf-edit.model';
 import { checkForEditorAndDocument, updateTreeProvider, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 import { DdsTreeProvider } from '../dspf-edit.providers/dspf-edit.providers';
 import { ExtensionState } from '../dspf-edit.states/state';
@@ -979,12 +979,15 @@ export class RecordPreviewPanel {
 
     /**
      * Checks whether a field/constant's own line-level indicators (columns 7-15, e.g. "61"/"N61")
-     * are satisfied. With live indicators, checks them against the currently toggled-on set
-     * (multiple indicators on one line are ANDed together, matching real DDS conditioning).
-     * Otherwise, uses the resting state — every indicator assumed OFF — so only unconditioned
-     * items and negated ("N") conditions show; this is what makes mutually-exclusive alternates
-     * (e.g. one shown on "61", another on "N61") resolve to a single, deterministic one even when
-     * they don't happen to share the same screen position. No indicators at all means "always shown".
+     * are satisfied. Indicators sharing the same `group` (all those coded on one line, plus any
+     * ANDed onto it via 'A'-continuation lines) are ANDed together; different groups (started by an
+     * 'O'-continuation line) are ORed — matching real DDS conditioning. Indicators with no `group`
+     * (the common case: a single, non-continued line) are all treated as one group. With live
+     * indicators, checks them against the currently toggled-on set. Otherwise, uses the resting
+     * state — every indicator assumed OFF — so only unconditioned items and negated ("N")
+     * conditions show; this is what makes mutually-exclusive alternates (e.g. one shown on "61",
+     * another on "N61") resolve to a single, deterministic one even when they don't happen to share
+     * the same screen position. No indicators at all means "always shown".
      * @param indicators - The item's own indicators
      * @param useLiveIndicators - Whether to check against the toggled-on indicator set, or assume all OFF
      */
@@ -992,10 +995,11 @@ export class RecordPreviewPanel {
         if (!indicators || indicators.length === 0) {
             return true;
         };
-        if (!useLiveIndicators) {
-            return indicators.every(ind => !ind.active);
-        };
-        return indicators.every(ind => this.activeIndicators.has(ind.number) === ind.active);
+
+        const satisfies = (ind: DdsIndicator) =>
+            useLiveIndicators ? this.activeIndicators.has(ind.number) === ind.active : !ind.active;
+
+        return groupIndicatorsByCondition(indicators).some(group => group.every(satisfies));
     };
 
     /**

--- a/src/test/dspf-edit.parser.indicators.test.ts
+++ b/src/test/dspf-edit.parser.indicators.test.ts
@@ -1,0 +1,118 @@
+import * as assert from 'assert';
+import { parseDocument } from '../dspf-edit.parser/dspf-edit.parser';
+import { DdsField, DdsIndicator } from '../dspf-edit.model/dspf-edit.model';
+
+/**
+ * Builds a full 80-column DDS source line from a "trimmedLine" (everything after the 5-character
+ * sequence number area), placing each field at the same 0-based offsets the parser itself reads —
+ * see extractLineComponents in dspf-edit.parser.ts. Keeps these tests readable without having to
+ * hand-count columns for every line.
+ */
+function ddsLine(opts: { marker?: string; ind?: string; name?: string; row?: number | ''; col?: number | ''; keyword?: string }): string {
+    const { marker = ' ', ind = '', name = '', row = '', col = '', keyword = '' } = opts;
+    const chars = new Array(80).fill(' ');
+    chars[0] = 'A';
+    chars[1] = marker;
+    for (let i = 0; i < ind.length && i < 9; i++) chars[2 + i] = ind[i];
+    for (let i = 0; i < name.length && i < 10; i++) chars[13 + i] = name[i];
+    if (row !== '') {
+        const rowStr = row.toString().padStart(3, ' ');
+        for (let i = 0; i < 3; i++) chars[33 + i] = rowStr[i];
+    };
+    if (col !== '') {
+        const colStr = col.toString().padStart(3, ' ');
+        for (let i = 0; i < 3; i++) chars[36 + i] = colStr[i];
+    };
+    for (let i = 0; i < keyword.length && i < 36; i++) chars[39 + i] = keyword[i];
+    return '00000' + chars.join('');
+}
+
+function indSlot(activeChar: ' ' | 'N', num: number): string {
+    return activeChar + num.toString().padStart(2, '0');
+}
+
+suite('Parser: indicator AND/OR conditioning', () => {
+
+    test('a plain, non-continued field keeps all its indicators in group 0', () => {
+        const src = [
+            ddsLine({ marker: ' ', ind: indSlot(' ', 50) + indSlot('N', 51), name: 'FLDC', row: 12, col: 20 }),
+        ].join('\n');
+
+        const field = parseDocument(src).find(el => el.kind === 'field') as DdsField;
+        assert.ok(field, 'FLDC should be parsed');
+        assert.deepStrictEqual(
+            field.indicators?.map(i => [i.number, i.active, i.group]),
+            [[50, true, 0], [51, false, 0]]
+        );
+    });
+
+    test('AND-continuation (position 7 blank/A) + a terminal line marked O reproduces the DDS reference example', () => {
+        // Mirrors the IBM DDS reference manual's own example (Figure 2): "FLDA is selected if
+        // either indicator 01 is off or indicator 02 is on."
+        const src = [
+            ddsLine({ marker: ' ', ind: indSlot('N', 1) }),
+            ddsLine({ marker: 'O', ind: indSlot(' ', 2), name: 'FLDA', row: 10, col: 20, keyword: 'DSPATR(HI)' }),
+        ].join('\n');
+
+        const field = parseDocument(src).find(el => el.kind === 'field') as DdsField;
+        assert.deepStrictEqual(
+            field.indicators?.map(i => [i.number, i.active, i.group]),
+            [[1, false, 0], [2, true, 1]]
+        );
+
+        const attr = field.attributes?.find(a => a.value === 'DSPATR(HI)');
+        assert.deepStrictEqual(
+            attr?.indicators?.map(i => [i.number, i.active, i.group]),
+            [[1, false, 0], [2, true, 1]]
+        );
+    });
+
+    test('AND-continuation beyond 3 indicators, then an OR group, conditioning a keyword (not the field itself)', () => {
+        const src = [
+            ddsLine({ name: 'FLDB', row: 11, col: 20 }),                                    // unconditioned itself
+            ddsLine({ marker: ' ', ind: indSlot(' ', 72) + indSlot(' ', 73) }),              // AND group 0: 72,73
+            ddsLine({ marker: 'O', ind: indSlot(' ', 60) + indSlot(' ', 61) + indSlot(' ', 62) }), // OR: group 1 starts
+            ddsLine({ marker: 'A', ind: indSlot(' ', 63), keyword: 'DSPATR(HI)' }),          // extends group 1, terminal
+        ].join('\n');
+
+        const field = parseDocument(src).find(el => el.kind === 'field') as DdsField;
+        assert.strictEqual(field.indicators?.length ?? 0, 0, 'FLDB itself is unconditioned');
+
+        const attr = field.attributes?.find(a => a.value === 'DSPATR(HI)');
+        assert.deepStrictEqual(
+            attr?.indicators?.map(i => [i.number, i.active, i.group]),
+            [[72, true, 0], [73, true, 0], [60, true, 1], [61, true, 1], [62, true, 1], [63, true, 1]]
+        );
+    });
+
+    test('a real-world 3-way OR condition (as coded by a user testing the preview) resolves correctly', () => {
+        // "     A                                 11 35'Hello world!'"
+        // "     A  51N61"
+        // "     AA 53"
+        // "     AO 52"
+        // "     AO 81 82                               COLOR(BLU)"
+        const src = [
+            "     A                                 11 35'Hello world!'",
+            "     A  51N61",
+            "     AA 53",
+            "     AO 52",
+            "     AO 81 82                               COLOR(BLU)",
+        ].join('\n');
+
+        const constant = parseDocument(src).find(el => el.kind === 'constant');
+        assert.ok(constant, 'the constant should be parsed');
+        const colorAttr = (constant as any).attributes?.find((a: any) => a.value === 'COLOR(BLU)');
+
+        const byGroup = new Map<number, DdsIndicator[]>();
+        for (const ind of colorAttr.indicators as DdsIndicator[]) {
+            const g = byGroup.get(ind.group ?? 0) ?? [];
+            g.push(ind);
+            byGroup.set(ind.group ?? 0, g);
+        };
+
+        assert.deepStrictEqual([...byGroup.keys()].sort(), [0, 1, 2]);
+        assert.deepStrictEqual(byGroup.get(0)!.map(i => [i.number, i.active]), [[51, true], [61, false], [53, true]]);
+        assert.deepStrictEqual(byGroup.get(1)!.map(i => [i.number, i.active]), [[52, true]]);
+        assert.deepStrictEqual(byGroup.get(2)!.map(i => [i.number, i.active]), [[81, true], [82, true]]);
+    });
+});


### PR DESCRIPTION
## [0.15.0] - 2026-08-11
### Added
- Indicators: full support for DDS's AND/OR conditioning — previously only a single line's worth (up to 3 ANDed) was read or editable, and OR'd conditions were silently ignored.
  - Parser: reads indicator-only continuation lines (position 7 `A`/blank to extend an AND group beyond 3, `O` to start a new OR'd group), up to DDS's own limits (9 ANDed indicators per condition, 9 OR'd conditions).
  - Tree view: an OR'd condition is now shown grouped into its ANDed sub-conditions instead of one flat, misleading list; hovering a conditioned field/constant/attribute shows the full condition as a tooltip (e.g. `51 AND NOT 61 AND 53  OR  52`).
  - Preview: indicator simulation (on/off toggles) now evaluates AND/OR conditions correctly instead of treating every indicator as ANDed together.
  - "Indicators" command: add a 4th+ ANDed indicator (continuation lines are generated/removed automatically), add or remove a whole OR'd condition, or edit indicators within a specific one when there's more than one.
