### PR TITLE
v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
+## [1.2.0] - 2026-08-31
+### Added
+- Preview: the decimal point and thousands-separator convention used for `EDTCDE()`-edited numeric fields is now configurable — US (`1,000.00`, the previous fixed behavior) or European (`1.000,00`) — from a new "Decimal Format" section in the "⚙ Configuration" panel. A "Fetch from IBM i" button reads it straight from the connected IBM i's `QDECFMT` system value (both `1` and `J` map to European); a "Reset to Default" button restores US. Saved in the extension's own storage, applying immediately to any open preview panel.
+### Fixed
+- Preview: a numeric field with no `EDTCDE`/`EDTWRD` (blank Type with decimal positions given, or explicit type `S`) didn't reserve the extra trailing position IBM i itself adds for the sign on an input-capable signed-numeric field — e.g. a 1,0 field showed as a single digit instead of digit + `-`, confirmed against real STRSDA. Input-capable `Y`/`N` fields with decimal positions now correctly get an extra position for the decimal point instead (never a sign); output-only fields are unaffected, matching the DDS reference.
+
 ## [1.1.1] - 2026-08-28
 ### Fixed
 - Preview: the `EDTCDE` thousands-separator table had commas alternating per individual code instead of per pair (1&2, A&B, J&K, N&O should show separators; 3&4, C&D, L&M, P&Q should not) — `EDTCDE(K)` (and 2/3/B/C/L/P) rendered with no thousands separator at all. (Issue #77)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ DSPF-edit doesn't replace your compiler — it closes the gap between writing DD
   - Stays in sync with the schema tree selection in both directions.
   - "Focus" maximizes the preview so it fills the editing area, hiding the DDS source editor beside it; "Show code" brings the source back.
   - Select a field or constant (or several, with Ctrl/Cmd+click) to get a "⋮ Actions" menu: add color/attribute, copy, or delete — applied to every selected element at once for a multi-selection (no per-element indicator prompts in that case).
+  - The decimal point and thousands-separator convention used to preview `EDTCDE()`-edited numeric fields — US or European — is configurable from the "⚙ Configuration" panel, either picked manually or fetched with one click from the connected IBM i's `QDECFMT` system value.
 
 ### 🧭 Schema navigation
   - Two levels are shown: **File** and **Records**.
@@ -145,11 +146,9 @@ No known blocking issues right now. Please [open an issue](https://github.com/ch
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**1.1.1** - 2026-08-28
-- Fixed: Preview `EDTCDE` thousands-separator table had commas alternating per individual code instead of per pair — `EDTCDE(K)` (and 2/3/B/C/L/P) rendered with no thousands separator at all.
-- Fixed: Preview `EDTCDE(N/O/P/Q)` weren't recognized at all; now supported, with the minus sign correctly reserved leading rather than trailing like J/K/L/M.
-- Fixed: a numeric field with a blank Type column (the default way to define a plain zoned-numeric field) was misdetected as alphanumeric in the preview and in Add Editing Keywords.
-- Fixed: the `EDTCDE` picker's descriptions mislabeled the comma/no-comma distinction as decimals/no-decimals.
+**1.2.0** - 2026-08-31
+- Added: Preview's decimal point/thousands-separator convention for `EDTCDE()`-edited numeric fields (US/European) is now configurable from the "⚙ Configuration" panel, with a one-click "Fetch from IBM i" (reads the connected system's `QDECFMT` value) and a "Reset to Default" button.
+- Fixed: an unedited numeric field (no `EDTCDE`/`EDTWRD`) didn't reserve the extra trailing position IBM i adds for the sign on an input-capable signed-numeric field — e.g. a 1,0 field showed as a single digit instead of digit + `-`, confirmed against real STRSDA.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dspf-edit",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dspf-edit",
-      "version": "1.1.1",
+      "version": "1.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"

--- a/src/dspf-edit.ibmi/dspf-edit.ibmi-integration.ts
+++ b/src/dspf-edit.ibmi/dspf-edit.ibmi-integration.ts
@@ -6,6 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsAttribute, DdsElement, DdsField, attributesFileLevel } from '../dspf-edit.model/dspf-edit.model';
+import { DecimalFormat } from '../dspf-edit.utils/dspf-edit.decimal-format';
 
 /**
  * Isolated from the rest of the extension on purpose: this is the only file that knows about the
@@ -195,4 +196,39 @@ export async function resolveReferencedField(documentUri: string, field: DdsFiel
     const resolved = mapSqlTypeToDds(String(row.DATA_TYPE), Number(row.LENGTH), Number(row.NUMERIC_SCALE ?? 0));
     setResolvedRef(documentUri, field.recordname, field.name, resolved);
     return resolved;
+};
+
+/**
+ * Maps the IBM i QDECFMT system value's raw character to the extension's DecimalFormat: '0' (the
+ * default) uses a period decimal point and comma thousands separator; '1' and 'J' both use a comma
+ * decimal point and period thousands separator — per the DDS reference's own Table 6 (footnote 1),
+ * 'J' only differs from '1' in its zero-suppression style for a zero-balance value, which this
+ * placeholder-based preview doesn't simulate, so both map to 'European' here.
+ */
+const QDECFMT_TO_DECIMAL_FORMAT: Record<string, DecimalFormat> = {
+    '0': 'US',
+    '1': 'European',
+    J: 'European'
+};
+
+/**
+ * Reads the connected IBM i's QDECFMT system value and maps it to the extension's decimal format.
+ * Throws (no connection, unrecognized value) rather than returning a sentinel — callers show it to
+ * the user.
+ */
+export async function resolveDecimalFormatFromSystem(): Promise<DecimalFormat> {
+    const connection = getIBMiConnection();
+    if (!connection) {
+        throw new Error('No active IBM i connection. Connect via the Code for i extension first.');
+    };
+
+    const rows = await connection.runSQL(
+        `SELECT CURRENT_CHARACTER_VALUE FROM QSYS2.SYSTEM_VALUE_INFO WHERE SYSTEM_VALUE_NAME = 'QDECFMT'`
+    );
+    const raw = String(rows[0]?.CURRENT_CHARACTER_VALUE ?? '').trim().toUpperCase();
+    const mapped = QDECFMT_TO_DECIMAL_FORMAT[raw];
+    if (!mapped) {
+        throw new Error(`Unrecognized QDECFMT value '${raw}' on the connected IBM i.`);
+    };
+    return mapped;
 };

