### PR TITLE
v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
+## [0.16.0] - 2026-08-11
+### Added
+- Multi-size (DSPSIZ) awareness across creation and editing: when a display file declares more than one screen size (e.g. `DSPSIZ(24 80 *DS3 27 132 *DS4)`), the extension now keeps every declared size correct instead of only ever acting on the first one.
+  - New Record / Change Window Size: creating or resizing a WINDOW now generates one `WINDOW()` line per declared size — same rows/columns, position recalculated to fit each screen — instead of a single line silently reused (and often mispositioned) on every size.
+  - Change Window Title: edits the title line that actually matches the size being worked on, asking which one when invoked from the tree and the record declares more than one.
+  - Preview: dragging/resizing/centering a window, or adjusting a subfile's SFLPAG/SFLSIZ, while a specific size is selected in the preview's format switcher no longer silently changes the other declared size too — the first time a shared, unconditioned line is edited this way, it's split into one explicit line per declared size, and only the one being viewed changes.
+  - New "Add Display Size" command (right-click the file in the tree) adds the second standard size (*DS3/*DS4) to a file that currently declares only one, rewriting its DSPSIZ specification in place. Existing windows/subfiles keep applying to the new size unchanged (DDS's own "unconditioned line applies everywhere" rule) until adjusted per size from the preview. Removing a declared size isn't supported yet.
+  - Change Position: a field/constant's row/column bounds are now validated against the smallest declared size, not just the first one, so a position stays reachable regardless of which size is active.
+
 ## [0.15.0] - 2026-08-11
 ### Added
 - Indicators: full support for DDS's AND/OR conditioning — previously only a single line's worth (up to 3 ANDed) was read or editable, and OR'd conditions were silently ignored.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
+## [0.17.0] - 2026-08-12
+### Added
+- Command Keys: adding a CAxx/CFxx now also checks the *other* level (the file, when adding to a record; every record, when adding at file level) and excludes any key number already used there from the picker, regardless of whether the type matches — prevents generating a record whose effective key set defines the same key number as both CA and CF (or twice), which DDS won't compile.
+- Preview: a function-key legend now always shows below the toolbar — one green-bordered `Fnn` badge per key actually available to the record being previewed (file-level + record-level CAxx/CFxx, record overriding file per key number, narrowed to the active display format). A key still shows even when its own indicator condition isn't currently met, so you can see at a glance that it's *defined*; it switches to solid (inverted) styling when it's actually active right now — correctly handling more than one indicator-conditioned alternate per key number (AND/OR), and hovering shows its description.
+- Preview: an active `ERRMSG()` on a `WINDOW` record now shows on the window's own reserved message line (its last content row) instead of always at the bottom of the physical screen — matching the DDS `WINDOW` keyword's `MSGLIN`/`*NOMSGLIN` parameter (a window reserves its own message line by default; `*NOMSGLIN` is what opts out and sends it to the display's normal message line instead).
+- Preview: the "Indicators" toggle and the active display format (e.g. *DS3) now persist across switching which record is previewed in the same panel, instead of resetting back off/default every time.
+### Fixed
+- Command Keys / Preview: a CAxx/CFxx description longer than 25 characters — legitimately allowed by DDS, spilling onto a continuation line in the source — was silently dropped from both the "current key commands" list and the preview's function-key legend. The reading regex incorrectly reused the 25-character cap that's only meant to apply when this tool itself creates a *new* key command.
+- Preview: the display-format dropdown (the *DS3/*DS4 selector) could end up blank instead of showing a real selection — it now keeps the previously-selected format across record switches, but wasn't falling back when that format no longer applied (e.g. after switching to a different file, or a live edit removed a DSPSIZ format from the current one).
+- Preview: the panel went blank after being dragged to a different editor group — VS Code was tearing down its live content whenever it became hidden (which moving it briefly does) and nothing re-rendered it on return; the panel now keeps its content alive in the background (`retainContextWhenHidden`).
+
 ## [0.16.0] - 2026-08-11
 ### Added
 - Multi-size (DSPSIZ) awareness across creation and editing: when a display file declares more than one screen size (e.g. `DSPSIZ(24 80 *DS3 27 132 *DS4)`), the extension now keeps every declared size correct instead of only ever acting on the first one.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The extension provides a **navigable schema view** of the DDS source file that i
   - View display file attributes (e.g., display size, command keys).
   - Right-click options:
     - Create new records.
-    - Assign command keys.
+    - Assign command keys — a key number already used at the other level (file vs. record) is excluded, so you can't end up with the same key defined as both CA and CF.
     - Add Display Size: adds a second standard screen size (*DS3/*DS4) to a file that currently declares only one.
 
 - **Records level**
@@ -32,7 +32,7 @@ The extension provides a **navigable schema view** of the DDS source file that i
     - Remove field.
     - Copy/Delete record.
     - Add "buttons" (constants for record commands).
-    - Assign command keys.
+    - Assign command keys — a key number already used at the other level (file vs. record) is excluded, so you can't end up with the same key defined as both CA and CF.
     - Add / Remove / Change indicators.
     - Resizing (if window record) — aware of every declared display size, resizing all of them at once.
     - Change Window Title (if window record) — targets the size being worked on when the record declares more than one.
@@ -82,7 +82,10 @@ The extension provides a **navigable schema view** of the DDS source file that i
   - Subfile (SFL/SFLCTL) records show all SFLPAG rows, and automatically preview their paired header/detail record; detail rows can't be dragged up over the header's own content.
   - Overlay any other record (dimmed) behind the one being previewed, to see how they compose.
   - Simulate indicators on/off to preview conditional fields, constants, and attributes.
+  - A function-key legend (`F3`, `F12`, ...) shows every command key available to the record being previewed (file-level + record-level CAxx/CFxx); a key still shows even when its indicator condition isn't currently met (so you can see it's defined), switching to solid/inverted styling when it's actually active.
+  - An active `ERRMSG()` on a window shows on the window's own reserved message line (its last content row) when the window doesn't specify `*NOMSGLIN`, matching real DDS behavior, instead of always at the bottom of the physical screen.
   - For files with more than one DSPSIZ format (e.g. *DS3/*DS4), switch which one is previewed — window positions/sizes and conditioned elements are resolved for the selected format. Dragging/resizing/centering a window, or adjusting a subfile's SFLPAG/SFLSIZ, only affects the size currently being previewed.
+  - The "Indicators" toggle and the selected display format persist when switching which record is previewed in the same panel.
   - Stays in sync with the schema tree selection in both directions.
 
 ---
@@ -121,8 +124,9 @@ Some features may not work as expected. Please leave an issue if something is no
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**0.16.0** - 2026-08-11
-- Added: Multi-size (DSPSIZ) awareness across creation and editing. Creating/resizing a WINDOW, or changing its title, now correctly handles every declared screen size (not just the first); editing a window or a subfile's SFLPAG/SFLSIZ from the preview while viewing one specific size no longer silently changes another; a new "Add Display Size" command adds a second standard size to a file that only declares one.
+**0.17.0** - 2026-08-12
+- Added: Command Keys now checks across file/record level to prevent a key number being defined as both CA and CF. Preview gained a function-key legend (shows every available `Fnn`, highlighting the ones currently active) and now shows an active `ERRMSG()` on the window's own message line when applicable. The "Indicators" toggle and selected display format persist across switching which record is previewed.
+- Fixed: a CAxx/CFxx description longer than 25 characters (spilling onto a continuation line) was silently dropped instead of shown. The display-format dropdown could go blank after switching records/files. The preview panel could go blank after being dragged to a different editor group.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The extension provides a **navigable schema view** of the DDS source file that i
   - Right-click options:
     - Create new records.
     - Assign command keys.
+    - Add Display Size: adds a second standard screen size (*DS3/*DS4) to a file that currently declares only one.
 
 - **Records level**
   - Right-click options:
@@ -33,8 +34,8 @@ The extension provides a **navigable schema view** of the DDS source file that i
     - Add "buttons" (constants for record commands).
     - Assign command keys.
     - Add / Remove / Change indicators.
-    - Resizing (if window record).
-    - Change Window Title (if window record).
+    - Resizing (if window record) — aware of every declared display size, resizing all of them at once.
+    - Change Window Title (if window record) — targets the size being worked on when the record declares more than one.
     - Sort elements.
     - Preview Screen Layout (also available as an inline button on the record).
 
@@ -81,7 +82,7 @@ The extension provides a **navigable schema view** of the DDS source file that i
   - Subfile (SFL/SFLCTL) records show all SFLPAG rows, and automatically preview their paired header/detail record; detail rows can't be dragged up over the header's own content.
   - Overlay any other record (dimmed) behind the one being previewed, to see how they compose.
   - Simulate indicators on/off to preview conditional fields, constants, and attributes.
-  - For files with more than one DSPSIZ format (e.g. *DS3/*DS4), switch which one is previewed — window positions/sizes and conditioned elements are resolved for the selected format.
+  - For files with more than one DSPSIZ format (e.g. *DS3/*DS4), switch which one is previewed — window positions/sizes and conditioned elements are resolved for the selected format. Dragging/resizing/centering a window, or adjusting a subfile's SFLPAG/SFLSIZ, only affects the size currently being previewed.
   - Stays in sync with the schema tree selection in both directions.
 
 ---
@@ -111,7 +112,7 @@ Some features may not work as expected. Please leave an issue if something is no
 ## 📝 To Do
 
 - Bug fixes.  
-- Correct handling of display sizes.  
+- Support removing a declared display size.  
 - Many new features to come!  
 
 ---
@@ -120,8 +121,8 @@ Some features may not work as expected. Please leave an issue if something is no
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**0.15.0** - 2026-08-11
-- Added: Indicators: full support for DDS's AND/OR conditioning — more than 3 ANDed indicators (up to DDS's limit of 9, spilling onto continuation lines automatically), and OR'd conditions (add/remove a whole OR'd group, or edit indicators within a specific one). Tree view shows an OR'd condition grouped by AND sub-condition, with a readable tooltip; preview's indicator simulation now evaluates AND/OR correctly instead of treating every indicator as ANDed together.
+**0.16.0** - 2026-08-11
+- Added: Multi-size (DSPSIZ) awareness across creation and editing. Creating/resizing a WINDOW, or changing its title, now correctly handles every declared screen size (not just the first); editing a window or a subfile's SFLPAG/SFLSIZ from the preview while viewing one specific size no longer silently changes another; a new "Add Display Size" command adds a second standard size to a file that only declares one.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dspf-edit",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dspf-edit",
-      "version": "0.16.0",
+      "version": "0.17.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dspf-edit",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dspf-edit",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"
@@ -100,6 +100,10 @@
       {
         "command": "dspf-edit.new-record",
         "title": "New Record"
+      },
+      {
+        "command": "dspf-edit.add-display-size",
+        "title": "Add Display Size"
       },
       {
         "command": "dspf-edit.add-buttons",
@@ -394,6 +398,11 @@
           "command": "dspf-edit.add-key",
           "when": "view == dspf-edit.schema-view && viewItem == file",
           "group": "file_navigation2@1"
+        },
+        {
+          "command": "dspf-edit.add-display-size",
+          "when": "view == dspf-edit.schema-view && viewItem == file",
+          "group": "file_navigation2@2"
         },
         {
           "command": "dspf-edit.fill-constant",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"

--- a/src/dspf-edit.commands/dspf-edit.add-display-size.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-display-size.ts
@@ -1,0 +1,102 @@
+/*
+    Christian Larsen, 2026
+    "RPG structure"
+    dspf-edit.add-display-size.ts
+*/
+
+import * as vscode from 'vscode';
+import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
+import { getAvailableDisplayFormats } from '../dspf-edit.model/dspf-edit.model';
+import {
+    checkForEditorAndDocument, applyWorkspaceEdit,
+    DisplaySize, STANDARD_DISPLAY_SIZES, collectDspsizConfiguration, updateDspsizLines
+} from '../dspf-edit.utils/dspf-edit.helper';
+
+// COMMAND REGISTRATION
+
+/**
+ * Registers the "Add Display Size" command for DDS files. Lets the user add a second declared
+ * DSPSIZ display size (e.g. *DS4 27x132) to a file that currently declares zero or one. Existing
+ * records' size-bearing keywords (WINDOW, SFLPAG, SFLSIZ, ...) are left unconditioned — an
+ * unconditioned line already applies to every declared format, including the newly added one — so
+ * they keep working unchanged; use the preview to give any of them a size-specific value afterward.
+ * @param context - The VS Code extension context
+ */
+export function addDisplaySize(context: vscode.ExtensionContext): void {
+    context.subscriptions.push(
+        vscode.commands.registerCommand("dspf-edit.add-display-size", async (node: DdsNode) => {
+            await handleAddDisplaySizeCommand(node);
+        })
+    );
+};
+
+// COMMAND HANDLER
+
+/**
+ * Handles the "Add Display Size" command workflow: validates the file isn't already at the
+ * supported ceiling of two declared sizes, lets the user pick which standard size to add, and
+ * rewrites the file's DSPSIZ specification to declare both.
+ * @param node - The DDS node the command was invoked on (must be the file-level node)
+ */
+async function handleAddDisplaySizeCommand(node: DdsNode): Promise<void> {
+    try {
+        const { editor, document } = checkForEditorAndDocument();
+        if (!document || !editor) {
+            return;
+        };
+
+        if (node.ddsElement.kind !== 'file') {
+            vscode.window.showWarningMessage('Display sizes can only be added at file level.');
+            return;
+        };
+
+        const declaredFormats = getAvailableDisplayFormats();
+        if (declaredFormats.length >= STANDARD_DISPLAY_SIZES.length) {
+            vscode.window.showInformationMessage(
+                `This file already declares ${declaredFormats.length} display size(s) — the supported maximum. Removing a display size isn't supported yet.`
+            );
+            return;
+        };
+
+        const existingSizes: DisplaySize[] = declaredFormats.map(format =>
+            STANDARD_DISPLAY_SIZES.find(s => s.name === format.name)
+                ?? { rows: format.rows, cols: format.cols, name: format.name, description: format.name }
+        );
+
+        const config = await collectDspsizConfiguration(existingSizes);
+        if (!config) {
+            // User cancelled
+            return;
+        };
+
+        // "Add" semantics only — keeping every existing size selected is required (removing one is
+        // out of scope for now); picking no new size means there's nothing to do.
+        const existingNames = new Set(existingSizes.map(s => s.name));
+        const droppedExisting = existingSizes.filter(s => !config.sizes.some(picked => picked.name === s.name));
+        if (droppedExisting.length > 0) {
+            vscode.window.showWarningMessage(
+                'Removing an existing display size is not supported yet — keep the existing size(s) selected and add a new one.'
+            );
+            return;
+        };
+
+        const newlyAdded = config.sizes.filter(s => !existingNames.has(s.name));
+        if (newlyAdded.length === 0) {
+            vscode.window.showInformationMessage('No new display size selected — nothing changed.');
+            return;
+        };
+
+        if (!(await updateDspsizLines(editor, config.sizes))) {
+            return;
+        };
+
+        const addedText = newlyAdded.map(s => `${s.rows}x${s.cols} (${s.name})`).join(', ');
+        vscode.window.showInformationMessage(
+            `Added display size ${addedText}. Existing windows/subfiles now apply to it unchanged — adjust any of them per size from the preview if needed.`
+        );
+
+    } catch (error) {
+        console.error('Error adding display size:', error);
+        vscode.window.showErrorMessage('An error occurred while adding the display size.');
+    };
+};

--- a/src/dspf-edit.commands/dspf-edit.add-keys.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-keys.ts
@@ -229,8 +229,12 @@ function extractKeyCommandsFromAttributes(attributes: any[] | undefined): KeyCom
     (attributes ?? []).forEach(attr => {
         const attribute = attr.value;
 
-        // Match CA or CF commands: CA03(03 'End of program') or CF12(12 'Cancel')
-        const commandMatch = attribute ? attribute.match(/^(CA|CF)(\d{2})\(\d{2}\s+'([^']{1,25})'\)$/) : false;
+        // Match CA or CF commands: CA03(03 'End of program') or CF12(12 'Cancel'). The description
+        // is capped at 25 chars only when THIS tool creates one (see validateKeyCommandDescription)
+        // — DDS itself allows longer text (spilling onto a continuation line, which extractAttributes
+        // already reassembles into `attribute` before this regex runs), so reading must not re-impose
+        // that cap: a longer existing description would otherwise silently fail to match at all.
+        const commandMatch = attribute ? attribute.match(/^(CA|CF)(\d{2})\(\d{2}\s+'([^']*)'\)$/) : false;
         if (commandMatch) {
             keyCommands.push({
                 type: commandMatch[1] as 'CA' | 'CF',

--- a/src/dspf-edit.commands/dspf-edit.add-keys.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-keys.ts
@@ -71,21 +71,31 @@ async function handleAddKeyCommandCommand(node: DdsNode): Promise<void> {
         };
 
         let currentKeyCommands: KeyCommandWithIndicators[] = [];
+        // Key numbers already assigned "on the other side" (the file, when working on a record; every
+        // record, when working on the file) — a new key here can't reuse one of these, since a record's
+        // effective key set is the union of its own and the file's, and DDS won't compile the same key
+        // number assigned twice (whether as CA+CF or the same type repeated) within that effective set.
+        let crossLevelKeyNumbers: string[] = [];
 
         switch (node.ddsElement.kind) {
             case 'record':
                 // Get current key commands from the record
                 currentKeyCommands = getCurrentKeyCommandsForRecord(node.ddsElement);
+                crossLevelKeyNumbers = getCurrentKeyCommandsForFile().map(k => k.keyNumber);
                 break;
             case 'file':
                 // Get current key commands from the file
-                currentKeyCommands = getCurrentKeyCommandsForFile(node.ddsElement);
+                currentKeyCommands = getCurrentKeyCommandsForFile();
+                crossLevelKeyNumbers = getAllRecordKeyNumbers();
                 break;
         };
 
 
-        // Get available key numbers (excluding current ones)
-        let availableKeys = getAvailableKeyNumbers(currentKeyCommands.map(k => k.keyNumber));
+        // Get available key numbers (excluding current ones, and any already reserved on the other level)
+        let availableKeys = getAvailableKeyNumbers([
+            ...currentKeyCommands.map(k => k.keyNumber),
+            ...crossLevelKeyNumbers
+        ]);
 
         // Show current key commands if any exist
         if (currentKeyCommands.length > 0) {
@@ -132,8 +142,8 @@ async function handleAddKeyCommandCommand(node: DdsNode): Promise<void> {
                 if (!removed) {
                     return;
                 };
-                // Continue to add new key commands
-                availableKeys = getAvailableKeyNumbers([]);
+                // Continue to add new key commands — still excluding whatever's reserved on the other level
+                availableKeys = getAvailableKeyNumbers(crossLevelKeyNumbers);
 
             }
             // If "Add more key commands", continue with current logic
@@ -197,11 +207,26 @@ async function handleAddKeyCommandCommand(node: DdsNode): Promise<void> {
 function getCurrentKeyCommandsForRecord(element: any): KeyCommandWithIndicators[] {
     // Find the record in the fieldsPerRecords data
     const recordInfo = fieldsPerRecords.find(r => r.record === element.name);
-    if (!recordInfo || !recordInfo.attributes) return [];
+    return extractKeyCommandsFromAttributes(recordInfo?.attributes);
+};
 
+/**
+ * Extracts current key commands from a DDS file (file level).
+ * @returns Array of current key commands
+ */
+function getCurrentKeyCommandsForFile(): KeyCommandWithIndicators[] {
+    return extractKeyCommandsFromAttributes(attributesFileLevel);
+};
+
+/**
+ * Parses CAxx()/CFxx() key command lines out of an arbitrary attribute list (a record's own, or
+ * the file's). Shared by every "current key commands" lookup so they all agree on the same format.
+ * @param attributes - Attribute lines to scan (a record's own, or the file's)
+ */
+function extractKeyCommandsFromAttributes(attributes: any[] | undefined): KeyCommandWithIndicators[] {
     const keyCommands: KeyCommandWithIndicators[] = [];
 
-    recordInfo.attributes.forEach(attr => {
+    (attributes ?? []).forEach(attr => {
         const attribute = attr.value;
 
         // Match CA or CF commands: CA03(03 'End of program') or CF12(12 'Cancel')
@@ -220,33 +245,18 @@ function getCurrentKeyCommandsForRecord(element: any): KeyCommandWithIndicators[
 };
 
 /**
- * Extracts current key commands from a DDS file (file level).
- * @param element - The DDS file element
- * @returns Array of current key commands
+ * Collects every key number (01-24) already assigned to ANY record in the file, own attributes
+ * only — used when adding key commands at file level, since a new file-level CAxx/CFxx applies to
+ * every record format and would conflict with a key number any one of them already assigns itself,
+ * regardless of whether the types match (DDS doesn't compile a key number defined as both CA and
+ * CF for the same record's effective set — a record redeclaring the same type is just as useless).
  */
-function getCurrentKeyCommandsForFile(element: any): KeyCommandWithIndicators[] {
-    // Find the record in the fieldsPerRecords data
-    const fileInfo = attributesFileLevel;
-    if (!fileInfo) return [];
-
-    const keyCommands: KeyCommandWithIndicators[] = [];
-
-    fileInfo.forEach(attr => {
-        const attribute = attr.value;
-
-        // Match CA or CF commands: CA03(03 'End of program') or CF12(12 'Cancel')
-        const commandMatch = attribute ? attribute.match(/^(CA|CF)(\d{2})\(\d{2}\s+'([^']{1,25})'\)$/) : false;
-        if (commandMatch) {
-            keyCommands.push({
-                type: commandMatch[1] as 'CA' | 'CF',
-                keyNumber: commandMatch[2],
-                description: commandMatch[3],
-                indicators: []
-            });
-        };
+function getAllRecordKeyNumbers(): string[] {
+    const keyNumbers = new Set<string>();
+    fieldsPerRecords.forEach(record => {
+        extractKeyCommandsFromAttributes(record.attributes).forEach(cmd => keyNumbers.add(cmd.keyNumber));
     });
-
-    return keyCommands;
+    return [...keyNumbers];
 };
 
 /**

--- a/src/dspf-edit.commands/dspf-edit.change-position.ts
+++ b/src/dspf-edit.commands/dspf-edit.change-position.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { fileSizeAttributes } from '../dspf-edit.model/dspf-edit.model';
+import { fileSizeAttributes, getAvailableDisplayFormats } from '../dspf-edit.model/dspf-edit.model';
 import { checkForEditorAndDocument, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
@@ -25,6 +25,23 @@ interface ElementPosition {
 interface PositionValidation {
     isValid: boolean;
     errorMessage?: string;
+};
+
+/**
+ * Returns the row/column bounds a position must fit within. When the file declares more than one
+ * DSPSIZ display format, a position needs to be reachable regardless of which one is active, so the
+ * bound is the smallest declared screen — not just the first format's.
+ */
+function getPositionBounds(): { maxRow: number; maxCol: number } {
+    const declaredFormats = getAvailableDisplayFormats();
+    if (declaredFormats.length === 0) {
+        return { maxRow: fileSizeAttributes.maxRow1, maxCol: fileSizeAttributes.maxCol1 };
+    };
+
+    return {
+        maxRow: Math.min(...declaredFormats.map(f => f.rows)),
+        maxCol: Math.min(...declaredFormats.map(f => f.cols))
+    };
 };
 
 // COMMAND REGISTRATION
@@ -136,7 +153,7 @@ async function collectNewPosition(elementName: string, currentPosition: ElementP
 async function collectRowPosition(elementName: string, currentRow: number): Promise<number | null> {
     const rowInput = await vscode.window.showInputBox({
         title: `Change Position - Step 1/2: Row for ${elementName}`,
-        prompt: `Enter the new row position (1-${fileSizeAttributes.maxRow1})`,
+        prompt: `Enter the new row position (1-${getPositionBounds().maxRow})`,
         value: String(currentRow),
         placeHolder: String(currentRow),
         validateInput: (value: string) => validateRowPosition(value)
@@ -155,7 +172,7 @@ async function collectRowPosition(elementName: string, currentRow: number): Prom
 async function collectColumnPosition(elementName: string, currentColumn: number): Promise<number | null> {
     const columnInput = await vscode.window.showInputBox({
         title: `Change Position - Step 2/2: Column for ${elementName}`,
-        prompt: `Enter the new column position (1-${fileSizeAttributes.maxCol1})`,
+        prompt: `Enter the new column position (1-${getPositionBounds().maxCol})`,
         value: String(currentColumn),
         placeHolder: String(currentColumn),
         validateInput: (value: string) => validateColumnPosition(value)
@@ -173,7 +190,7 @@ async function collectColumnPosition(elementName: string, currentColumn: number)
  * @returns Error message or null if valid
  */
 function validateRowPosition(value: string): string | null {
-    const validation = validatePositionInput(value, 1, fileSizeAttributes.maxRow1, "Row");
+    const validation = validatePositionInput(value, 1, getPositionBounds().maxRow, "Row");
     return validation.isValid ? null : validation.errorMessage!;
 };
 
@@ -183,7 +200,7 @@ function validateRowPosition(value: string): string | null {
  * @returns Error message or null if valid
  */
 function validateColumnPosition(value: string): string | null {
-    const validation = validatePositionInput(value, 1, fileSizeAttributes.maxCol1, "Column");
+    const validation = validatePositionInput(value, 1, getPositionBounds().maxCol, "Column");
     return validation.isValid ? null : validation.errorMessage!;
 };
 
@@ -230,24 +247,25 @@ function validatePositionInput(value: string, min: number, max: number, fieldNam
  * @returns Validation result with error message if invalid
  */
 function validatePositionBounds(position: ElementPosition): PositionValidation {
+    const bounds = getPositionBounds();
     const rowValidation = validatePositionInput(
-        String(position.row), 
-        1, 
-        fileSizeAttributes.maxRow1, 
+        String(position.row),
+        1,
+        bounds.maxRow,
         "Row"
     );
-    
+
     if (!rowValidation.isValid) {
         return rowValidation;
     };
 
     const columnValidation = validatePositionInput(
-        String(position.column), 
-        1, 
-        fileSizeAttributes.maxCol1, 
+        String(position.column),
+        1,
+        bounds.maxCol,
         "Column"
     );
-    
+
     return columnValidation;
 };
 

--- a/src/dspf-edit.commands/dspf-edit.new-record.ts
+++ b/src/dspf-edit.commands/dspf-edit.new-record.ts
@@ -8,8 +8,8 @@ import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { recordExists, DspsizConfig,
     checkIfDspsizNeeded, collectDspsizConfiguration, generateDspsizLines,
-    checkForEditorAndDocument, applyWorkspaceEdit} from '../dspf-edit.utils/dspf-edit.helper';
-import { fileSizeAttributes } from '../dspf-edit.model/dspf-edit.model';
+    checkForEditorAndDocument, applyWorkspaceEdit, writeDisplayFormatCondition} from '../dspf-edit.utils/dspf-edit.helper';
+import { fileSizeAttributes, getAvailableDisplayFormats } from '../dspf-edit.model/dspf-edit.model';
 
 // INTERFACES AND TYPES
 
@@ -42,10 +42,21 @@ interface WindowDimensions {
 };
 
 /**
+ * A window's dimensions as they apply under one declared DSPSIZ display format. `format` is
+ * undefined when the file has at most one declared format (or the computed dimensions happen to be
+ * identical across every declared format) — in that case a single unconditioned WINDOW() line covers
+ * every format, matching pre-multi-size behavior exactly.
+ */
+interface FormatDimensions {
+    format?: string;
+    dimensions: WindowDimensions;
+};
+
+/**
  * Window configuration including title.
  */
 interface WindowConfig {
-    dimensions: WindowDimensions;
+    dimensionsByFormat: FormatDimensions[];
     title?: string;
 };
 
@@ -284,30 +295,39 @@ async function collectWindowConfiguration(): Promise<WindowConfig | null> {
     const position = await collectWindowPosition();
     if (!position) return null;
 
-    // Calculate actual dimensions based on size and position
-    const dimensions = calculateWindowDimensions(windowSize, position);
-    if (!dimensions) {
-        vscode.window.showErrorMessage("Cannot position window with these dimensions on the current screen size.");
+    // Calculate actual dimensions for every declared display size (DSPSIZ format); when the file
+    // declares more than one, the window keeps the same rows/cols in each but gets its own
+    // position, appropriate to that format's screen size.
+    const dimensionsByFormat = calculateWindowDimensionsForAllFormats(windowSize, position);
+    if (!dimensionsByFormat) {
+        vscode.window.showErrorMessage("Cannot position window with these dimensions on the current screen size(s).");
         return null;
     };
 
-    // Collect window title
-    const title = await collectWindowTitle(dimensions.numCols);
+    // Collect window title (width is the same across every format, since only position varies)
+    const title = await collectWindowTitle(dimensionsByFormat[0].dimensions.numCols);
     if (title === null) return null; // User cancelled
 
     return {
-        dimensions,
+        dimensionsByFormat,
         title: title || undefined
     };
 };
 
 /**
- * Collects window size (rows and columns).
+ * Collects window size (rows and columns). Bounded by the smallest declared display size (DSPSIZ
+ * format), when the file declares more than one, so the same rows/cols fit on every screen the
+ * window will need a line for.
  * @returns Window size or null if cancelled
  */
 async function collectWindowSize(): Promise<WindowSize | null> {
-    const maxRows = fileSizeAttributes.maxRow1 || 24;
-    const maxCols = fileSizeAttributes.maxCol1 || 80;
+    const declaredFormats = getAvailableDisplayFormats();
+    const maxRows = declaredFormats.length > 0
+        ? Math.min(...declaredFormats.map(f => f.rows))
+        : (fileSizeAttributes.maxRow1 || 24);
+    const maxCols = declaredFormats.length > 0
+        ? Math.min(...declaredFormats.map(f => f.cols))
+        : (fileSizeAttributes.maxCol1 || 80);
 
     const numRows = await vscode.window.showInputBox({
         title: 'Window Configuration - Size',
@@ -365,15 +385,15 @@ async function collectWindowPosition(): Promise<WindowPosition | null> {
 };
 
 /**
- * Calculates actual window dimensions based on size and position preferences.
+ * Calculates actual window dimensions based on size and position preferences, for a single screen
+ * size (rows/cols). Called once per declared display format by `calculateWindowDimensionsForAllFormats`.
  * @param size Window size requirements
  * @param position Positioning preference
+ * @param maxRows Screen rows to position within
+ * @param maxCols Screen columns to position within
  * @returns Calculated dimensions or null if invalid
  */
-function calculateWindowDimensions(size: WindowSize, position: WindowPosition): WindowDimensions | null {
-    const maxRows = fileSizeAttributes.maxRow1 || 24;
-    const maxCols = fileSizeAttributes.maxCol1 || 80;
-
+function calculateWindowDimensions(size: WindowSize, position: WindowPosition, maxRows: number, maxCols: number): WindowDimensions | null {
     // Validate that window fits on screen
     if (size.numRows > maxRows || size.numCols > maxCols) {
         return null;
@@ -416,6 +436,50 @@ function calculateWindowDimensions(size: WindowSize, position: WindowPosition): 
         numRows: size.numRows,
         numCols: size.numCols
     };
+};
+
+/**
+ * Calculates window dimensions for every display size (DSPSIZ format) the file declares — same
+ * rows/cols in each, position recalculated per format so the window is actually correctly placed
+ * (e.g. centered) on every screen it can appear on, not just the first. Falls back to a single,
+ * unconditioned entry when the file declares at most one format, or when the computed dimensions
+ * turn out identical across every declared format (e.g. TOP_LEFT positioning) — same source output
+ * as before multi-size support existed.
+ * @param size Window size requirements
+ * @param position Positioning preference
+ * @returns One entry per declared format (or a single unconditioned entry), or null if the window
+ * doesn't fit on at least one declared screen
+ */
+function calculateWindowDimensionsForAllFormats(size: WindowSize, position: WindowPosition): FormatDimensions[] | null {
+    const declaredFormats = getAvailableDisplayFormats();
+
+    if (declaredFormats.length <= 1) {
+        const maxRows = declaredFormats[0]?.rows ?? (fileSizeAttributes.maxRow1 || 24);
+        const maxCols = declaredFormats[0]?.cols ?? (fileSizeAttributes.maxCol1 || 80);
+        const dimensions = calculateWindowDimensions(size, position, maxRows, maxCols);
+        return dimensions ? [{ dimensions }] : null;
+    };
+
+    const perFormat: FormatDimensions[] = [];
+    for (const format of declaredFormats) {
+        const dimensions = calculateWindowDimensions(size, position, format.rows, format.cols);
+        if (!dimensions) {
+            return null;
+        };
+        perFormat.push({ format: format.name, dimensions });
+    };
+
+    // Collapse to a single unconditioned line when every format landed on the same geometry
+    // (e.g. TOP_LEFT is the same regardless of screen size) — avoids redundant identical lines.
+    const first = perFormat[0].dimensions;
+    const allIdentical = perFormat.every(f =>
+        f.dimensions.startRow === first.startRow &&
+        f.dimensions.startCol === first.startCol &&
+        f.dimensions.numRows === first.numRows &&
+        f.dimensions.numCols === first.numCols
+    );
+
+    return allIdentical ? [{ dimensions: first }] : perFormat;
 };
 
 /**
@@ -539,7 +603,7 @@ function generateRecordLines(config: NewRecordConfig): string[] {
     switch (config.type) {
         case 'WINDOW':
             if (config.windowConfig) {
-                lines.push(generateWindowLine(config.windowConfig.dimensions));
+                lines.push(...generateWindowLines(config.windowConfig.dimensionsByFormat));
                 if (config.windowConfig.title) {
                     lines.push(...generateWindowTitleLines(config.windowConfig.title));
                 }
@@ -559,7 +623,7 @@ function generateRecordLines(config: NewRecordConfig): string[] {
         case 'SFLWDW':
             if (config.subfileConfig && config.windowConfig) {
                 lines.push(generateSubfileControlLine(config.name, config.subfileConfig));
-                lines.push(generateWindowLine(config.windowConfig.dimensions));
+                lines.push(...generateWindowLines(config.windowConfig.dimensionsByFormat));
                 if (config.windowConfig.title) {
                     lines.push(...generateWindowTitleLines(config.windowConfig.title));
                 }
@@ -591,16 +655,21 @@ function generateMainRecordLine(config: NewRecordConfig): string {
 };
 
 /**
- * Generates a window specification line.
- * @param dimensions - Window dimensions
- * @returns Formatted window line
+ * Generates one WINDOW() specification line per entry — one per declared display format when the
+ * file declares more than one (see `calculateWindowDimensionsForAllFormats`), each conditioned on
+ * its format name, or a single unconditioned line otherwise (unchanged pre-multi-size output).
+ * @param dimensionsByFormat - Window dimensions, one entry per format (or a single entry)
+ * @returns Formatted WINDOW() lines
  */
-function generateWindowLine(dimensions: WindowDimensions): string {
-    return ' '.repeat(5) + 'A' + ' '.repeat(38) + 'WINDOW(' + 
-           dimensions.startRow + ' ' + 
-           dimensions.startCol + ' ' + 
-           dimensions.numRows + ' ' + 
-           dimensions.numCols + ')';
+function generateWindowLines(dimensionsByFormat: FormatDimensions[]): string[] {
+    return dimensionsByFormat.map(({ format, dimensions }) => {
+        const line = ' '.repeat(5) + 'A' + ' '.repeat(38) + 'WINDOW(' +
+            dimensions.startRow + ' ' +
+            dimensions.startCol + ' ' +
+            dimensions.numRows + ' ' +
+            dimensions.numCols + ')';
+        return writeDisplayFormatCondition(line, format);
+    });
 };
 
 /**

--- a/src/dspf-edit.commands/dspf-edit.window-resize.ts
+++ b/src/dspf-edit.commands/dspf-edit.window-resize.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { fileSizeAttributes, fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
+import { fileSizeAttributes, fieldsPerRecords, getAvailableDisplayFormats, getSizeForFormat } from '../dspf-edit.model/dspf-edit.model';
 import { checkForEditorAndDocument, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
@@ -22,7 +22,7 @@ type WindowPosition = 'CENTERED' | 'BOTTOM_CENTERED';
 type ResizeOperation = 'CHANGE_SIZE' | 'AUTO_ADJUST';
 
 /**
- * Current window dimensions from WINDOW keyword.
+ * Current window dimensions from a WINDOW keyword.
  */
 interface CurrentWindowDimensions {
     startRow: number;
@@ -30,6 +30,9 @@ interface CurrentWindowDimensions {
     numRows: number;
     numCols: number;
     windowLine : number;
+    /** Display format (e.g. "*DS3") this line is conditioned on, or undefined if unconditioned
+     * (applies to every declared format). */
+    format?: string;
 };
 
 /**
@@ -77,7 +80,11 @@ export function windowResize(context: vscode.ExtensionContext): void {
 
 /**
  * Handles the window resize command workflow.
- * Validates that the record has WINDOW keyword and provides resize options.
+ * Validates that the record has WINDOW keyword and provides resize options. When the record has more
+ * than one WINDOW() line (one per declared DSPSIZ display format), all of them are resized together:
+ * the user picks one size/position preference, and it's applied to every declared format, each
+ * repositioned according to its own screen size — mirroring how a new window is created (see
+ * `dspf-edit.new-record.ts`'s `calculateWindowDimensionsForAllFormats`).
  * @param node - The DDS node containing the window record
  */
 async function handleWindowResizeCommand(node: DdsNode): Promise<void> {
@@ -87,7 +94,7 @@ async function handleWindowResizeCommand(node: DdsNode): Promise<void> {
         if (!document || !editor) {
             return;
         };
-        
+
         const element = node.ddsElement;
 
         // Validate element type - only records can have windows
@@ -96,16 +103,17 @@ async function handleWindowResizeCommand(node: DdsNode): Promise<void> {
             return;
         };
 
-        // Check if record has WINDOW keyword
-        const currentWindow = findCurrentWindowDimensions(editor, element);
-        if (!currentWindow) {
+        // Check if record has one or more WINDOW keyword lines (one per declared display format)
+        const currentWindows = findCurrentWindowDimensions(editor, element);
+        if (currentWindows.length === 0) {
             vscode.window.showWarningMessage(`Record '${element.name}' does not have a WINDOW keyword.`);
             return;
         };
 
         // Show current window information
-        const currentInfo = `Current: ${currentWindow.numRows}x${currentWindow.numCols} at (${currentWindow.startRow},${currentWindow.startCol})`;
-        const windowLine = currentWindow.windowLine;
+        const currentInfo = currentWindows.length === 1
+            ? `Current: ${currentWindows[0].numRows}x${currentWindows[0].numCols} at (${currentWindows[0].startRow},${currentWindows[0].startCol})`
+            : `Current: ${currentWindows[0].numRows}x${currentWindows[0].numCols} (${currentWindows.length} display sizes declared)`;
 
         // Collect resize configuration from user
         const resizeConfig = await collectWindowResizeConfiguration(currentInfo, element);
@@ -114,15 +122,20 @@ async function handleWindowResizeCommand(node: DdsNode): Promise<void> {
             return;
         };
 
-        // Calculate new dimensions based on operation
-        const newDimensions = await calculateNewDimensions(resizeConfig, currentWindow, editor, element);
-        if (!newDimensions) {
-            vscode.window.showErrorMessage("Unable to calculate new window dimensions.");
-            return;
+        // Calculate new dimensions for every existing WINDOW line, each positioned according to its
+        // own declared format's screen size (or the file default, when unconditioned).
+        const newDimensionsList: CurrentWindowDimensions[] = [];
+        for (const currentWindow of currentWindows) {
+            const newDimensions = await calculateNewDimensionsForWindow(resizeConfig, currentWindow, editor, element);
+            if (!newDimensions) {
+                vscode.window.showErrorMessage("Unable to calculate new window dimensions.");
+                return;
+            };
+            newDimensionsList.push(newDimensions);
         };
 
         // Apply the window resize
-        if (!(await applyWindowResize(editor, element, windowLine, newDimensions))) {
+        if (!(await applyWindowResize(editor, newDimensionsList))) {
             return;
         };
         await vscode.commands.executeCommand('cursorRight');
@@ -130,8 +143,11 @@ async function handleWindowResizeCommand(node: DdsNode): Promise<void> {
 
         // Show success message
         const operationLabel = resizeConfig.operation === 'CHANGE_SIZE' ? 'resized' : 'auto-adjusted';
+        const dimensionsSummary = newDimensionsList.length === 1
+            ? `${newDimensionsList[0].numRows}x${newDimensionsList[0].numCols} at (${newDimensionsList[0].startRow},${newDimensionsList[0].startCol})`
+            : newDimensionsList.map(d => `${d.format ?? 'default'}: ${d.numRows}x${d.numCols} at (${d.startRow},${d.startCol})`).join(', ');
         vscode.window.showInformationMessage(
-            `Successfully ${operationLabel} window '${element.name}' to ${newDimensions.numRows}x${newDimensions.numCols} at (${newDimensions.startRow},${newDimensions.startCol}).`
+            `Successfully ${operationLabel} window '${element.name}' — ${dimensionsSummary}.`
         );
 
     } catch (error) {
@@ -190,13 +206,13 @@ async function collectWindowResizeConfiguration(currentInfo: string, element: an
  */
 async function collectResizeOperation(currentInfo: string): Promise<ResizeOperation | null> {
     const operationOptions: vscode.QuickPickItem[] = [
-        { 
-            label: "CHANGE_SIZE", 
+        {
+            label: "CHANGE_SIZE",
             description: "Specify new window size",
             detail: "Enter custom width and height for the window"
         },
-        { 
-            label: "AUTO_ADJUST", 
+        {
+            label: "AUTO_ADJUST",
             description: "Auto-adjust to fit content",
             detail: "Calculate optimal size based on fields and constants"
         }
@@ -213,12 +229,19 @@ async function collectResizeOperation(currentInfo: string): Promise<ResizeOperat
 };
 
 /**
- * Collects new window size when changing size manually.
+ * Collects new window size when changing size manually. Bounded by the smallest declared display
+ * size (DSPSIZ format), when the file declares more than one, so the same rows/cols fit on every
+ * screen a WINDOW() line will be written for.
  * @returns New window size or null if cancelled
  */
 async function collectNewWindowSize(): Promise<{ numRows: number; numCols: number } | null> {
-    const maxRows = fileSizeAttributes.maxRow1 || 24;
-    const maxCols = fileSizeAttributes.maxCol1 || 80;
+    const declaredFormats = getAvailableDisplayFormats();
+    const maxRows = declaredFormats.length > 0
+        ? Math.min(...declaredFormats.map(f => f.rows))
+        : (fileSizeAttributes.maxRow1 || 24);
+    const maxCols = declaredFormats.length > 0
+        ? Math.min(...declaredFormats.map(f => f.cols))
+        : (fileSizeAttributes.maxCol1 || 80);
 
     const numRows = await vscode.window.showInputBox({
         title: 'Window Resize - New Size',
@@ -231,7 +254,7 @@ async function collectNewWindowSize(): Promise<{ numRows: number; numCols: numbe
     const numCols = await vscode.window.showInputBox({
         title: 'Window Resize - New Size',
         prompt: `Enter number of columns (1-${maxCols})`,
-        placeHolder: "50", 
+        placeHolder: "50",
         validateInput: (value) => validateNumericRange(value, 1, maxCols, "Number of columns")
     });
     if (!numCols) return null;
@@ -248,13 +271,13 @@ async function collectNewWindowSize(): Promise<{ numRows: number; numCols: numbe
  */
 async function collectWindowPosition(): Promise<WindowPosition | null> {
     const positionOptions: vscode.QuickPickItem[] = [
-        { 
-            label: "CENTERED", 
+        {
+            label: "CENTERED",
             description: "Center the window on screen",
             detail: "Window will be positioned in the center of the display"
         },
-        { 
-            label: "BOTTOM_CENTERED", 
+        {
+            label: "BOTTOM_CENTERED",
             description: "Center horizontally, position at bottom",
             detail: "Window will be centered horizontally and positioned at the bottom"
         }
@@ -273,39 +296,62 @@ async function collectWindowPosition(): Promise<WindowPosition | null> {
 // WINDOW ANALYSIS FUNCTIONS
 
 /**
- * Finds current window dimensions from WINDOW keyword in the record.
+ * Resolves the screen bounds (rows/cols) a WINDOW() line should be positioned within: the declared
+ * display format's own size when the line is conditioned on one, else the file's default size.
+ * @param format - Display format name (e.g. "*DS3") the line is conditioned on, or undefined
+ */
+function getScreenBoundsForFormat(format?: string): { maxRows: number; maxCols: number } {
+    if (format) {
+        const size = getSizeForFormat(format);
+        if (size) {
+            return { maxRows: size.rows, maxCols: size.cols };
+        };
+    };
+
+    return {
+        maxRows: fileSizeAttributes.maxRow1 || 24,
+        maxCols: fileSizeAttributes.maxCol1 || 80
+    };
+};
+
+/**
+ * Finds current window dimensions from every WINDOW keyword line in the record — normally one, but
+ * two when the file declares more than one DSPSIZ display format and the window was created/split
+ * per-format (see `dspf-edit.new-record.ts` and the preview's split-on-edit logic).
  * @param editor - The text editor
  * @param element - The record element
- * @returns Current window dimensions or null if not found
+ * @returns Current window dimensions for each WINDOW() line found, in source order
  */
-function findCurrentWindowDimensions(editor: vscode.TextEditor, element: any): CurrentWindowDimensions | null {
-    const currentRecord = fieldsPerRecords.find(record => 
+function findCurrentWindowDimensions(editor: vscode.TextEditor, element: any): CurrentWindowDimensions[] {
+    const currentRecord = fieldsPerRecords.find(record =>
         element.lineIndex >= record.startIndex && element.lineIndex <= record.endIndex
     );
-    
+
     if (!currentRecord?.attributes) {
-        return null;
+        return [];
     }
 
-    const windowAttribute = currentRecord.attributes.find(attr => 
+    const windowAttributes = currentRecord.attributes.filter(attr =>
         attr.value.startsWith('WINDOW(')
     );
 
-    if (windowAttribute) {
+    const results: CurrentWindowDimensions[] = [];
+    for (const windowAttribute of windowAttributes) {
         // WINDOW(startRow startCol numRows numCols)
         const match = windowAttribute.value.match(/WINDOW\((\d+) (\d+) (\d+) (\d+)(?: [^)]*)?\)/);
         if (match) {
-            return {
+            results.push({
                 startRow: parseInt(match[1]),
                 startCol: parseInt(match[2]),
                 numRows: parseInt(match[3]),
                 numCols: parseInt(match[4]),
-                windowLine : windowAttribute.lineIndex
-            };
+                windowLine: windowAttribute.lineIndex,
+                format: windowAttribute.displayFormat
+            });
         };
     };
 
-    return null;
+    return results;
 };
 
 /**
@@ -322,18 +368,20 @@ function isNextRecord(lineText: string): boolean {
  * Analyzes fields and constants in the record to determine optimal window size.
  * @param editor - The text editor
  * @param element - The record element
+ * @param maxRows - Screen rows to clamp the result within
+ * @param maxCols - Screen columns to clamp the result within
  * @returns Optimal dimensions based on content
  */
-function analyzeRecordContent(editor: vscode.TextEditor, element: any): { numRows: number; numCols: number } {
+function analyzeRecordContent(editor: vscode.TextEditor, element: any, maxRows: number, maxCols: number): { numRows: number; numCols: number } {
     const positions: FieldPosition[] = [];
-    
+
     // Get field and constant positions from the model
     const recordInfo = fieldsPerRecords.find(r => r.record === element.name);
     if (!recordInfo) {
         // If no record info found, return minimum dimensions
         return {
-            numRows: Math.min(5, (fileSizeAttributes.maxRow1 || 24) - 2),
-            numCols: Math.min(20, (fileSizeAttributes.maxCol1 || 80) - 2)
+            numRows: Math.min(5, maxRows - 2),
+            numCols: Math.min(20, maxCols - 2)
         };
     };
 
@@ -366,8 +414,8 @@ function analyzeRecordContent(editor: vscode.TextEditor, element: any): { numRow
     // If no positions found, return minimum dimensions
     if (positions.length === 0) {
         return {
-            numRows: Math.min(5, (fileSizeAttributes.maxRow1 || 24) - 2),
-            numCols: Math.min(20, (fileSizeAttributes.maxCol1 || 80) - 2)
+            numRows: Math.min(5, maxRows - 2),
+            numCols: Math.min(20, maxCols - 2)
         };
     };
 
@@ -385,9 +433,6 @@ function analyzeRecordContent(editor: vscode.TextEditor, element: any): { numRow
     const numCols = Math.max(20, maxCol + 4);       // Minimum 20 columns, +4 for padding
 
     // Ensure we don't exceed screen limits
-    const maxRows = fileSizeAttributes.maxRow1 || 24;
-    const maxCols = fileSizeAttributes.maxCol1 || 80;
-
     return {
         numRows: Math.min(numRows, maxRows - 2), // Leave space for positioning
         numCols: Math.min(numCols, maxCols - 2)
@@ -397,19 +442,21 @@ function analyzeRecordContent(editor: vscode.TextEditor, element: any): { numRow
 // DIMENSION CALCULATION FUNCTIONS
 
 /**
- * Calculates new window dimensions based on resize configuration.
+ * Calculates new dimensions for a single existing WINDOW() line, positioned within its own declared
+ * format's screen bounds (or the file default, when unconditioned).
  * @param config - The resize configuration
- * @param currentWindow - Current window dimensions
+ * @param currentWindow - The existing WINDOW() line being resized
  * @param editor - The text editor
  * @param element - The record element
- * @returns New window dimensions or null if invalid
+ * @returns New window dimensions (carrying the same line/format as `currentWindow`) or null if invalid
  */
-async function calculateNewDimensions(
-    config: WindowResizeConfig, 
+async function calculateNewDimensionsForWindow(
+    config: WindowResizeConfig,
     currentWindow: CurrentWindowDimensions,
     editor: vscode.TextEditor,
     element: any
 ): Promise<CurrentWindowDimensions | null> {
+    const { maxRows, maxCols } = getScreenBoundsForFormat(currentWindow.format);
     let targetSize: { numRows: number; numCols: number };
 
     if (config.operation === 'CHANGE_SIZE' && config.newDimensions) {
@@ -418,32 +465,42 @@ async function calculateNewDimensions(
             numCols: config.newDimensions.numCols
         };
     } else if (config.operation === 'AUTO_ADJUST' && config.autoAdjustConfig) {
-        targetSize = analyzeRecordContent(editor, element);
+        targetSize = analyzeRecordContent(editor, element, maxRows, maxCols);
     } else {
         return null;
     };
 
     // Calculate new position based on size and position preference
-    const position = config.operation === 'CHANGE_SIZE' 
-        ? config.newDimensions!.position 
+    const position = config.operation === 'CHANGE_SIZE'
+        ? config.newDimensions!.position
         : config.autoAdjustConfig!.position;
 
-    return calculateWindowPosition(targetSize, position);
+    const positioned = calculateWindowPosition(targetSize, position, maxRows, maxCols);
+    if (!positioned) {
+        return null;
+    };
+
+    return {
+        ...positioned,
+        windowLine: currentWindow.windowLine,
+        format: currentWindow.format
+    };
 };
 
 /**
- * Calculates window position based on size and position preference.
+ * Calculates window position based on size and position preference, within the given screen bounds.
  * @param size - Target window size
  * @param position - Position preference
+ * @param maxRows - Screen rows to position within
+ * @param maxCols - Screen columns to position within
  * @returns Calculated window dimensions or null if invalid
  */
 function calculateWindowPosition(
-    size: { numRows: number; numCols: number }, 
-    position: WindowPosition
+    size: { numRows: number; numCols: number },
+    position: WindowPosition,
+    maxRows: number,
+    maxCols: number
 ): CurrentWindowDimensions | null {
-    const maxRows = fileSizeAttributes.maxRow1 || 24;
-    const maxCols = fileSizeAttributes.maxCol1 || 80;
-
     // Validate that window fits on screen
     if (size.numRows > maxRows || size.numCols > maxCols) {
         return null;
@@ -469,8 +526,8 @@ function calculateWindowPosition(
     };
 
     // Final validation - ensure window doesn't go off screen
-    if (startRow < 1 || startCol < 1 || 
-        startRow + size.numRows - 1 > maxRows || 
+    if (startRow < 1 || startCol < 1 ||
+        startRow + size.numRows - 1 > maxRows ||
         startCol + size.numCols - 1 > maxCols) {
         return null;
     };
@@ -487,66 +544,32 @@ function calculateWindowPosition(
 // WINDOW UPDATE FUNCTIONS
 
 /**
- * Applies the window resize by updating the WINDOW keyword line.
+ * Applies the window resize by updating every WINDOW() line's keyword parameters, one edit per
+ * line, applied together as a single workspace edit.
  * @param editor - The text editor
- * @param element - The record element
- * @param windowLine - Window line
- * @param newDimensions - New window dimensions
+ * @param newDimensionsList - New dimensions for each existing WINDOW() line (same order/count as
+ * the `currentWindows` they were computed from)
  */
 async function applyWindowResize(
     editor: vscode.TextEditor,
-    element: any,
-    windowLine : number,
-    newDimensions: CurrentWindowDimensions
+    newDimensionsList: CurrentWindowDimensions[]
 ): Promise<boolean> {
-
-/*    const windowLine = findWindowKeywordLine(editor, element);
-    if (windowLine === -1) {
-        throw new Error('Could not find WINDOW keyword line to update');
-    };
-*/
     const workspaceEdit = new vscode.WorkspaceEdit();
     const uri = editor.document.uri;
-    const line = editor.document.lineAt(windowLine);
-    const lineText = line.text;
 
     // Replace the WINDOW keyword parameters, preserving any trailing suffix (e.g. *NOMSGLIN)
     const oldWindowPattern = /WINDOW\(\d+\s+\d+\s+\d+\s+\d+(\s+[^)]*)?\)/;
 
-    const updatedLine = lineText.replace(
-        oldWindowPattern,
-        (_match, suffix) => `WINDOW(${newDimensions.startRow} ${newDimensions.startCol} ${newDimensions.numRows} ${newDimensions.numCols}${suffix ?? ''})`
-    );
-    workspaceEdit.replace(uri, line.range, updatedLine);
-
-    return applyWorkspaceEdit(workspaceEdit, 'resize the window');
-};
-
-/**
- * Finds the line number containing the WINDOW keyword for the record.
- * @param editor - The text editor
- * @param element - The record element
- * @returns Line number or -1 if not found
- */
-function findWindowKeywordLine(editor: vscode.TextEditor, element: any): number {
-    const startLine = element.lineIndex;
-
-    // Search for WINDOW keyword in record and its attribute lines
-    for (let i = startLine; i < editor.document.lineCount; i++) {
-        const lineText = editor.document.lineAt(i).text;
-
-        // Stop searching when we reach the next record or non-attribute line
-        if (i > startLine && (!lineText.trim().startsWith('A ') || isNextRecord(lineText))) {
-            break;
-        };
-
-        // Look for WINDOW keyword
-        if (lineText.includes('WINDOW(')) {
-            return i;
-        };
+    for (const newDimensions of newDimensionsList) {
+        const line = editor.document.lineAt(newDimensions.windowLine);
+        const updatedLine = line.text.replace(
+            oldWindowPattern,
+            (_match, suffix) => `WINDOW(${newDimensions.startRow} ${newDimensions.startCol} ${newDimensions.numRows} ${newDimensions.numCols}${suffix ?? ''})`
+        );
+        workspaceEdit.replace(uri, line.range, updatedLine);
     };
 
-    return -1;
+    return applyWorkspaceEdit(workspaceEdit, 'resize the window');
 };
 
 // VALIDATION HELPER FUNCTIONS

--- a/src/dspf-edit.commands/dspf-edit.window-title.ts
+++ b/src/dspf-edit.commands/dspf-edit.window-title.ts
@@ -6,8 +6,9 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { FieldsPerRecord, fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { checkForEditorAndDocument, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
+import { DdsAttribute, FieldsPerRecord, fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
+import { checkForEditorAndDocument, applyWorkspaceEdit, writeDisplayFormatCondition } from '../dspf-edit.utils/dspf-edit.helper';
+import { pickForActiveFormat } from '../dspf-edit.parser/dspf-edit.parser';
 import { generateWindowTitleLines } from './dspf-edit.new-record';
 
 type TitleAlign = 'LEFT' | 'CENTER' | 'RIGHT';
@@ -59,8 +60,10 @@ async function handleWindowTitleCommand(node: DdsNode): Promise<void> {
  * WDWTITLE() keyword for the given window record. Shared by the tree context-menu command and by
  * clicking the title directly in the record preview.
  * @param recordName - Name of the window record to edit the title for
+ * @param activeFormat - Display format (e.g. "*DS3") currently being previewed, when called from the
+ * preview panel; undefined when called from the tree, which has no notion of an "active" format.
  */
-export async function editWindowTitleForRecord(recordName: string): Promise<void> {
+export async function editWindowTitleForRecord(recordName: string, activeFormat?: string): Promise<void> {
     try {
         const { editor } = checkForEditorAndDocument();
         if (!editor) {
@@ -68,11 +71,23 @@ export async function editWindowTitleForRecord(recordName: string): Promise<void
         };
 
         const record = fieldsPerRecords.find(r => r.record === recordName);
-        const windowAttr = record?.attributes?.find(a => a.value.toUpperCase().startsWith('WINDOW('));
-        if (!record || !windowAttr) {
+        const windowCandidates = (record?.attributes ?? []).filter(a => a.value.toUpperCase().startsWith('WINDOW('));
+        if (!record || windowCandidates.length === 0) {
             vscode.window.showWarningMessage(`Record '${recordName}' does not have a WINDOW keyword.`);
             return;
         };
+
+        // The tree has no "active format" of its own — if the record declares a separate window per
+        // display size (one WINDOW() line per format), ask which one this title edit targets.
+        if (!activeFormat && windowCandidates.length > 1) {
+            const picked = await pickTargetFormat(windowCandidates);
+            if (!picked) {
+                return;
+            };
+            activeFormat = picked.format;
+        };
+
+        const windowAttr = pickForActiveFormat(windowCandidates, activeFormat)!;
 
         const windowMatch = windowAttr.value.match(/WINDOW\s*\(\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+)(?:\s+[^)]*)?\s*\)/i);
         if (!windowMatch) {
@@ -83,7 +98,7 @@ export async function editWindowTitleForRecord(recordName: string): Promise<void
         };
         const windowWidth = parseInt(windowMatch[4], 10);
 
-        const existing = findExistingWindowTitle(record);
+        const existing = findExistingWindowTitle(record, activeFormat);
 
         const text = await collectTitleText(existing?.text, windowWidth);
         if (text === null) {
@@ -112,8 +127,13 @@ export async function editWindowTitleForRecord(recordName: string): Promise<void
             return;
         };
 
+        // A brand-new title (no existing WDWTITLE() line yet) only needs to be conditioned on the
+        // active format when this record actually has more than one declared format's window — a
+        // single declared format (or none) means "applies everywhere" already, unconditioned.
+        const conditionFormat = !existing && windowCandidates.length > 1 ? activeFormat : undefined;
+
         const anchorLineIndex = windowAttr.lastLineIndex ?? windowAttr.lineIndex;
-        if (!(await applyWindowTitle(editor, anchorLineIndex, existing, text, align, position))) {
+        if (!(await applyWindowTitle(editor, anchorLineIndex, existing, text, align, position, conditionFormat))) {
             return;
         };
 
@@ -128,14 +148,40 @@ export async function editWindowTitleForRecord(recordName: string): Promise<void
     };
 };
 
+/**
+ * Asks the user which declared display format's window a title edit should target, when the record
+ * has more than one WINDOW() line and the caller (the tree) has no implicit "active format" to go by.
+ * @param windowCandidates - The record's WINDOW() attribute lines, one per declared format
+ * @returns The chosen format (undefined means the unconditioned/shared line), or null if cancelled
+ */
+async function pickTargetFormat(windowCandidates: DdsAttribute[]): Promise<{ format?: string } | null> {
+    const options: (vscode.QuickPickItem & { format?: string })[] = windowCandidates.map(c => ({
+        label: c.displayFormat ?? 'All sizes (unconditioned)',
+        format: c.displayFormat
+    }));
+
+    const selection = await vscode.window.showQuickPick(options, {
+        title: 'Change Window Title - Select Display Size',
+        placeHolder: 'This record has a separate window per display size — choose which one to edit',
+        ignoreFocusOut: true
+    });
+
+    return selection ? { format: selection.format } : null;
+};
+
 // EXISTING TITLE LOOKUP
 
 /**
- * Finds and parses the record's WDWTITLE() keyword, if any.
+ * Finds and parses the record's WDWTITLE() keyword for the given display format, if any — the one
+ * explicitly conditioned on `activeFormat`, else the shared unconditioned one, else the first
+ * candidate (see `pickForActiveFormat`).
  * @param record - The record's field/attribute info
+ * @param activeFormat - Display format (e.g. "*DS3") to prefer, when the record has more than one
+ * WDWTITLE() line (one per format)
  */
-function findExistingWindowTitle(record: FieldsPerRecord): ExistingWindowTitle | undefined {
-    const attr = record.attributes?.find(a => a.value.toUpperCase().startsWith('WDWTITLE('));
+function findExistingWindowTitle(record: FieldsPerRecord, activeFormat?: string): ExistingWindowTitle | undefined {
+    const candidates = record.attributes?.filter(a => a.value.toUpperCase().startsWith('WDWTITLE(')) ?? [];
+    const attr = pickForActiveFormat(candidates, activeFormat);
     if (!attr) {
         return undefined;
     };
@@ -252,6 +298,8 @@ async function collectTitlePosition(current: TitlePosition | undefined): Promise
  * @param text - The new title text
  * @param align - The new horizontal alignment
  * @param position - The new vertical position
+ * @param conditionFormat - Display format to condition a brand-new title line on (only used when
+ * `existing` is undefined); undefined leaves it unconditioned, applying to every declared format
  */
 async function applyWindowTitle(
     editor: vscode.TextEditor,
@@ -259,7 +307,8 @@ async function applyWindowTitle(
     existing: ExistingWindowTitle | undefined,
     text: string,
     align: TitleAlign,
-    position: TitlePosition
+    position: TitlePosition,
+    conditionFormat?: string
 ): Promise<boolean> {
     const lines = generateWindowTitleLines(text, align, position);
     const workspaceEdit = new vscode.WorkspaceEdit();
@@ -272,6 +321,9 @@ async function applyWindowTitle(
         );
         workspaceEdit.replace(uri, range, lines.join('\n'));
     } else {
+        if (conditionFormat && lines.length > 0) {
+            lines[0] = writeDisplayFormatCondition(lines[0], conditionFormat);
+        };
         const insertPosition = new vscode.Position(anchorLineIndex + 1, 0);
         workspaceEdit.insert(uri, insertPosition, lines.join('\n') + '\n');
     };

--- a/src/dspf-edit.commands/register-commands.ts
+++ b/src/dspf-edit.commands/register-commands.ts
@@ -15,6 +15,7 @@ import { viewStructure } from './dspf-edit.view-structure';
 import { copyRecord } from './dspf-edit.copy-record';
 import { deleteRecord } from './dspf-edit.delete-record';
 import { newRecord } from './dspf-edit.new-record';
+import { addDisplaySize } from './dspf-edit.add-display-size';
 import { goToLineHandler } from './dspf-edit.goto-line';
 import { addButtons } from './dspf-edit.add-buttons';
 import { addCommandsRecord } from './dspf-edit.add-commands-record';
@@ -50,6 +51,7 @@ export const commands = [
     { name: 'copyRecord', handler: copyRecord, needsTreeProvider: false },
     { name: 'deleteRecord', handler: deleteRecord, needsTreeProvider: false },
     { name: 'newRecord', handler: newRecord, needsTreeProvider: false },
+    { name: 'addDisplaySize', handler: addDisplaySize, needsTreeProvider: false },
     { name: 'goToLine', handler: goToLineHandler, needsTreeProvider: false },
     { name: 'addButtons', handler: addButtons, needsTreeProvider: false },
     { name: 'addCommandsRecord', handler: addCommandsRecord, needsTreeProvider: false },

--- a/src/dspf-edit.parser/dspf-edit.parser.ts
+++ b/src/dspf-edit.parser/dspf-edit.parser.ts
@@ -1213,6 +1213,40 @@ export function resolveRecordSizeForFormat(recordName: string, activeFormat: str
 };
 
 /**
+ * Filters out attributes/fields/constants conditioned by a display format other than the active
+ * one; unconditioned ones (and everything, when no format is active) always pass through.
+ * @param items - Items carrying an optional displayFormat condition
+ * @param activeFormat - Currently selected display format name (e.g. "*DS3"), or undefined
+ */
+export function filterForActiveFormat<T extends { displayFormat?: string }>(items: T[], activeFormat: string | undefined): T[] {
+    if (!activeFormat) {
+        return items;
+    };
+    return items.filter(item => !item.displayFormat || item.displayFormat === activeFormat);
+};
+
+/**
+ * Picks which of several same-keyword candidates applies, when a record/field/constant is
+ * conditioned by more than one display format (one line per format, e.g. WDWTITLE or SFLPAG
+ * declared once for *DS3 and once for *DS4). Prefers the one matching activeFormat, falling back
+ * to an unconditioned one, then to the first candidate — so behavior is unchanged when no format
+ * is active.
+ * @param candidates - Same-keyword attribute candidates, in source order
+ * @param activeFormat - Currently selected display format name (e.g. "*DS3"), or undefined
+ */
+export function pickForActiveFormat<T extends { displayFormat?: string }>(candidates: T[], activeFormat?: string): T | undefined {
+    if (candidates.length === 0) {
+        return undefined;
+    };
+    if (!activeFormat) {
+        return candidates[0];
+    };
+    return candidates.find(c => c.displayFormat === activeFormat)
+        ?? candidates.find(c => !c.displayFormat)
+        ?? candidates[0];
+};
+
+/**
  * Shares a window's size across an SFL/SFLCTL pair when only one side declares WINDOW(): the
  * subfile detail (SFL) record and its control (SFLCTL) record occupy the exact same screen area,
  * but the WINDOW() keyword (direct or shared-reference) commonly sits on just one of them.

--- a/src/dspf-edit.utils/dspf-edit.helper.ts
+++ b/src/dspf-edit.utils/dspf-edit.helper.ts
@@ -7,9 +7,9 @@
 
 import * as vscode from 'vscode';
 import * as fs from 'fs';
-import { DdsElement, DdsIndicator, DdsAttribute, records, FieldsPerRecord, ConstantInfo, FieldInfo, fieldsPerRecords, groupIndicatorsByCondition } from '../dspf-edit.model/dspf-edit.model';
+import { DdsElement, DdsIndicator, DdsAttribute, records, FieldsPerRecord, ConstantInfo, FieldInfo, fieldsPerRecords, attributesFileLevel, groupIndicatorsByCondition } from '../dspf-edit.model/dspf-edit.model';
 import { DdsTreeProvider } from '../dspf-edit.providers/dspf-edit.providers';
-import { parseDocument } from '../dspf-edit.parser/dspf-edit.parser';
+import { parseDocument, pickForActiveFormat } from '../dspf-edit.parser/dspf-edit.parser';
 import { ExtensionState } from '../dspf-edit.states/state';
 import { getResolvedRef } from '../dspf-edit.ibmi/dspf-edit.ibmi-integration';
 
@@ -488,14 +488,21 @@ export async function checkIfDspsizNeeded(editor: vscode.TextEditor): Promise<bo
 
 /**
  * Collects DSPSIZ configuration from user.
+ * @param existingSizes - Sizes the file already declares, when adding to an existing DSPSIZ (e.g.
+ * the "Add Display Size" command) rather than declaring one from scratch — pre-checked in the
+ * picker so the user adds to them instead of starting over. Empty (the default) for the from-scratch
+ * case, which pre-checks the standard 24x80 size instead.
  * @returns DSPSIZ configuration or null if cancelled
  */
-export async function collectDspsizConfiguration(): Promise<DspsizConfig | null> {
+export async function collectDspsizConfiguration(existingSizes: DisplaySize[] = []): Promise<DspsizConfig | null> {
     // Ask user which display sizes to support
+    const existingNames = new Set(existingSizes.map(s => s.name));
     const sizeOptions = STANDARD_DISPLAY_SIZES.map(size => ({
         label: `${size.rows}x${size.cols} (${size.name})`,
         description: size.description,
-        picked: size.rows === 24 && size.cols === 80 // Default to standard size
+        picked: existingSizes.length > 0
+            ? existingNames.has(size.name)
+            : (size.rows === 24 && size.cols === 80) // Default to standard size, from scratch
     }));
 
     const selectedSizes = await vscode.window.showQuickPick(sizeOptions, {
@@ -603,6 +610,38 @@ export async function insertDspsizLines(editor: vscode.TextEditor, dspsizLines: 
 };
 
 /**
+ * Updates the file's DSPSIZ specification to declare the given complete set of sizes — used by the
+ * "Add Display Size" command, as opposed to `insertDspsizLines`, which only covers declaring DSPSIZ
+ * from scratch when the file has none yet. When an existing DSPSIZ attribute is found (via
+ * `attributesFileLevel`, already parsed), its line range — including any wrapped continuation lines
+ * — is replaced wholesale with the freshly generated lines; otherwise falls back to inserting a new
+ * DSPSIZ specification, same as the from-scratch case.
+ * @param editor - The active text editor
+ * @param sizes - The complete set of sizes the file should declare afterward (existing + newly added)
+ */
+export async function updateDspsizLines(editor: vscode.TextEditor, sizes: DisplaySize[]): Promise<boolean> {
+    const dspsizLines = generateDspsizLines({ sizes, needsDspsiz: true });
+    if (dspsizLines.length === 0) {
+        return true;
+    };
+
+    const existingAttr = attributesFileLevel.find(attr => attr.value.toUpperCase().includes('DSPSIZ('));
+    if (!existingAttr) {
+        return insertDspsizLines(editor, dspsizLines);
+    };
+
+    const workspaceEdit = new vscode.WorkspaceEdit();
+    const uri = editor.document.uri;
+    const lastLineIndex = existingAttr.lastLineIndex ?? existingAttr.lineIndex;
+    const range = new vscode.Range(
+        existingAttr.lineIndex, 0,
+        lastLineIndex, editor.document.lineAt(lastLineIndex).text.length
+    );
+    workspaceEdit.replace(uri, range, dspsizLines.join('\n'));
+    return applyWorkspaceEdit(workspaceEdit, 'update the DSPSIZ specification');
+};
+
+/**
  * Finds the correct insertion point for DSPSIZ specification.
  * Should be after existing file-level attributes but before the first record.
  * @param editor - The active text editor
@@ -637,6 +676,107 @@ function findDspsizInsertionPoint(editor: vscode.TextEditor): number {
     };
 
     return insertionPoint;
+};
+
+/**
+ * Stamps (or clears) a display-format condition (e.g. "*DS3") onto a DDS line, in the same 9-character
+ * zone (columns 8-16, 0-based 7-15) that normally holds indicators — see `parseDisplayFormatCondition`
+ * in the parser for the read side of this convention, and `setIndicatorsOnLine` in
+ * dspf-edit.add-indicators.ts for the equivalent indicator-writing convention this mirrors.
+ * @param lineText - The line to stamp (must already have its keyword text in place)
+ * @param formatName - Display format name (e.g. "*DS3") to condition the line on, or undefined to
+ * leave the line unconditioned (returned unchanged)
+ */
+export function writeDisplayFormatCondition(lineText: string, formatName?: string): string {
+    if (!formatName) {
+        return lineText;
+    };
+
+    const line = lineText.padEnd(80, ' ');
+    const formatZone = formatName.padEnd(9, ' ').substring(0, 9);
+    return (line.substring(0, 7) + formatZone + line.substring(16)).trimEnd();
+};
+
+/**
+ * A single existing line of a keyword that can be conditioned per DSPSIZ display format (WINDOW,
+ * WDWTITLE, SFLPAG, SFLSIZ, ...) — the minimal shape `applyDisplayFormatSplitEdit` needs to pick the
+ * right candidate and locate it in the document.
+ */
+export interface DisplayFormatConditionable {
+    lineIndex: number;
+    displayFormat?: string;
+};
+
+/**
+ * Applies the "split on edit" rule to a workspace edit for a keyword that may be conditioned per
+ * display format, so that editing it while previewing one format never silently changes another.
+ *
+ * Rule: resolve which existing line is actually in effect for `activeFormat` the same way the
+ * preview already resolves it for reading (`pickForActiveFormat`: a line explicitly conditioned for
+ * it, else the shared unconditioned line, else the first candidate). If that line is already
+ * conditioned for `activeFormat` specifically (or the file declares at most one format), just
+ * rewrite it in place with the new value — already correctly scoped, no change in behavior. If it's
+ * the *shared* unconditioned line and the file declares more than one format, every other declared
+ * format currently falling back to that same line gets its own new line inserted right after,
+ * preserving the line's OLD value and explicitly conditioned for that format; the original line is
+ * then rewritten in place, now conditioned for `activeFormat`, with the NEW value — so afterward
+ * every declared format has its own explicit line and none are left relying on a fallback that just
+ * changed under them.
+ * @param workspaceEdit - Edit to add the replace/insert operations to
+ * @param document - The document being edited (for reading each candidate line's current text/range)
+ * @param candidates - This keyword's existing lines on the record, in source order
+ * @param activeFormat - Display format (e.g. "*DS3") currently being previewed/edited, or undefined
+ * @param declaredFormats - Every display format the file declares (from `getAvailableDisplayFormats`)
+ * @param generateLine - Produces the full line text to write, given the resolved line's current text
+ * and the format it should end up conditioned on (undefined for the rewritten/active line only when
+ * no split occurs). Called once per line written (1 rewrite, plus 1 insert per other format on split).
+ */
+export function applyDisplayFormatSplitEdit<T extends DisplayFormatConditionable>(
+    workspaceEdit: vscode.WorkspaceEdit,
+    document: vscode.TextDocument,
+    candidates: T[],
+    activeFormat: string | undefined,
+    declaredFormats: string[],
+    generateLine: (existingLineText: string, format?: string) => string
+): void {
+    if (candidates.length === 0) {
+        return;
+    };
+
+    const effective = pickForActiveFormat(candidates, activeFormat);
+    if (!effective) {
+        return;
+    };
+
+    const uri = document.uri;
+    const effectiveLine = document.lineAt(effective.lineIndex);
+
+    // No-op guard: if the edit wouldn't actually change this line's content (e.g. a drag that ends
+    // back where it started), skip entirely — including the split, which should never fire for a
+    // change that isn't really happening.
+    const proposedLine = generateLine(effectiveLine.text, effective.displayFormat);
+    if (proposedLine === effectiveLine.text) {
+        return;
+    };
+
+    const needsSplit = !!activeFormat && !effective.displayFormat && declaredFormats.length > 1;
+
+    if (!needsSplit) {
+        workspaceEdit.replace(uri, effectiveLine.range, proposedLine);
+        return;
+    };
+
+    // Preserve the OLD value for every other declared format that would otherwise keep silently
+    // falling back to this same shared line once it's rewritten.
+    const otherFormats = declaredFormats.filter(f => f !== activeFormat);
+    for (const format of otherFormats) {
+        const oldConditionedLine = writeDisplayFormatCondition(effectiveLine.text, format);
+        workspaceEdit.insert(uri, effectiveLine.range.end, '\n' + oldConditionedLine);
+    };
+
+    // Rewrite the original line in place: now conditioned for the active format, with the new value.
+    const newLine = writeDisplayFormatCondition(generateLine(effectiveLine.text, activeFormat), activeFormat);
+    workspaceEdit.replace(uri, effectiveLine.range, newLine);
 };
 
 /**

--- a/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
@@ -295,7 +295,7 @@ function attributeGroupKey(value: string): string {
  * @param recordName - Name of the record to inspect
  * @param activeFormat - Currently selected display format name (e.g. "*DS3"), or undefined
  */
-function findWindowAttribute(recordName: string, activeFormat?: string): { startRow: number; startCol: number; numRows: number; numCols: number; lineIndex: number } | undefined {
+function findWindowAttribute(recordName: string, activeFormat?: string): { startRow: number; startCol: number; numRows: number; numCols: number; lineIndex: number; hasOwnMessageLine: boolean } | undefined {
     const record = fieldsPerRecords.find(r => r.record === recordName);
     const candidates = record?.attributes?.filter(a => a.value.toUpperCase().startsWith('WINDOW(')) ?? [];
     const attr = pickForActiveFormat(candidates, activeFormat);
@@ -303,17 +303,23 @@ function findWindowAttribute(recordName: string, activeFormat?: string): { start
         return undefined;
     };
 
-    const match = attr.value.match(/WINDOW\s*\(\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+)(?:\s+[^)]*)?\s*\)/i);
+    const match = attr.value.match(/WINDOW\s*\(\s*(\d+)\s+(\d+)\s+(\d+)\s+(\d+)((?:\s+[^)]*)?)\s*\)/i);
     if (!match) {
         return undefined;
     };
+
+    // Per the DDS reference (WINDOW keyword, "MSGLIN parameter"): a window's own last content line
+    // is reserved as its message line by default — *NOMSGLIN is what opts OUT of that, moving error
+    // messages back to the bottom of the physical display (or MSGLOC) instead.
+    const hasOwnMessageLine = !/\*NOMSGLIN\b/i.test(match[5] ?? '');
 
     return {
         startRow: parseInt(match[1], 10),
         startCol: parseInt(match[2], 10),
         numRows: parseInt(match[3], 10),
         numCols: parseInt(match[4], 10),
-        lineIndex: attr.lineIndex
+        lineIndex: attr.lineIndex,
+        hasOwnMessageLine
     };
 };
 
@@ -382,7 +388,13 @@ function extractFunctionKeyCommands(attributes: DdsAttribute[] | undefined): Fun
     const commands: FunctionKeyCommand[] = [];
 
     (attributes ?? []).forEach(attr => {
-        const match = attr.value.match(/^(CA|CF)(\d{2})\(\d{2}\s+'([^']{1,25})'\)$/);
+        // No length cap on the description here: DDS allows text longer than fits on one source
+        // line (spilling onto a continuation line, already reassembled into `attr.value` by the
+        // parser) — capping the match would silently drop keys with a longer description, e.g. one
+        // that had to wrap (see dspf-edit.add-keys.ts's extractKeyCommandsFromAttributes for the
+        // matching read-side fix, and validateKeyCommandDescription for where 25 legitimately still
+        // applies: only when this tool itself creates a new one).
+        const match = attr.value.match(/^(CA|CF)(\d{2})\(\d{2}\s+'([^']*)'\)$/);
         if (match) {
             commands.push({
                 type: match[1] as 'CA' | 'CF',
@@ -564,7 +576,13 @@ export class RecordPreviewPanel {
             'dspfEditRecordPreview',
             `Preview: ${recordName}`,
             { viewColumn: vscode.ViewColumn.Beside, preserveFocus: true },
-            { enableScripts: true }
+            // retainContextWhenHidden: without it, VS Code tears down the webview's live page
+            // (canvas, drag state, everything) whenever it's hidden — which moving/dragging the
+            // panel to a different editor group briefly does — and only reloads the static HTML on
+            // return, with nothing to trigger a fresh 'render' message; the canvas just stays blank
+            // until some unrelated state change (editing the document, switching records...) happens
+            // to call render() again. Keeping the page alive in the background avoids that entirely.
+            { enableScripts: true, retainContextWhenHidden: true }
         );
 
         this.panel.webview.html = this.getHtml();
@@ -675,10 +693,20 @@ export class RecordPreviewPanel {
             return null;
         };
 
+        const availableFormats = getAvailableDisplayFormats();
+
+        // A previously-selected format can stop being valid for what's being previewed now — the
+        // panel is reused across documents (switching which record is shown doesn't recreate it), so
+        // a format kept from a different file, or one a live edit just dropped from DSPSIZ, must be
+        // let go too. Left in place, the format dropdown would try to select a value with no matching
+        // <option>, which a <select> just renders blank instead of falling back to any real choice.
+        if (this.activeDisplayFormat && !availableFormats.some(f => f.name === this.activeDisplayFormat)) {
+            this.activeDisplayFormat = undefined;
+        };
+
         // Default to the first declared format so a record's WINDOW()/attributes conditioned per
         // format resolve consistently from the very first render, instead of showing every
         // candidate at once. The selector itself stays locked to it when the file only declares one.
-        const availableFormats = getAvailableDisplayFormats();
         if (availableFormats.length > 0 && !this.activeDisplayFormat) {
             this.activeDisplayFormat = availableFormats[0].name;
         };
@@ -801,6 +829,15 @@ export class RecordPreviewPanel {
         const availableRecords = records.filter(name => name !== this.recordName);
         const windowTitle = isWindow ? (findWindowTitle(this.recordName, this.activeDisplayFormat) ?? null) : null;
         const errorMessage = this.resolveErrorMessage(recordInfo);
+
+        // A window reserves its own last content line as a message line unless *NOMSGLIN is coded
+        // on its WINDOW() keyword (DDS reference, WINDOW keyword's MSGLIN parameter) — when that's
+        // the case, an active error shows there instead of at the bottom of the physical display.
+        const windowInfoForMsgLine = isWindow ? findWindowAttribute(this.resolveWindowRecordName(), this.activeDisplayFormat) : undefined;
+        const errorMessageFrame = (errorMessage && windowFrame && (windowInfoForMsgLine?.hasOwnMessageLine ?? true))
+            ? { row: windowFrame.row + windowFrame.rows - 1, col: windowFrame.col, cols: windowFrame.cols }
+            : null;
+
         const sflPagAttr = isSflCtlRecordInfo(recordInfo) ? findOwnSflPagAttribute(recordInfo, this.activeDisplayFormat) : undefined;
         const sflPagMatch = sflPagAttr?.value.match(/SFLPAG\(\s*(\d+)\s*\)/i);
         const sflPag = sflPagMatch ? parseInt(sflPagMatch[1], 10) : null;
@@ -817,6 +854,7 @@ export class RecordPreviewPanel {
             outerFrame,
             windowTitle,
             errorMessage,
+            errorMessageFrame,
             sflPag,
             maxSize,
             availableRecords,
@@ -1963,6 +2001,7 @@ export class RecordPreviewPanel {
     let currentOuterFrame = null;
     let currentWindowTitle = null;
     let currentErrorMessage = null;
+    let currentErrorMessageFrame = null;
     let currentTitleRect = null;
     let currentMenuIconRect = null;
     let currentCenterIconRect = null;
@@ -2216,19 +2255,28 @@ export class RecordPreviewPanel {
 
         drawGridDots(size, items, currentBackgroundItems, moveDelta, currentOuterFrame, currentWindowFrame);
 
-        // A currently-active ERRMSG() shows on the display's message line — the physical screen's
-        // bottom row, whether or not the record being previewed is itself a window — in white,
-        // overwriting whatever would otherwise be there, same as a real 5250 error line.
+        // A currently-active ERRMSG() shows on the message line, in white, overwriting whatever
+        // would otherwise be there, same as a real 5250 error line. Where that line actually is
+        // depends on the window's own WINDOW() keyword (DDS's MSGLIN parameter, see
+        // findWindowAttribute's hasOwnMessageLine): by default a window reserves its own last
+        // content line for this (currentErrorMessageFrame, set by the extension); only with
+        // *NOMSGLIN coded (or when the record isn't a window at all) does it fall back to the
+        // physical display's own bottom row, spanning the full canvas width.
         if (currentErrorMessage) {
-            const rowY = (size.rows - 1) * CHAR_H;
+            const frame = currentErrorMessageFrame;
+            const rowY = frame ? (frame.row - 1) * CHAR_H : (size.rows - 1) * CHAR_H;
+            const colX = frame ? (frame.col - 1) * CHAR_W : 0;
+            const widthPx = frame ? frame.cols * CHAR_W : canvas.width;
+            const maxChars = frame ? frame.cols : size.cols;
+
             ctx.fillStyle = '#000000';
-            ctx.fillRect(0, rowY, canvas.width, CHAR_H);
+            ctx.fillRect(colX, rowY, widthPx, CHAR_H);
             ctx.fillStyle = '#ffffff';
             ctx.font = (CHAR_H - 4) + 'px ' + fontFamily;
             ctx.textAlign = 'center';
             const text = currentErrorMessage.text;
-            for (let i = 0; i < text.length && i < size.cols; i++) {
-                ctx.fillText(text[i], i * CHAR_W + CHAR_W / 2, rowY + CHAR_H / 2);
+            for (let i = 0; i < text.length && i < maxChars; i++) {
+                ctx.fillText(text[i], colX + i * CHAR_W + CHAR_W / 2, rowY + CHAR_H / 2);
             }
             ctx.textAlign = 'start';
         }
@@ -2874,6 +2922,7 @@ export class RecordPreviewPanel {
                 : baseInfo;
 
             currentErrorMessage = message.errorMessage || null;
+            currentErrorMessageFrame = message.errorMessageFrame || null;
             draw(message.size, message.items, message.backgroundItems, message.windowFrame, message.windowTitle, message.outerFrame);
         } else if (message.type === 'notFound') {
             info.textContent = 'Record no longer exists.';

--- a/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
@@ -5,7 +5,7 @@
 */
 
 import * as vscode from 'vscode';
-import { FieldsPerRecord, DdsSize, DdsAttribute, AttributeWithIndicators, DdsIndicator, fieldsPerRecords, records, getDefaultSize, getAvailableDisplayFormats, getSizeForFormat, SYSTEM_FIELD_PLACEHOLDER, groupIndicatorsByCondition } from '../dspf-edit.model/dspf-edit.model';
+import { FieldsPerRecord, DdsSize, DdsAttribute, AttributeWithIndicators, DdsIndicator, fieldsPerRecords, attributesFileLevel, records, getDefaultSize, getAvailableDisplayFormats, getSizeForFormat, SYSTEM_FIELD_PLACEHOLDER, groupIndicatorsByCondition } from '../dspf-edit.model/dspf-edit.model';
 import { checkForEditorAndDocument, updateTreeProvider, applyWorkspaceEdit, applyDisplayFormatSplitEdit } from '../dspf-edit.utils/dspf-edit.helper';
 import { DdsTreeProvider } from '../dspf-edit.providers/dspf-edit.providers';
 import { ExtensionState } from '../dspf-edit.states/state';
@@ -362,6 +362,63 @@ function findWindowTitle(recordName: string, activeFormat?: string): WindowTitle
     return undefined;
 };
 
+/** A single function-key command (CAxx/CFxx), as relevant to the preview's legend. */
+interface FunctionKeyCommand {
+    type: 'CA' | 'CF';
+    keyNumber: string;
+    description: string;
+    indicators?: DdsIndicator[];
+    displayFormat?: string;
+};
+
+/**
+ * Parses CAxx()/CFxx() key command lines out of an arbitrary attribute list (a record's own, or the
+ * file's) — same format `dspf-edit.add-keys.ts` generates/reads, kept independent since this also
+ * needs each command's own indicators/display-format condition, which that command's own model
+ * doesn't carry (it's only used there for a flat "current commands" summary).
+ * @param attributes - Attribute lines to scan
+ */
+function extractFunctionKeyCommands(attributes: DdsAttribute[] | undefined): FunctionKeyCommand[] {
+    const commands: FunctionKeyCommand[] = [];
+
+    (attributes ?? []).forEach(attr => {
+        const match = attr.value.match(/^(CA|CF)(\d{2})\(\d{2}\s+'([^']{1,25})'\)$/);
+        if (match) {
+            commands.push({
+                type: match[1] as 'CA' | 'CF',
+                keyNumber: match[2],
+                description: match[3],
+                indicators: attr.indicators,
+                displayFormat: attr.displayFormat
+            });
+        };
+    });
+
+    return commands;
+};
+
+/**
+ * Resolves the candidate function-key commands (CAxx/CFxx) for a record, for the preview's
+ * function-key legend: the record's own, plus the file-level ones (which apply to every record
+ * format) — except for any key number the record already defines itself, which entirely overrides
+ * the file-level one for that number, matching how DDS actually resolves it at runtime. A key
+ * number can still yield more than one candidate here (e.g. two indicator-conditioned alternates,
+ * "CA03 cond. on 50" / "CA03 cond. on N50") — narrowing that down to the one that currently applies
+ * (by display format, then by indicator state) is the caller's job, the same way it's already done
+ * for every other conditionable item in the preview (see `isItemDisplayed`/`filterForActiveFormat`).
+ * @param recordName - Name of the record being previewed
+ */
+function getEffectiveFunctionKeyCommands(recordName: string): FunctionKeyCommand[] {
+    const record = fieldsPerRecords.find(r => r.record === recordName);
+    const recordCommands = extractFunctionKeyCommands(record?.attributes);
+    const overriddenNumbers = new Set(recordCommands.map(cmd => cmd.keyNumber));
+
+    const fileCommands = extractFunctionKeyCommands(attributesFileLevel)
+        .filter(cmd => !overriddenNumbers.has(cmd.keyNumber));
+
+    return [...recordCommands, ...fileCommands];
+};
+
 /** Whether a record's attributes include the SFL keyword (i.e. it's a subfile detail record). */
 function isSflRecordInfo(recordInfo: FieldsPerRecord): boolean {
     return recordInfo.attributes?.some(attr => attr.value === 'SFL') ?? false;
@@ -560,9 +617,11 @@ export class RecordPreviewPanel {
             existing.recordName = recordName;
             existing.treeProvider = treeProvider;
             existing.overlayRecordName = undefined;
-            existing.indicatorsEnabled = false;
+            // indicatorsEnabled (the "Indicators" toggle checkbox) and activeDisplayFormat (the
+            // selected DSPSIZ format, e.g. *DS3) are deliberately NOT reset here — they're panel-wide
+            // view preferences (formats are file-level, not per-record) that should stay as the user
+            // left them when switching which record is previewed.
             existing.activeIndicators = new Set();
-            existing.activeDisplayFormat = undefined;
             existing.panel.title = `Preview: ${recordName}`;
             // Reveal without forcing a column: the user may have moved the panel elsewhere
             // (e.g. to a bottom group), and switching records shouldn't snap it back to "Beside".
@@ -746,6 +805,9 @@ export class RecordPreviewPanel {
         const sflPagMatch = sflPagAttr?.value.match(/SFLPAG\(\s*(\d+)\s*\)/i);
         const sflPag = sflPagMatch ? parseInt(sflPagMatch[1], 10) : null;
 
+        // Function-key legend (e.g. "F3=Exit  F12=Cancel"): file-level + record-level CAxx/CFxx.
+        const functionKeys = this.getVisibleFunctionKeys(this.recordName);
+
         this.panel.webview.postMessage({
             type: 'render',
             recordName: this.recordName,
@@ -766,7 +828,8 @@ export class RecordPreviewPanel {
             activeDisplayFormat: this.activeDisplayFormat ?? null,
             minDetailRow,
             items,
-            backgroundItems
+            backgroundItems,
+            functionKeys
         });
     };
 
@@ -992,6 +1055,42 @@ export class RecordPreviewPanel {
             result.push(attr);
         };
         return result;
+    };
+
+    /**
+     * Resolves the function keys to show in the preview's legend for a record: every distinct key
+     * number among its candidate CAxx/CFxx commands (see `getEffectiveFunctionKeyCommands` — record
+     * overriding file), narrowed to the active display format. Unlike a field/constant, a key stays
+     * in the legend even when its own indicator condition currently isn't satisfied — it's still
+     * *defined*, just not presently enabled — so the caller can render it dimmed; `active` says
+     * whether at least one of that key's candidates (there can be more than one — indicator-ANDed,
+     * OR'd alternates, or just unconditioned) is currently satisfied (live simulation, same check
+     * used everywhere else conditionable in the preview). When more than one candidate exists for a
+     * number, the active one's description is shown (falling back to the first candidate's when
+     * none currently apply).
+     * @param recordName - Name of the record being previewed
+     */
+    private getVisibleFunctionKeys(recordName: string): { key: string; description: string; active: boolean }[] {
+        const forFormat = filterForActiveFormat(getEffectiveFunctionKeyCommands(recordName), this.activeDisplayFormat);
+
+        const byKeyNumber = new Map<string, FunctionKeyCommand[]>();
+        for (const cmd of forFormat) {
+            const candidates = byKeyNumber.get(cmd.keyNumber);
+            if (candidates) {
+                candidates.push(cmd);
+            } else {
+                byKeyNumber.set(cmd.keyNumber, [cmd]);
+            };
+        };
+
+        const result: { key: string; description: string; active: boolean }[] = [];
+        for (const [keyNumber, candidates] of byKeyNumber) {
+            const activeCandidate = candidates.find(cmd => this.isItemDisplayed(cmd.indicators, this.indicatorsEnabled));
+            const chosen = activeCandidate ?? candidates[0];
+            result.push({ key: `F${parseInt(keyNumber, 10)}`, description: chosen.description, active: Boolean(activeCandidate) });
+        };
+
+        return result.sort((a, b) => parseInt(a.key.slice(1), 10) - parseInt(b.key.slice(1), 10));
     };
 
     /**
@@ -1768,6 +1867,24 @@ export class RecordPreviewPanel {
         border: 1px solid #333333;
         cursor: default;
     }
+    #functionKeyList {
+        display: none;
+        margin-bottom: 6px;
+    }
+    .function-key-badge {
+        display: inline-block;
+        margin: 2px;
+        padding: 1px 6px;
+        border: 1px solid #00ff00;
+        color: #00ff00;
+        background: #000000;
+        font-family: inherit;
+        font-size: 11px;
+    }
+    .function-key-badge.active {
+        color: #000000;
+        background: #00ff00;
+    }
 </style>
 </head>
 <body>
@@ -1800,6 +1917,7 @@ export class RecordPreviewPanel {
     </span>
 </div>
 <div id="indicatorList"></div>
+<div id="functionKeyList"></div>
 <canvas id="screen"></canvas>
 <script>
     const vscode = acquireVsCodeApi();
@@ -1813,6 +1931,7 @@ export class RecordPreviewPanel {
     const indicatorBar = document.getElementById('indicatorBar');
     const indicatorsToggle = document.getElementById('indicatorsToggle');
     const indicatorList = document.getElementById('indicatorList');
+    const functionKeyList = document.getElementById('functionKeyList');
     const sflpagBar = document.getElementById('sflpagBar');
     const sflpagMinusBtn = document.getElementById('sflpagMinusBtn');
     const sflpagPlusBtn = document.getElementById('sflpagPlusBtn');
@@ -2686,6 +2805,18 @@ export class RecordPreviewPanel {
         }
     }
 
+    function rebuildFunctionKeyList(functionKeys) {
+        functionKeyList.innerHTML = '';
+
+        for (const fk of functionKeys) {
+            const badge = document.createElement('span');
+            badge.className = 'function-key-badge' + (fk.active ? ' active' : '');
+            badge.textContent = fk.key;
+            badge.title = fk.description;
+            functionKeyList.appendChild(badge);
+        }
+    }
+
     window.addEventListener('message', (event) => {
         const message = event.data;
         if (message.type === 'render') {
@@ -2721,6 +2852,12 @@ export class RecordPreviewPanel {
             indicatorsToggle.checked = Boolean(message.indicatorsEnabled);
             indicatorList.style.display = (hasIndicators && message.indicatorsEnabled) ? 'block' : 'none';
             rebuildIndicatorList(message.availableIndicators || [], message.activeIndicators || []);
+
+            // Always shown (no on/off toggle, unlike indicators) — a programmer benefits from
+            // seeing which function keys are defined at a glance, without an extra click.
+            const hasFunctionKeys = message.functionKeys && message.functionKeys.length > 0;
+            functionKeyList.style.display = hasFunctionKeys ? 'block' : 'none';
+            rebuildFunctionKeyList(message.functionKeys || []);
 
             const hasSflPag = typeof message.sflPag === 'number';
             sflpagBar.style.display = hasSflPag ? 'inline-flex' : 'none';

--- a/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
@@ -6,11 +6,11 @@
 
 import * as vscode from 'vscode';
 import { FieldsPerRecord, DdsSize, DdsAttribute, AttributeWithIndicators, DdsIndicator, fieldsPerRecords, records, getDefaultSize, getAvailableDisplayFormats, getSizeForFormat, SYSTEM_FIELD_PLACEHOLDER, groupIndicatorsByCondition } from '../dspf-edit.model/dspf-edit.model';
-import { checkForEditorAndDocument, updateTreeProvider, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, updateTreeProvider, applyWorkspaceEdit, applyDisplayFormatSplitEdit } from '../dspf-edit.utils/dspf-edit.helper';
 import { DdsTreeProvider } from '../dspf-edit.providers/dspf-edit.providers';
 import { ExtensionState } from '../dspf-edit.states/state';
 import { getResolvedRef } from '../dspf-edit.ibmi/dspf-edit.ibmi-integration';
-import { resolveRecordSizeForFormat } from '../dspf-edit.parser/dspf-edit.parser';
+import { resolveRecordSizeForFormat, filterForActiveFormat, pickForActiveFormat } from '../dspf-edit.parser/dspf-edit.parser';
 import { editWindowTitleForRecord } from '../dspf-edit.commands/dspf-edit.window-title';
 import { getConstantTextFromUser, insertNewConstant } from '../dspf-edit.commands/dspf-edit.edit-constant';
 import { addFieldAtPosition } from '../dspf-edit.commands/dspf-edit.edit-field';
@@ -476,40 +476,6 @@ function getEffectiveSize(recordName: string, activeFormat?: string): DdsSize | 
         return resolveRecordSizeForFormat(recordName, activeFormat);
     };
     return fieldsPerRecords.find(r => r.record === recordName)?.size;
-};
-
-/**
- * Filters out attributes/fields/constants conditioned by a display format other than the active
- * one; unconditioned ones (and everything, when no format is active) always pass through.
- * @param items - Items carrying an optional displayFormat condition
- * @param activeFormat - Currently selected display format name (e.g. "*DS3"), or undefined
- */
-function filterForActiveFormat<T extends { displayFormat?: string }>(items: T[], activeFormat: string | undefined): T[] {
-    if (!activeFormat) {
-        return items;
-    };
-    return items.filter(item => !item.displayFormat || item.displayFormat === activeFormat);
-};
-
-/**
- * Picks which of several same-keyword candidates applies, when a record/field/constant is
- * conditioned by more than one display format (one line per format, e.g. WDWTITLE or SFLPAG
- * declared once for *DS3 and once for *DS4). Prefers the one matching activeFormat, falling back
- * to an unconditioned one, then to the first candidate — so behavior is unchanged when no format
- * is active.
- * @param candidates - Same-keyword attribute candidates, in source order
- * @param activeFormat - Currently selected display format name (e.g. "*DS3"), or undefined
- */
-function pickForActiveFormat<T extends { displayFormat?: string }>(candidates: T[], activeFormat?: string): T | undefined {
-    if (candidates.length === 0) {
-        return undefined;
-    };
-    if (!activeFormat) {
-        return candidates[0];
-    };
-    return candidates.find(c => c.displayFormat === activeFormat)
-        ?? candidates.find(c => !c.displayFormat)
-        ?? candidates[0];
 };
 
 /**
@@ -1426,12 +1392,13 @@ export class RecordPreviewPanel {
      * @param newCols - New window width
      */
     private async resizeWindow(newRows: number, newCols: number): Promise<void> {
-        const windowInfo = findWindowAttribute(this.resolveWindowRecordName(), this.activeDisplayFormat);
+        const windowRecordName = this.resolveWindowRecordName();
+        const windowInfo = findWindowAttribute(windowRecordName, this.activeDisplayFormat);
         if (!windowInfo) {
             return;
         };
 
-        await this.rewriteWindowKeyword(windowInfo.lineIndex, windowInfo.startRow, windowInfo.startCol, newRows, newCols);
+        await this.rewriteWindowKeyword(windowRecordName, windowInfo.startRow, windowInfo.startCol, newRows, newCols);
     };
 
     /**
@@ -1440,12 +1407,13 @@ export class RecordPreviewPanel {
      * @param newCol - New window screen column
      */
     private async moveWindowPosition(newRow: number, newCol: number): Promise<void> {
-        const windowInfo = findWindowAttribute(this.resolveWindowRecordName(), this.activeDisplayFormat);
+        const windowRecordName = this.resolveWindowRecordName();
+        const windowInfo = findWindowAttribute(windowRecordName, this.activeDisplayFormat);
         if (!windowInfo) {
             return;
         };
 
-        await this.rewriteWindowKeyword(windowInfo.lineIndex, newRow, newCol, windowInfo.numRows, windowInfo.numCols);
+        await this.rewriteWindowKeyword(windowRecordName, newRow, newCol, windowInfo.numRows, windowInfo.numCols);
     };
 
     /**
@@ -1454,7 +1422,7 @@ export class RecordPreviewPanel {
      * belongs to a shared window (WINDOW(other-record-name), or an inherited SFL/SFLCTL pair).
      */
     private async editWindowTitle(): Promise<void> {
-        await editWindowTitleForRecord(this.resolveWindowRecordName());
+        await editWindowTitleForRecord(this.resolveWindowRecordName(), this.activeDisplayFormat);
 
         const { editor } = checkForEditorAndDocument();
         if (editor) {
@@ -1508,7 +1476,7 @@ export class RecordPreviewPanel {
             return;
         };
 
-        await this.rewriteWindowKeyword(windowInfo.lineIndex, windowInfo.startRow, newStartCol, windowInfo.numRows, windowInfo.numCols);
+        await this.rewriteWindowKeyword(windowRecordName, windowInfo.startRow, newStartCol, windowInfo.numRows, windowInfo.numCols);
     };
 
     /**
@@ -1569,26 +1537,40 @@ export class RecordPreviewPanel {
     };
 
     /**
-     * Rewrites the record's WINDOW(startRow startCol numRows numCols) keyword in place.
+     * Rewrites the record's WINDOW(startRow startCol numRows numCols) keyword to the given values.
+     * When the file declares more than one display format and the currently-effective WINDOW() line
+     * is the shared unconditioned one, this splits it first (see `applyDisplayFormatSplitEdit`) so
+     * the edit only affects the format currently being previewed, instead of silently changing every
+     * format's window at once.
+     * @param recordName - Name of the record whose WINDOW() line(s) to rewrite
      */
-    private async rewriteWindowKeyword(lineIndex: number, startRow: number, startCol: number, numRows: number, numCols: number): Promise<void> {
+    private async rewriteWindowKeyword(recordName: string, startRow: number, startCol: number, numRows: number, numCols: number): Promise<void> {
         const { editor } = checkForEditorAndDocument();
         if (!editor) {
             return;
         };
 
-        const line = editor.document.lineAt(lineIndex);
-        const updatedLine = line.text.replace(
-            /WINDOW\s*\(\s*\d+\s+\d+\s+\d+\s+\d+(\s+[^)]*)?\s*\)/i,
-            (_match, suffix) => `WINDOW(${startRow} ${startCol} ${numRows} ${numCols}${suffix ?? ''})`
-        );
-
-        if (updatedLine === line.text) {
+        const record = fieldsPerRecords.find(r => r.record === recordName);
+        const candidates = record?.attributes?.filter(a => a.value.toUpperCase().startsWith('WINDOW(')) ?? [];
+        if (candidates.length === 0) {
             return;
         };
 
+        const declaredFormats = getAvailableDisplayFormats().map(f => f.name);
         const workspaceEdit = new vscode.WorkspaceEdit();
-        workspaceEdit.replace(editor.document.uri, line.range, updatedLine);
+
+        applyDisplayFormatSplitEdit(
+            workspaceEdit,
+            editor.document,
+            candidates,
+            this.activeDisplayFormat,
+            declaredFormats,
+            (existingLineText) => existingLineText.replace(
+                /WINDOW\s*\(\s*\d+\s+\d+\s+\d+\s+\d+(\s+[^)]*)?\s*\)/i,
+                (_match, suffix) => `WINDOW(${startRow} ${startCol} ${numRows} ${numCols}${suffix ?? ''})`
+            )
+        );
+
         if (!(await applyWorkspaceEdit(workspaceEdit, 'resize/move the window'))) {
             return;
         };
@@ -1598,7 +1580,10 @@ export class RecordPreviewPanel {
     /**
      * Increments or decrements an SFLCTL record's SFLPAG() (number of subfile rows shown at once),
      * always keeping SFLSIZ() one more than SFLPAG — the common convention that gives the subfile
-     * one row of headroom past what's visible. Both are 4-digit zero-padded numeric literals.
+     * one row of headroom past what's visible. Both are 4-digit zero-padded numeric literals. When
+     * the file declares more than one display format and either keyword's currently-effective line
+     * is still the shared unconditioned one, splits it first (see `applyDisplayFormatSplitEdit`) so
+     * the change only affects the format currently being previewed.
      */
     private async adjustSubfilePageSize(delta: number): Promise<void> {
         const { editor } = checkForEditorAndDocument();
@@ -1611,7 +1596,8 @@ export class RecordPreviewPanel {
             return;
         };
 
-        const pagAttr = findOwnSflPagAttribute(recordInfo, this.activeDisplayFormat);
+        const pagCandidates = recordInfo.attributes?.filter(a => a.value.toUpperCase().startsWith('SFLPAG(')) ?? [];
+        const pagAttr = pickForActiveFormat(pagCandidates, this.activeDisplayFormat);
         const pagMatch = pagAttr?.value.match(/SFLPAG\(\s*(\d+)\s*\)/i);
         if (!pagAttr || !pagMatch) {
             return;
@@ -1624,25 +1610,27 @@ export class RecordPreviewPanel {
         };
         const newSiz = newPag + 1;
 
+        const declaredFormats = getAvailableDisplayFormats().map(f => f.name);
         const workspaceEdit = new vscode.WorkspaceEdit();
 
-        const pagLine = editor.document.lineAt(pagAttr.lineIndex);
-        workspaceEdit.replace(
-            editor.document.uri,
-            pagLine.range,
-            pagLine.text.replace(/SFLPAG\(\s*\d+\s*\)/i, `SFLPAG(${String(newPag).padStart(4, '0')})`)
+        applyDisplayFormatSplitEdit(
+            workspaceEdit,
+            editor.document,
+            pagCandidates,
+            this.activeDisplayFormat,
+            declaredFormats,
+            (existingLineText) => existingLineText.replace(/SFLPAG\(\s*\d+\s*\)/i, `SFLPAG(${String(newPag).padStart(4, '0')})`)
         );
 
         const sizCandidates = recordInfo.attributes?.filter(a => a.value.toUpperCase().startsWith('SFLSIZ(')) ?? [];
-        const sizAttr = pickForActiveFormat(sizCandidates, this.activeDisplayFormat);
-        if (sizAttr) {
-            const sizLine = editor.document.lineAt(sizAttr.lineIndex);
-            workspaceEdit.replace(
-                editor.document.uri,
-                sizLine.range,
-                sizLine.text.replace(/SFLSIZ\(\s*\d+\s*\)/i, `SFLSIZ(${String(newSiz).padStart(4, '0')})`)
-            );
-        };
+        applyDisplayFormatSplitEdit(
+            workspaceEdit,
+            editor.document,
+            sizCandidates,
+            this.activeDisplayFormat,
+            declaredFormats,
+            (existingLineText) => existingLineText.replace(/SFLSIZ\(\s*\d+\s*\)/i, `SFLSIZ(${String(newSiz).padStart(4, '0')})`)
+        );
 
         if (!(await applyWorkspaceEdit(workspaceEdit, 'change the subfile page size'))) {
             return;


### PR DESCRIPTION
## [0.17.0] - 2026-08-12
### Added
- Command Keys: adding a CAxx/CFxx now also checks the *other* level (the file, when adding to a record; every record, when adding at file level) and excludes any key number already used there from the picker, regardless of whether the type matches — prevents generating a record whose effective key set defines the same key number as both CA and CF (or twice), which DDS won't compile.
- Preview: a function-key legend now always shows below the toolbar — one green-bordered `Fnn` badge per key actually available to the record being previewed (file-level + record-level CAxx/CFxx, record overriding file per key number, narrowed to the active display format). A key still shows even when its own indicator condition isn't currently met, so you can see at a glance that it's *defined*; it switches to solid (inverted) styling when it's actually active right now — correctly handling more than one indicator-conditioned alternate per key number (AND/OR), and hovering shows its description.
- Preview: an active `ERRMSG()` on a `WINDOW` record now shows on the window's own reserved message line (its last content row) instead of always at the bottom of the physical screen — matching the DDS `WINDOW` keyword's `MSGLIN`/`*NOMSGLIN` parameter (a window reserves its own message line by default; `*NOMSGLIN` is what opts out and sends it to the display's normal message line instead).
- Preview: the "Indicators" toggle and the active display format (e.g. *DS3) now persist across switching which record is previewed in the same panel, instead of resetting back off/default every time.
### Fixed
- Command Keys / Preview: a CAxx/CFxx description longer than 25 characters — legitimately allowed by DDS, spilling onto a continuation line in the source — was silently dropped from both the "current key commands" list and the preview's function-key legend. The reading regex incorrectly reused the 25-character cap that's only meant to apply when this tool itself creates a *new* key command.
- Preview: the display-format dropdown (the *DS3/*DS4 selector) could end up blank instead of showing a real selection — it now keeps the previously-selected format across record switches, but wasn't falling back when that format no longer applied (e.g. after switching to a different file, or a live edit removed a DSPSIZ format from the current one).
- Preview: the panel went blank after being dragged to a different editor group — VS Code was tearing down its live content whenever it became hidden (which moving it briefly does) and nothing re-rendered it on return; the panel now keeps its content alive in the background (`retainContextWhenHidden`).
