### PR TITLE
v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
+## [1.1.1] - 2026-08-28
+### Fixed
+- Preview: the `EDTCDE` thousands-separator table had commas alternating per individual code instead of per pair (1&2, A&B, J&K, N&O should show separators; 3&4, C&D, L&M, P&Q should not) — `EDTCDE(K)` (and 2/3/B/C/L/P) rendered with no thousands separator at all. (Issue #77)
+- Preview: `EDTCDE(N/O/P/Q)` weren't recognized at all, so no decimal point/comma/sign width was reserved for them. Now supported, with the minus sign correctly reserved leading (before the first digit), unlike J/K/L/M which reserve it trailing — confirmed against real STRSDA.
+- Preview and Add Editing Keywords: a numeric field with a blank Type column (position 35) — the default, most common way to define a plain zoned-numeric field, without an explicit type letter — was misdetected as alphanumeric, showing letter placeholders instead of digit ones, and could be blocked from getting an edit code/word.
+- Add Editing Keywords: the `EDTCDE` picker's descriptions mislabeled the comma/no-comma distinction between paired codes as a decimals/no-decimals distinction.
+
 ## [1.1.0] - 2026-08-26
 ### Added
 - Preview: the "⋮ Actions" menu now offers Copy (click a spot in the preview to place a copy of the selected field/constant, keeping its attributes/colors/indicators, within the same record) and Delete, alongside Add Color/Add Attribute. With more than one element selected, Add Color/Add Attribute/Delete apply to all of them at once.

--- a/README.md
+++ b/README.md
@@ -145,13 +145,11 @@ No known blocking issues right now. Please [open an issue](https://github.com/ch
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**1.1.0** - 2026-08-26
-- Added: Preview "⋮ Actions" menu now offers Copy and Delete, alongside Add Color/Add Attribute — applied to every selected element at once for a multi-selection.
-- Added: Preview toolbar buttons regrouped into one row that moves together when something's selected.
-- Fixed: `EDTMSK` could be applied to an output-only field.
-- Fixed: `*DS3`/`*DS4` display-format conditioning on a keyword line was written one column too early, and could condition the primary display size explicitly — both invalid DDS.
-- Fixed: Add Field/Add Constant (tree) validated position against the whole file's size instead of a window record's own content area.
-- Fixed: Field/record names starting with `@`, `#`, or `$` were rejected.
+**1.1.1** - 2026-08-28
+- Fixed: Preview `EDTCDE` thousands-separator table had commas alternating per individual code instead of per pair — `EDTCDE(K)` (and 2/3/B/C/L/P) rendered with no thousands separator at all.
+- Fixed: Preview `EDTCDE(N/O/P/Q)` weren't recognized at all; now supported, with the minus sign correctly reserved leading rather than trailing like J/K/L/M.
+- Fixed: a numeric field with a blank Type column (the default way to define a plain zoned-numeric field) was misdetected as alphanumeric in the preview and in Add Editing Keywords.
+- Fixed: the `EDTCDE` picker's descriptions mislabeled the comma/no-comma distinction as decimals/no-decimals.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dspf-edit",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dspf-edit",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"

--- a/src/dspf-edit.commands/dspf-edit.add-editing-keywords.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-editing-keywords.ts
@@ -319,8 +319,16 @@ function inputCapableFieldWarning(element: any): string {
  * @returns true if field is numeric
  */
 function isNumericField(fieldInfo: any): boolean {
-    const fieldType = fieldInfo.type || '';
-    
+    const fieldType = (fieldInfo.type || '').trim();
+
+    // A blank Type column is DDS's own default and is ambiguous on its own: it's alphanumeric
+    // only when the decimal-positions column is also blank, but a blank Type with decimal
+    // positions given (even 0) is a plain zoned-numeric field — the most common way to define a
+    // numeric field in DDS, without ever writing an explicit type letter.
+    if (fieldType === '') {
+        return fieldInfo.decimals !== undefined;
+    };
+
     // All numeric types that support editing in DDS:
     // P = Packed decimal
     // S = Zoned decimal (signed)
@@ -399,26 +407,26 @@ function isNumericFieldDetailed(fieldInfo: any): boolean {
 function getAvailableEditCodes(): EditCodeOption[] {
     return [
         // Standard codes (1-4)
-        { code: '1', description: 'Commas, decimals, no sign, zero as .00/0', category: 'Standard', supportsAsterisk: true, supportsCurrency: true },
-        { code: '2', description: 'Commas, decimals, no sign, zero as blanks', category: 'Standard', supportsAsterisk: true, supportsCurrency: true },
-        { code: '3', description: 'Commas, no decimals, no sign, zero as .00/0', category: 'Standard', supportsAsterisk: true, supportsCurrency: true },
-        { code: '4', description: 'Commas, no decimals, no sign, zero as blanks', category: 'Standard', supportsAsterisk: true, supportsCurrency: true },
+        { code: '1', description: 'Commas, no sign, zero as .00/0', category: 'Standard', supportsAsterisk: true, supportsCurrency: true },
+        { code: '2', description: 'Commas, no sign, zero as blanks', category: 'Standard', supportsAsterisk: true, supportsCurrency: true },
+        { code: '3', description: 'No commas, no sign, zero as .00/0', category: 'Standard', supportsAsterisk: true, supportsCurrency: true },
+        { code: '4', description: 'No commas, no sign, zero as blanks', category: 'Standard', supportsAsterisk: true, supportsCurrency: true },
 
         // Credit codes (A-D) - show CR for negative
-        { code: 'A', description: 'Commas, decimals, CR for negative, zero as .00/0', category: 'Credit', supportsAsterisk: true, supportsCurrency: true },
-        { code: 'B', description: 'Commas, decimals, CR for negative, zero as blanks', category: 'Credit', supportsAsterisk: true, supportsCurrency: true },
-        { code: 'C', description: 'Commas, no decimals, CR for negative, zero as .00/0', category: 'Credit', supportsAsterisk: true, supportsCurrency: true },
-        { code: 'D', description: 'Commas, no decimals, CR for negative, zero as blanks', category: 'Credit', supportsAsterisk: true, supportsCurrency: true },
+        { code: 'A', description: 'Commas, CR for negative, zero as .00/0', category: 'Credit', supportsAsterisk: true, supportsCurrency: true },
+        { code: 'B', description: 'Commas, CR for negative, zero as blanks', category: 'Credit', supportsAsterisk: true, supportsCurrency: true },
+        { code: 'C', description: 'No commas, CR for negative, zero as .00/0', category: 'Credit', supportsAsterisk: true, supportsCurrency: true },
+        { code: 'D', description: 'No commas, CR for negative, zero as blanks', category: 'Credit', supportsAsterisk: true, supportsCurrency: true },
 
         // Minus codes (J-Q) - show - for negative
-        { code: 'J', description: 'Commas, decimals, minus for negative, zero as .00/0', category: 'Minus', supportsAsterisk: true, supportsCurrency: true },
-        { code: 'K', description: 'Commas, decimals, minus for negative, zero as blanks', category: 'Minus', supportsAsterisk: true, supportsCurrency: true },
-        { code: 'L', description: 'Commas, no decimals, minus for negative, zero as .00/0', category: 'Minus', supportsAsterisk: true, supportsCurrency: true },
-        { code: 'M', description: 'Commas, no decimals, minus for negative, zero as blanks', category: 'Minus', supportsAsterisk: true, supportsCurrency: true },
-        { code: 'N', description: 'Commas, decimals, leading minus, zero as .00/0', category: 'Minus', supportsAsterisk: true, supportsCurrency: true },
-        { code: 'O', description: 'Commas, decimals, leading minus, zero as blanks', category: 'Minus', supportsAsterisk: true, supportsCurrency: true },
-        { code: 'P', description: 'Commas, no decimals, leading minus, zero as .00/0', category: 'Minus', supportsAsterisk: true, supportsCurrency: true },
-        { code: 'Q', description: 'Commas, no decimals, leading minus, zero as blanks', category: 'Minus', supportsAsterisk: true, supportsCurrency: true },
+        { code: 'J', description: 'Commas, minus for negative, zero as .00/0', category: 'Minus', supportsAsterisk: true, supportsCurrency: true },
+        { code: 'K', description: 'Commas, minus for negative, zero as blanks', category: 'Minus', supportsAsterisk: true, supportsCurrency: true },
+        { code: 'L', description: 'No commas, minus for negative, zero as .00/0', category: 'Minus', supportsAsterisk: true, supportsCurrency: true },
+        { code: 'M', description: 'No commas, minus for negative, zero as blanks', category: 'Minus', supportsAsterisk: true, supportsCurrency: true },
+        { code: 'N', description: 'Commas, leading minus for negative, zero as .00/0', category: 'Minus', supportsAsterisk: true, supportsCurrency: true },
+        { code: 'O', description: 'Commas, leading minus for negative, zero as blanks', category: 'Minus', supportsAsterisk: true, supportsCurrency: true },
+        { code: 'P', description: 'No commas, leading minus for negative, zero as .00/0', category: 'Minus', supportsAsterisk: true, supportsCurrency: true },
+        { code: 'Q', description: 'No commas, leading minus for negative, zero as blanks', category: 'Minus', supportsAsterisk: true, supportsCurrency: true },
 
         // Special codes
         { code: 'W', description: 'Date format with slashes, suppresses leftmost zeros', category: 'Special', supportsAsterisk: false, supportsCurrency: false },

--- a/src/dspf-edit.parser/dspf-edit.parser.ts
+++ b/src/dspf-edit.parser/dspf-edit.parser.ts
@@ -468,7 +468,13 @@ function parseFieldElement(
 ) {
     const type = trimmedLine[29];
     const length = Number(trimmedLine.substring(24, 29).trim()) || FIXED_LENGTH_BY_TYPE[type] || 0;
-    const decimals = trimmedLine.substring(30, 32) !== ' ' ? Number(trimmedLine.substring(30, 32).trim()) : 0;
+    // A truly blank decimal-positions column (vs. an explicit "0") is kept as `undefined`, not
+    // coerced to 0 — with a blank Type column too, that blank/non-blank distinction is exactly
+    // what tells a plain zoned-numeric field (Type blank, decimals given, even 0) apart from a
+    // plain alphanumeric one (Type blank, decimals also blank). See isNumeric in
+    // dspf-edit.record-preview-panel.ts and isNumericField in dspf-edit.add-editing-keywords.ts.
+    const decimalsRaw = trimmedLine.substring(30, 32).trim();
+    const decimals = decimalsRaw !== '' ? Number(decimalsRaw) : undefined;
     const usage = trimmedLine[32] !== ' ' ? trimmedLine[32] : ' ';
     const isHidden = trimmedLine[32] === 'H';
     const isReferenced = trimmedLine[23] === 'R';

--- a/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
@@ -109,22 +109,26 @@ const FIELD_USAGE_PLACEHOLDER: Record<'alpha' | 'numeric', Record<string, string
  * (O=output, B=both, I=input), matching the classic screen-design-aid convention.
  * Falls back to the field name if the usage code isn't one of O/B/I.
  * @param name - Field name (used as a fallback label, and to detect a system keyword field)
- * @param type - DDS data type code; blank (DDS's own default when no decimals are given) or 'A'
- * is alphanumeric, anything else (Y, S, L, T, Z, ...) is treated as numeric
+ * @param type - DDS data type code; 'A' is always alphanumeric, anything else non-blank (Y, S, L,
+ * T, Z, ...) is always numeric. A blank Type is DDS's own default and is ambiguous on its own —
+ * it's alphanumeric only when the decimal-positions column is also blank; a blank Type with
+ * decimal positions given (even 0) is a plain zoned-numeric field, so `decimals` disambiguates it.
  * @param usage - DDS usage code (O, B, I, H, ...)
  * @param length - Field length, i.e. how many placeholder characters to repeat
  * @param editWordMask - The field's EDTWRD() mask text, if any (e.g. '   .  ') — when present, its
  * blanks are filled with the placeholder character instead of just repeating it for `length`, so
  * an edited numeric field previews with its decimal point (or other insert characters) in place.
+ * @param decimals - The field's decimal positions as parsed from the source, `undefined` when that
+ * column was left blank — only consulted when `type` is blank (see above)
  */
-function getFieldPlaceholderText(name: string, type: string | undefined, usage: string | undefined, length: number, editWordMask?: string | null): string {
+function getFieldPlaceholderText(name: string, type: string | undefined, usage: string | undefined, length: number, editWordMask?: string | null, decimals?: number): string {
     const systemPlaceholder = SYSTEM_FIELD_PLACEHOLDER[name.trim().toUpperCase()];
     if (systemPlaceholder) {
         return systemPlaceholder;
     };
 
     const trimmedType = (type || '').trim();
-    const isNumeric = trimmedType !== '' && trimmedType !== 'A';
+    const isNumeric = trimmedType !== '' ? trimmedType !== 'A' : decimals !== undefined;
     // A blank usage column means Output — DDS's own default (see generateNewFieldLine, which
     // leaves it blank for that same reason) — not "no usage code".
     const usageCode = (usage || '').trim().toUpperCase() || 'O';
@@ -156,23 +160,32 @@ function getEditWordMask(attributes: AttributeWithIndicators[] | undefined): str
 
 /**
  * The standard DDS numeric edit codes: whether each inserts thousands commas, and what (if any)
- * sign indicator it reserves trailing room for. Every edit code always inserts a decimal point
- * when the field has decimals and suppresses leading zeros — irrelevant to a generic placeholder
- * preview (there's no real value to format), which only needs the extra display width/characters.
+ * sign indicator it reserves room for. Every edit code always inserts a decimal point when the
+ * field has decimals and suppresses leading zeros — irrelevant to a generic placeholder preview
+ * (there's no real value to format), which only needs the extra display width/characters.
+ * The DDS reference's own edit-code summary table (Table 6) shows N/O/P/Q as identical to
+ * J/K/L/M in every column, including sign — but that table doesn't capture sign *position*, and
+ * real STRSDA shows they differ there: J/K/L/M reserve the minus sign trailing (after the last
+ * digit), N/O/P/Q reserve it leading (before the first digit) — confirmed against a real STRSDA
+ * screenshot, not just the manual (see the mirror-STRSDA project guidance).
  */
-const EDIT_CODE_INFO: Record<string, { comma: boolean; sign: '' | '-' | 'CR' }> = {
+const EDIT_CODE_INFO: Record<string, { comma: boolean; sign: '' | '-' | 'CR'; signLeading?: boolean }> = {
     '1': { comma: true, sign: '' },
-    '2': { comma: false, sign: '' },
-    '3': { comma: true, sign: '' },
+    '2': { comma: true, sign: '' },
+    '3': { comma: false, sign: '' },
     '4': { comma: false, sign: '' },
     A: { comma: true, sign: 'CR' },
-    B: { comma: false, sign: 'CR' },
-    C: { comma: true, sign: 'CR' },
+    B: { comma: true, sign: 'CR' },
+    C: { comma: false, sign: 'CR' },
     D: { comma: false, sign: 'CR' },
     J: { comma: true, sign: '-' },
-    K: { comma: false, sign: '-' },
-    L: { comma: true, sign: '-' },
-    M: { comma: false, sign: '-' }
+    K: { comma: true, sign: '-' },
+    L: { comma: false, sign: '-' },
+    M: { comma: false, sign: '-' },
+    N: { comma: true, sign: '-', signLeading: true },
+    O: { comma: true, sign: '-', signLeading: true },
+    P: { comma: false, sign: '-', signLeading: true },
+    Q: { comma: false, sign: '-', signLeading: true }
 };
 
 /**
@@ -186,7 +199,7 @@ function getEditCode(attributes: AttributeWithIndicators[] | undefined): string 
         return null;
     };
 
-    return attr.value.match(/^EDTCDE\(\s*([1-4A-DJ-M])/i)?.[1]?.toUpperCase() ?? null;
+    return attr.value.match(/^EDTCDE\(\s*([1-4A-DJ-Q])/i)?.[1]?.toUpperCase() ?? null;
 };
 
 /**
@@ -195,7 +208,7 @@ function getEditCode(attributes: AttributeWithIndicators[] | undefined): string 
  * width (commas, decimal point, sign) SDA/RDi reserve when previewing an edited numeric field.
  * @param length - The field's digit length
  * @param decimals - The field's decimal positions
- * @param code - The EDTCDE code (1-4, A-D, J-M)
+ * @param code - The EDTCDE code (1-4, A-D, J-Q)
  */
 function getEditCodeMask(length: number, decimals: number, code: string): string | null {
     const info = EDIT_CODE_INFO[code];
@@ -215,7 +228,7 @@ function getEditCodeMask(length: number, decimals: number, code: string): string
     if (decimals > 0) {
         mask += '.' + ' '.repeat(decimals);
     };
-    mask += info.sign;
+    mask = info.signLeading ? info.sign + mask : mask + info.sign;
 
     return mask;
 };
@@ -1177,11 +1190,12 @@ export class RecordPreviewPanel {
                 // per insert character (its decimal point, thousands commas, sign...), which
                 // text.length already reflects.
                 const effectiveLength = resolvedRef?.length ?? field.length;
-                const effectiveDecimals = resolvedRef?.decimals ?? field.decimals ?? 0;
+                const rawDecimals = resolvedRef?.decimals ?? field.decimals;
+                const effectiveDecimals = rawDecimals ?? 0;
                 const editingMask = getEditingMask(activeAttrs, effectiveLength, effectiveDecimals);
                 const text = isReferenced
                     ? getFieldPlaceholderText(field.name, field.type, field.usage, 1)
-                    : getFieldPlaceholderText(field.name, resolvedRef?.type ?? field.type, field.usage, effectiveLength, editingMask);
+                    : getFieldPlaceholderText(field.name, resolvedRef?.type ?? field.type, field.usage, effectiveLength, editingMask, rawDecimals);
                 const color = isReferenced || (field.referenced && activeAttrs.length === 0)
                     ? getReferencedFieldColor()
                     : getDisplayColor(activeAttrs, hasDisplayAttribute(activeAttrs, 'HI'));


### PR DESCRIPTION
## [1.1.1] - 2026-08-28
### Fixed
- Preview: the `EDTCDE` thousands-separator table had commas alternating per individual code instead of per pair (1&2, A&B, J&K, N&O should show separators; 3&4, C&D, L&M, P&Q should not) — `EDTCDE(K)` (and 2/3/B/C/L/P) rendered with no thousands separator at all. (Issue #77)
- Preview: `EDTCDE(N/O/P/Q)` weren't recognized at all, so no decimal point/comma/sign width was reserved for them. Now supported, with the minus sign correctly reserved leading (before the first digit), unlike J/K/L/M which reserve it trailing — confirmed against real STRSDA.
- Preview and Add Editing Keywords: a numeric field with a blank Type column (position 35) — the default, most common way to define a plain zoned-numeric field, without an explicit type letter — was misdetected as alphanumeric, showing letter placeholders instead of digit ones, and could be blocked from getting an edit code/word.
- Add Editing Keywords: the `EDTCDE` picker's descriptions mislabeled the comma/no-comma distinction between paired codes as a decimals/no-decimals distinction.