--- a/src/dspf-edit.utils/dspf-edit.decimal-format.ts
+++ b/src/dspf-edit.utils/dspf-edit.decimal-format.ts
@@ -1,0 +1,78 @@
+/*
+    Christian Larsen, 2026
+    "RPG structure"
+    utils/dspf-edit.decimal-format.ts
+*/
+
+import { ExtensionState } from '../dspf-edit.states/state';
+
+/** The decimal/thousands-separator convention the preview renders EDTCDE()-edited numeric masks with. */
+export type DecimalFormat = 'US' | 'European';
+
+/** Separator characters for a decimal format, as used when building an EDTCDE mask. */
+export interface DecimalFormatSeparators {
+    thousands: string;
+    decimal: string;
+};
+
+/** One selectable decimal format, for the configuration panel. */
+export interface DecimalFormatOption {
+    value: DecimalFormat;
+    label: string;
+    example: string;
+    separators: DecimalFormatSeparators;
+};
+
+/**
+ * The two decimal formats the preview supports — matching the two distinct character conventions
+ * the IBM i QDECFMT system value can produce (see resolveDecimalFormatFromSystem in
+ * dspf-edit.ibmi-integration.ts): '0' (US) and '1'/'J' (European). QDECFMT '1' and 'J' use the same
+ * decimal-point/thousands-separator characters — per the DDS reference's own Table 6, footnote 1,
+ * 'J' only differs from '1' in its zero-suppression style for a zero-balance value (kept as a
+ * literal '0' instead of blanked out), which this placeholder-based preview doesn't simulate since
+ * there's no real value being formatted — so both map to 'European' here.
+ */
+export const DECIMAL_FORMAT_OPTIONS: DecimalFormatOption[] = [
+    { value: 'US', label: 'US (QDECFMT 0)', example: '1,000.00', separators: { thousands: ',', decimal: '.' } },
+    { value: 'European', label: 'European (QDECFMT 1 or J)', example: '1.000,00', separators: { thousands: '.', decimal: ',' } }
+];
+
+const STORAGE_KEY = 'dspf-edit.decimalFormat';
+
+/** The decimal format used until the user picks or fetches their own — matches QDECFMT's own default ('0'). */
+export const DEFAULT_DECIMAL_FORMAT: DecimalFormat = 'US';
+
+/**
+ * Reads the configured decimal format — stored in the extension's own global storage
+ * (`ExtensionContext.globalState`), not a VS Code setting, same as the preview colors (see
+ * dspf-edit.preview-colors.ts). Falls back to the default when unset or not a recognized value.
+ */
+export function getDecimalFormat(): DecimalFormat {
+    const value = ExtensionState.context.globalState.get<DecimalFormat>(STORAGE_KEY);
+    return DECIMAL_FORMAT_OPTIONS.some(opt => opt.value === value) ? value! : DEFAULT_DECIMAL_FORMAT;
+};
+
+/** The thousands/decimal separator characters for the currently configured decimal format. */
+export function getDecimalSeparators(): DecimalFormatSeparators {
+    return DECIMAL_FORMAT_OPTIONS.find(opt => opt.value === getDecimalFormat())!.separators;
+};
+
+/**
+ * Saves the decimal format, in the extension's own global storage.
+ * @param value - The new decimal format
+ */
+export async function setDecimalFormat(value: DecimalFormat): Promise<void> {
+    await ExtensionState.context.globalState.update(STORAGE_KEY, value);
+};
+
+/**
+ * Resets the decimal format to its default (US).
+ * @returns Whether it actually changed (false if already at default)
+ */
+export async function resetDecimalFormat(): Promise<boolean> {
+    if (getDecimalFormat() === DEFAULT_DECIMAL_FORMAT) {
+        return false;
+    };
+    await ExtensionState.context.globalState.update(STORAGE_KEY, undefined);
+    return true;
+};

--- a/src/dspf-edit.webview/dspf-edit.preview-colors-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.preview-colors-panel.ts
@@ -6,13 +6,18 @@
 
 import * as vscode from 'vscode';
 import { PREVIEW_COLOR_SETTINGS, readColorSetting, resetPreviewColors, setPreviewColor } from '../dspf-edit.utils/dspf-edit.preview-colors';
+import { DECIMAL_FORMAT_OPTIONS, DecimalFormat, getDecimalFormat, resetDecimalFormat, setDecimalFormat } from '../dspf-edit.utils/dspf-edit.decimal-format';
+import { resolveDecimalFormatFromSystem } from '../dspf-edit.ibmi/dspf-edit.ibmi-integration';
 import { RecordPreviewPanel } from './dspf-edit.record-preview-panel';
 
 /**
- * Small webview panel to pick the record preview's colors visually — a native OS/browser color
- * picker per swatch (`<input type="color">`) instead of typing hex codes by hand. Reads and
- * writes straight to the extension's own stored preview colors (see
- * dspf-edit.utils/dspf-edit.preview-colors.ts), so there's no separate state of its own: closing
+ * The extension's "⚙ Configuration" webview panel. Lets the user pick the record preview's colors
+ * visually — a native OS/browser color picker per swatch (`<input type="color">`) instead of
+ * typing hex codes by hand — and choose the decimal/thousands-separator convention (US/European)
+ * used when previewing EDTCDE()-edited numeric fields, either manually or fetched from the
+ * connected IBM i's QDECFMT system value. Reads and writes straight to the extension's own
+ * stored settings (see dspf-edit.utils/dspf-edit.preview-colors.ts and
+ * dspf-edit.utils/dspf-edit.decimal-format.ts), so there's no separate state of its own: closing
  * this panel loses nothing, since every change was already saved the moment it was made — and it
  * pushes each change straight to an open record preview panel, if any.
  */
@@ -55,6 +60,19 @@ export class PreviewColorsPanel {
         this.panel.webview.html = this.getHtml();
     };
 
+    /**
+     * Tells the already-open panel's own script which decimal format radio should be checked.
+     * Deliberately not done via `refresh()` (reassigning `webview.html`): VS Code skips the reload
+     * when the new html string is byte-identical to what's already loaded — which happens here
+     * whenever the resulting format matches whatever was baked into the panel's last real reload
+     * (e.g. picking a format by hand, with no intervening reload, then resetting back to the
+     * default already shown at panel-open time) — leaving the manually-picked radio visibly
+     * checked despite the setting having actually changed underneath it.
+     */
+    private updateDecimalFormatRadio(): void {
+        this.panel.webview.postMessage({ type: 'updateDecimalFormat', value: getDecimalFormat() });
+    };
+
     private async onDidReceiveMessage(message: any): Promise<void> {
         switch (message?.type) {
             case 'setColor':
@@ -71,6 +89,32 @@ export class PreviewColorsPanel {
                 this.refresh();
                 RecordPreviewPanel.refreshTheme();
                 break;
+            case 'setDecimalFormat':
+                await setDecimalFormat(message.value as DecimalFormat);
+                RecordPreviewPanel.refreshTheme();
+                break;
+            case 'resetDecimalFormat': {
+                const changed = await resetDecimalFormat();
+                this.updateDecimalFormatRadio();
+                RecordPreviewPanel.refreshTheme();
+                vscode.window.showInformationMessage(
+                    changed
+                        ? 'DSPF Edit: decimal format reset to default (US).'
+                        : 'DSPF Edit: decimal format was already at its default (US).'
+                );
+                break;
+            };
+            case 'fetchDecimalFormatFromIBMi':
+                try {
+                    const format = await resolveDecimalFormatFromSystem();
+                    await setDecimalFormat(format);
+                    this.updateDecimalFormatRadio();
+                    RecordPreviewPanel.refreshTheme();
+                    vscode.window.showInformationMessage(`DSPF Edit: decimal format set to '${format}' from the connected IBM i (QDECFMT).`);
+                } catch (error) {
+                    vscode.window.showErrorMessage(error instanceof Error ? error.message : 'Could not read QDECFMT from the connected IBM i.');
+                };
+                break;
         };
     };
 
@@ -85,6 +129,15 @@ export class PreviewColorsPanel {
         <button class="reset" data-key="${setting.key}" title="Reset to default">↺</button>
     </div>`;
         }).join('');
+
+        const currentDecimalFormat = getDecimalFormat();
+        const decimalFormatRows = DECIMAL_FORMAT_OPTIONS.map(opt => `
+    <div class="row">
+        <label class="radio-label">
+            <input type="radio" name="decimalFormat" value="${opt.value}" ${opt.value === currentDecimalFormat ? 'checked' : ''}>
+            ${opt.label} — <span class="hex">${opt.example}</span>
+        </label>
+    </div>`).join('');
 
         return `<!DOCTYPE html>
 <html lang="en">
@@ -143,7 +196,7 @@ export class PreviewColorsPanel {
     button.reset:hover {
         background: var(--vscode-toolbar-hoverBackground, rgba(128, 128, 128, 0.2));
     }
-    #resetAll {
+    .btn-secondary {
         margin-top: 16px;
         background: var(--vscode-button-secondaryBackground, transparent);
         color: var(--vscode-button-secondaryForeground, inherit);
@@ -153,8 +206,21 @@ export class PreviewColorsPanel {
         cursor: pointer;
         font-size: 12px;
     }
-    #resetAll:hover {
+    .btn-secondary:hover {
         background: var(--vscode-button-secondaryHoverBackground, rgba(128, 128, 128, 0.2));
+    }
+    .radio-label {
+        flex: 1;
+        font-size: 13px;
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        gap: 6px;
+    }
+    hr.section {
+        border: none;
+        border-top: 1px solid var(--vscode-input-border, #555555);
+        margin: 20px 0;
     }
 </style>
 </head>
@@ -162,7 +228,17 @@ export class PreviewColorsPanel {
 <h2>Preview Colors</h2>
 <p class="hint">Changes save immediately and apply to any open preview panel.</p>
 ${rows}
-<button id="resetAll">Reset All to Default</button>
+<button id="resetAll" class="btn-secondary">Reset All to Default</button>
+
+<hr class="section">
+
+<h2>Decimal Format</h2>
+<p class="hint">Decimal point and thousands separator used when previewing EDTCDE()-edited numeric fields.</p>
+${decimalFormatRows}
+<div class="row" style="gap: 8px; margin-top: 8px;">
+    <button id="fetchDecimalFormat" class="btn-secondary" style="margin-top: 0;">Fetch from IBM i</button>
+    <button id="resetDecimalFormat" class="btn-secondary" style="margin-top: 0;">Reset to Default</button>
+</div>
 <script>
     const vscode = acquireVsCodeApi();
 
@@ -187,6 +263,31 @@ ${rows}
 
     document.getElementById('resetAll').addEventListener('click', () => {
         vscode.postMessage({ type: 'resetAll' });
+    });
+
+    document.querySelectorAll('input[name="decimalFormat"]').forEach(input => {
+        input.addEventListener('change', () => {
+            vscode.postMessage({ type: 'setDecimalFormat', value: input.value });
+        });
+    });
+
+    document.getElementById('fetchDecimalFormat').addEventListener('click', () => {
+        vscode.postMessage({ type: 'fetchDecimalFormatFromIBMi' });
+    });
+
+    document.getElementById('resetDecimalFormat').addEventListener('click', () => {
+        vscode.postMessage({ type: 'resetDecimalFormat' });
+    });
+
+    // Reset/Fetch don't reload the panel's html (see updateDecimalFormatRadio's comment on the
+    // extension side for why) — they instead send this message so the already-live radios get
+    // updated directly, without depending on a reload happening at all.
+    window.addEventListener('message', event => {
+        if (event.data?.type === 'updateDecimalFormat') {
+            document.querySelectorAll('input[name="decimalFormat"]').forEach(input => {
+                input.checked = input.value === event.data.value;
+            });
+        };
     });
 </script>
 </body>

--- a/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import { FieldsPerRecord, DdsSize, DdsAttribute, AttributeWithIndicators, DdsIndicator, fieldsPerRecords, attributesFileLevel, records, getDefaultSize, getAvailableDisplayFormats, getSizeForFormat, SYSTEM_FIELD_PLACEHOLDER, groupIndicatorsByCondition } from '../dspf-edit.model/dspf-edit.model';
 import { checkForEditorAndDocument, updateTreeProvider, applyWorkspaceEdit, applyDisplayFormatSplitEdit } from '../dspf-edit.utils/dspf-edit.helper';
 import { getBackgroundColor, getDdsColorMap, getReferencedFieldColor } from '../dspf-edit.utils/dspf-edit.preview-colors';
+import { getDecimalSeparators } from '../dspf-edit.utils/dspf-edit.decimal-format';
 import { DdsTreeProvider, DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { ExtensionState } from '../dspf-edit.states/state';
 import { getResolvedRef } from '../dspf-edit.ibmi/dspf-edit.ibmi-integration';
@@ -105,6 +106,19 @@ const FIELD_USAGE_PLACEHOLDER: Record<'alpha' | 'numeric', Record<string, string
 };
 
 /**
+ * Whether a field is numeric, per DDS's own Type/decimal-positions default rules: 'A' is always
+ * alphanumeric, anything else non-blank (Y, S, L, T, Z, ...) is always numeric. A blank Type is
+ * ambiguous on its own — it's alphanumeric only when the decimal-positions column is also blank; a
+ * blank Type with decimal positions given (even 0) is a plain zoned-numeric field.
+ * @param type - DDS data type code (position 35), possibly blank
+ * @param rawDecimals - The field's decimal positions as parsed, `undefined` when left blank
+ */
+function isNumericFieldType(type: string | undefined, rawDecimals: number | undefined): boolean {
+    const trimmedType = (type || '').trim();
+    return trimmedType !== '' ? trimmedType !== 'A' : rawDecimals !== undefined;
+};
+
+/**
  * Builds the placeholder text shown across a field's width, based on its data type and usage
  * (O=output, B=both, I=input), matching the classic screen-design-aid convention.
  * Falls back to the field name if the usage code isn't one of O/B/I.
@@ -127,8 +141,7 @@ function getFieldPlaceholderText(name: string, type: string | undefined, usage: 
         return systemPlaceholder;
     };
 
-    const trimmedType = (type || '').trim();
-    const isNumeric = trimmedType !== '' ? trimmedType !== 'A' : decimals !== undefined;
+    const isNumeric = isNumericFieldType(type, decimals);
     // A blank usage column means Output — DDS's own default (see generateNewFieldLine, which
     // leaves it blank for that same reason) — not "no usage code".
     const usageCode = (usage || '').trim().toUpperCase() || 'O';
@@ -159,10 +172,13 @@ function getEditWordMask(attributes: AttributeWithIndicators[] | undefined): str
 };
 
 /**
- * The standard DDS numeric edit codes: whether each inserts thousands commas, and what (if any)
- * sign indicator it reserves room for. Every edit code always inserts a decimal point when the
- * field has decimals and suppresses leading zeros — irrelevant to a generic placeholder preview
- * (there's no real value to format), which only needs the extra display width/characters.
+ * The standard DDS numeric edit codes: whether each inserts a thousands separator, and what (if
+ * any) sign indicator it reserves room for. The separator/decimal-point characters themselves come
+ * from the user's configured decimal format (see dspf-edit.utils/dspf-edit.decimal-format.ts,
+ * driven by the IBM i's QDECFMT system value), not hardcoded here. Every edit code always inserts a
+ * decimal point when the field has decimals and suppresses leading zeros — irrelevant to a generic
+ * placeholder preview (there's no real value to format), which only needs the extra display
+ * width/characters.
  * The DDS reference's own edit-code summary table (Table 6) shows N/O/P/Q as identical to
  * J/K/L/M in every column, including sign — but that table doesn't capture sign *position*, and
  * real STRSDA shows they differ there: J/K/L/M reserve the minus sign trailing (after the last
@@ -216,17 +232,18 @@ function getEditCodeMask(length: number, decimals: number, code: string): string
         return null;
     };
 
+    const { thousands, decimal } = getDecimalSeparators();
     const intDigits = Math.max(length - decimals, 1);
     let mask = '';
     for (let i = 0; i < intDigits; i++) {
         const remaining = intDigits - i;
         if (info.comma && i > 0 && remaining % 3 === 0) {
-            mask += ',';
+            mask += thousands;
         };
         mask += ' ';
     };
     if (decimals > 0) {
-        mask += '.' + ' '.repeat(decimals);
+        mask += decimal + ' '.repeat(decimals);
     };
     mask = info.signLeading ? info.sign + mask : mask + info.sign;
 
@@ -234,21 +251,71 @@ function getEditCodeMask(length: number, decimals: number, code: string): string
 };
 
 /**
- * Resolves the EDTWRD/EDTCDE mask that determines an edited numeric field's placeholder text and
- * extra display width — EDTWRD (an explicit mask) takes precedence since DDS doesn't allow both on
- * the same field.
+ * Determines the extra width IBM i itself reserves for an *unedited* numeric field (no EDTCDE/
+ * EDTWRD) — confirmed against real STRSDA and the DDS reference's own "Default (blank)" and
+ * per-keyboard-shift display-length rules:
+ * - Blank Type with decimal positions given (even 0) defaults to signed numeric (S) when no editing
+ *   keyword is present (an editing keyword would instead default it to numeric-only (Y), but then
+ *   `editingMask` wouldn't be null and this function wouldn't run).
+ * - An input-capable (I/B) signed numeric (S) field always reserves one extra trailing position for
+ *   a minus sign, regardless of decimal positions — and never shows a decimal point on screen (the
+ *   manual is explicit that IBM i performs no decimal alignment for S fields).
+ * - An input-capable numeric-only (Y) or numeric-shift (N) field instead reserves one extra position
+ *   for the decimal point, but only when it actually has decimal positions — no sign position at all.
+ * - An output-only field never gets an extra position, whatever its shift.
+ * @param type - DDS data type code (position 35), possibly blank
+ * @param usage - DDS usage code (O, B, I, H, ...)
+ * @param length - The field's digit length
+ * @param rawDecimals - The field's decimal positions as parsed, `undefined` when left blank
+ */
+function getUneditedNumericMask(type: string | undefined, usage: string | undefined, length: number, rawDecimals: number | undefined): string | null {
+    if (!isNumericFieldType(type, rawDecimals)) {
+        return null;
+    };
+
+    const usageCode = (usage || '').trim().toUpperCase() || 'O';
+    if (usageCode !== 'I' && usageCode !== 'B') {
+        return null;
+    };
+
+    const shift = (type || '').trim().toUpperCase() || 'S';
+    if (shift === 'S') {
+        return ' '.repeat(Math.max(length, 1)) + '-';
+    };
+
+    const decimals = rawDecimals ?? 0;
+    if ((shift === 'Y' || shift === 'N') && decimals > 0) {
+        const intDigits = Math.max(length - decimals, 1);
+        return ' '.repeat(intDigits) + getDecimalSeparators().decimal + ' '.repeat(decimals);
+    };
+
+    return null;
+};
+
+/**
+ * Resolves the mask that determines a numeric field's placeholder text and extra display width
+ * beyond its raw DDS length — an explicit EDTWRD (takes precedence, since DDS doesn't allow both on
+ * the same field), a standard EDTCDE code, or — when neither is present — the extra sign/decimal-
+ * point position IBM i itself reserves for an unedited numeric field (see getUneditedNumericMask).
  * @param attributes - The element's DDS attributes
+ * @param type - DDS data type code (position 35), possibly blank
+ * @param usage - DDS usage code (O, B, I, H, ...)
  * @param length - The field's digit length (post REFFLD resolution, if applicable)
  * @param decimals - The field's decimal positions (post REFFLD resolution, if applicable)
+ * @param rawDecimals - The field's decimal positions as parsed, `undefined` when left blank
  */
-function getEditingMask(attributes: AttributeWithIndicators[] | undefined, length: number, decimals: number): string | null {
+function getEditingMask(attributes: AttributeWithIndicators[] | undefined, type: string | undefined, usage: string | undefined, length: number, decimals: number, rawDecimals: number | undefined): string | null {
     const wordMask = getEditWordMask(attributes);
     if (wordMask) {
         return wordMask;
     };
 
     const code = getEditCode(attributes);
-    return code ? getEditCodeMask(length, decimals, code) : null;
+    if (code) {
+        return getEditCodeMask(length, decimals, code);
+    };
+
+    return getUneditedNumericMask(type, usage, length, rawDecimals);
 };
 
 /**
@@ -1192,10 +1259,11 @@ export class RecordPreviewPanel {
                 const effectiveLength = resolvedRef?.length ?? field.length;
                 const rawDecimals = resolvedRef?.decimals ?? field.decimals;
                 const effectiveDecimals = rawDecimals ?? 0;
-                const editingMask = getEditingMask(activeAttrs, effectiveLength, effectiveDecimals);
+                const effectiveType = resolvedRef?.type ?? field.type;
+                const editingMask = getEditingMask(activeAttrs, effectiveType, field.usage, effectiveLength, effectiveDecimals, rawDecimals);
                 const text = isReferenced
                     ? getFieldPlaceholderText(field.name, field.type, field.usage, 1)
-                    : getFieldPlaceholderText(field.name, resolvedRef?.type ?? field.type, field.usage, effectiveLength, editingMask, rawDecimals);
+                    : getFieldPlaceholderText(field.name, effectiveType, field.usage, effectiveLength, editingMask, rawDecimals);
                 const color = isReferenced || (field.referenced && activeAttrs.length === 0)
                     ? getReferencedFieldColor()
                     : getDisplayColor(activeAttrs, hasDisplayAttribute(activeAttrs, 'HI'));
@@ -1203,8 +1271,10 @@ export class RecordPreviewPanel {
                 // 1:1 back to its raw DDS length: not a referenced field (its length lives in the
                 // external database field, not this source), not a system keyword like DATE/USER
                 // (fixed width, no real length column), not carrying an editing mask (EDTCDE/EDTWRD
-                // widen the display for the decimal point/commas/sign beyond the raw length), and
-                // not PSHBTNFLD (DDS requires it to be exactly length 2 — resizing it would produce
+                // widen the display for the decimal point/commas/sign beyond the raw length, and an
+                // unedited signed-numeric/decimal-point-bearing field reserves its own extra
+                // sign/decimal position the same way — see getUneditedNumericMask), and not
+                // PSHBTNFLD (DDS requires it to be exactly length 2 — resizing it would produce
                 // uncompilable DDS).
                 const isSystemField = Boolean(SYSTEM_FIELD_PLACEHOLDER[field.name.trim().toUpperCase()]);
                 const isPushButtonField = activeAttrs.some(attr => /^PSHBTNFLD\b/i.test(attr.value));


### PR DESCRIPTION
## [1.2.0] - 2026-08-31
### Added
- Preview: the decimal point and thousands-separator convention used for `EDTCDE()`-edited numeric fields is now configurable — US (`1,000.00`, the previous fixed behavior) or European (`1.000,00`) — from a new "Decimal Format" section in the "⚙ Configuration" panel. A "Fetch from IBM i" button reads it straight from the connected IBM i's `QDECFMT` system value (both `1` and `J` map to European); a "Reset to Default" button restores US. Saved in the extension's own storage, applying immediately to any open preview panel.
### Fixed
- Preview: a numeric field with no `EDTCDE`/`EDTWRD` (blank Type with decimal positions given, or explicit type `S`) didn't reserve the extra trailing position IBM i itself adds for the sign on an input-capable signed-numeric field — e.g. a 1,0 field showed as a single digit instead of digit + `-`, confirmed against real STRSDA. Input-capable `Y`/`N` fields with decimal positions now correctly get an extra position for the decimal point instead (never a sign); output-only fields are unaffected, matching the DDS reference.
