### PR TITLE
v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
-## [1.3.0] - 2026-09-01
+## [1.3.0] - 2026-09-02
 ### Added
 - Preview: the "⋮ Actions" menu (single selection) now also offers Rename... (fields) / Edit Text... (constants), Indicators..., and — for fields — Validity Checks..., Editing Keywords..., and Error Messages..., delegating to the exact same tree commands (same prompts, validation, and confirmations as right-clicking the element in the tree). The preview now covers practically everything the tree's context menu offers for a single field or constant.
 - Preview: a resizable constant now also gets a second drag handle on its *left* edge, growing/shrinking its leading blank padding (moving its start column back to keep the visible text in place) instead of only the trailing padding on the right — down to column 1, or a window's own left content edge. Not offered for a constant inside a subfile record.
+- Add Editing Keywords: replaced with a single summary menu showing all three slots (EDTCDE/EDTWRD/EDTMSK) and their current value at a glance, each with its own set/change (✏️) and remove (🗑️) buttons — instead of the old "Replace/Remove, then pick a type" two-step flow. Picking EDTCDE/EDTWRD is now a flat, type-to-filter list (no more category separators). Changing an existing EDTWRD/EDTMSK pre-fills the input with its current value; starting a new EDTWRD pre-fills a blank template already sized to the field, satisfying the "N digit positions" rule from the start. Setting EDTCDE/EDTWRD automatically drops the other (they're mutually exclusive in DDS) while keeping any existing EDTMSK; removing the base takes its EDTMSK with it.
 
 ## [1.2.0] - 2026-08-31
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
+## [1.3.0] - 2026-09-01
+### Added
+- Preview: the "⋮ Actions" menu (single selection) now also offers Rename... (fields) / Edit Text... (constants), Indicators..., and — for fields — Validity Checks..., Editing Keywords..., and Error Messages..., delegating to the exact same tree commands (same prompts, validation, and confirmations as right-clicking the element in the tree). The preview now covers practically everything the tree's context menu offers for a single field or constant.
+- Preview: a resizable constant now also gets a second drag handle on its *left* edge, growing/shrinking its leading blank padding (moving its start column back to keep the visible text in place) instead of only the trailing padding on the right — down to column 1, or a window's own left content edge. Not offered for a constant inside a subfile record.
+
 ## [1.2.0] - 2026-08-31
 ### Added
 - Preview: the decimal point and thousands-separator convention used for `EDTCDE()`-edited numeric fields is now configurable — US (`1,000.00`, the previous fixed behavior) or European (`1.000,00`) — from a new "Decimal Format" section in the "⚙ Configuration" panel. A "Fetch from IBM i" button reads it straight from the connected IBM i's `QDECFMT` system value (both `1` and `J` map to European); a "Reset to Default" button restores US. Saved in the extension's own storage, applying immediately to any open preview panel.

--- a/README.md
+++ b/README.md
@@ -146,9 +146,10 @@ No known blocking issues right now. Please [open an issue](https://github.com/ch
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**1.3.0** - 2026-09-01
+**1.3.0** - 2026-09-02
 - Added: Preview's "⋮ Actions" menu (single selection) now also offers Rename.../Edit Text..., Indicators..., and — for fields — Validity Checks..., Editing Keywords..., and Error Messages..., the same commands the tree's context menu offers.
 - Added: a resizable constant now also gets a left-edge drag handle, growing/shrinking its leading blank padding instead of only the trailing one on the right, down to column 1 (or a window's own left edge).
+- Added: Add Editing Keywords now shows a single summary menu with EDTCDE/EDTWRD/EDTMSK and their current values, each with its own set/change and remove buttons, instead of a multi-step "Replace/Remove, then pick a type" wizard.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ DSPF-edit doesn't replace your compiler — it closes the gap between writing DD
   - The "Indicators" toggle and the selected display format persist when switching which record is previewed in the same panel.
   - Stays in sync with the schema tree selection in both directions.
   - "Focus" maximizes the preview so it fills the editing area, hiding the DDS source editor beside it; "Show code" brings the source back.
-  - Select a field or constant (or several, with Ctrl/Cmd+click) to get a "⋮ Actions" menu: add color/attribute, copy, or delete — applied to every selected element at once for a multi-selection (no per-element indicator prompts in that case).
+  - Select a field or constant (or several, with Ctrl/Cmd+click) to get a "⋮ Actions" menu: add color/attribute, copy, or delete — applied to every selected element at once for a multi-selection. A single selected field or constant also gets Rename.../Edit Text..., Indicators..., and — for fields — Validity Checks..., Editing Keywords..., and Error Messages..., the same commands the tree's context menu offers, so most of what you'd do from the tree is also reachable straight from the preview.
   - The decimal point and thousands-separator convention used to preview `EDTCDE()`-edited numeric fields — US or European — is configurable from the "⚙ Configuration" panel, either picked manually or fetched with one click from the connected IBM i's `QDECFMT` system value.
 
 ### 🧭 Schema navigation
@@ -146,9 +146,9 @@ No known blocking issues right now. Please [open an issue](https://github.com/ch
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**1.2.0** - 2026-08-31
-- Added: Preview's decimal point/thousands-separator convention for `EDTCDE()`-edited numeric fields (US/European) is now configurable from the "⚙ Configuration" panel, with a one-click "Fetch from IBM i" (reads the connected system's `QDECFMT` value) and a "Reset to Default" button.
-- Fixed: an unedited numeric field (no `EDTCDE`/`EDTWRD`) didn't reserve the extra trailing position IBM i adds for the sign on an input-capable signed-numeric field — e.g. a 1,0 field showed as a single digit instead of digit + `-`, confirmed against real STRSDA.
+**1.3.0** - 2026-09-01
+- Added: Preview's "⋮ Actions" menu (single selection) now also offers Rename.../Edit Text..., Indicators..., and — for fields — Validity Checks..., Editing Keywords..., and Error Messages..., the same commands the tree's context menu offers.
+- Added: a resizable constant now also gets a left-edge drag handle, growing/shrinking its leading blank padding instead of only the trailing one on the right, down to column 1 (or a window's own left edge).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dspf-edit",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dspf-edit",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"

--- a/src/dspf-edit.commands/dspf-edit.add-editing-keywords.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-editing-keywords.ts
@@ -26,6 +26,11 @@ interface EditCodeOption {
     supportsCurrency: boolean;
 };
 
+/** One row of the editing-keywords summary menu — one of the 3 keyword slots for a field. */
+interface EditingMenuItem extends vscode.QuickPickItem {
+    editType: 'EDTCDE' | 'EDTWRD' | 'EDTMSK';
+};
+
 // COMMAND REGISTRATION
 
 /**
@@ -44,8 +49,10 @@ export function editingKeywords(context: vscode.ExtensionContext): void {
 // COMMAND HANDLER
 
 /**
- * Handles the edit field command for a DDS field.
- * Manages field editing options: EDTCDE, EDTWRD, and EDTMSK.
+ * Handles the edit field command for a DDS field: shows a summary menu with all 3 keyword slots
+ * (EDTCDE/EDTWRD/EDTMSK) and their current value, letting the user jump straight to setting/
+ * changing whichever one they want, or remove one directly via its own trash button — instead of
+ * the old "Replace/Remove, then pick a type" two-step flow.
  * @param node - The DDS node containing the field
  */
 async function handleEditingKeywordsCommand(node: DdsNode): Promise<void> {
@@ -71,130 +78,100 @@ async function handleEditingKeywordsCommand(node: DdsNode): Promise<void> {
             return;
         };
         const effectiveFieldInfo = getEffectiveFieldInfo(fieldInfo, node.ddsElement, document.uri.toString());
-
-        // Get current editing configuration
         const currentEditing = getCurrentEditingForField(node.ddsElement);
+        const inputCapable = isInputCapableField(effectiveFieldInfo);
 
-        // Show current editing if exists
-        if (currentEditing.length > 0) {
-            const currentEditDisplay = currentEditing.map(edit => 
-                `${edit.type}(${edit.value}${edit.modifier ? ' ' + edit.modifier : ''})`
-            ).join(', ');
+        const choice = await showEditingMenu(buildEditingMenuItems(currentEditing, inputCapable), effectiveFieldInfo.name);
+        if (!choice) return;
 
-            const action = await vscode.window.showQuickPick(
-                ['Replace field editing', 'Remove field editing'],
-                {
-                    title: `Current editing: ${currentEditDisplay}`,
-                    placeHolder: 'Choose how to manage field editing'
-                }
-            );
-
-            if (!action) return;
-
-            if (action === 'Remove field editing') {
-                await removeEditingFromField(editor, node.ddsElement);
-                return;
-            };
-
-            if (action === 'Replace field editing') {
-                await removeEditingFromField(editor, node.ddsElement);
-                // Continue to add new editing
-            };
+        if (choice.action === 'remove') {
+            await removeOneEditingType(editor, node.ddsElement, choice.editType);
+            return;
         };
 
-        // Ask user what type of editing they want
-        const editingType = await vscode.window.showQuickPick([
-            'EDTCDE - Edit Code (predefined formatting)',
-            'EDTWRD - Edit Word (custom formatting patterns)',
-            'EDTMSK - Edit Mask (field protection with EDTCDE/EDTWRD)'
-        ], {
-            title: `Select editing type for ${effectiveFieldInfo.name} (Type: ${effectiveFieldInfo.type || 'unresolved'})`,
-            placeHolder: 'Choose editing method'
-        });
+        let newEdits: EditConfiguration[] | null = null;
 
-        if (!editingType) return;
-
-        let selectedEditing: EditConfiguration[] = [];
-
-        if (editingType.startsWith('EDTCDE')) {
+        if (choice.editType === 'EDTCDE') {
             // Validate field is numeric for EDTCDE
             if (!isNumericField(effectiveFieldInfo)) {
                 vscode.window.showWarningMessage(numericFieldWarning('Edit codes (EDTCDE)', node.ddsElement, effectiveFieldInfo));
                 return;
             };
             const editCode = await collectEditCode(effectiveFieldInfo);
-            if (editCode) selectedEditing.push(editCode);
+            if (editCode) newEdits = [editCode];
 
-        } else if (editingType.startsWith('EDTWRD')) {
+        } else if (choice.editType === 'EDTWRD') {
             // Validate field is numeric for EDTWRD
             if (!isNumericField(effectiveFieldInfo)) {
                 vscode.window.showWarningMessage(numericFieldWarning('Edit words (EDTWRD)', node.ddsElement, effectiveFieldInfo));
                 return;
             };
-            const editWord = await collectEditWord(effectiveFieldInfo);
-            if (editWord) selectedEditing.push(editWord);
+            const currentEdtwrd = currentEditing.find(edit => edit.type === 'EDTWRD');
+            const editWord = await collectEditWord(effectiveFieldInfo, currentEdtwrd);
+            if (editWord) newEdits = [editWord];
 
-        } else if (editingType.startsWith('EDTMSK')) {
+        } else {
             // EDTMSK protects/masks what the user types, so it's only meaningful on a field the
-            // user can actually type into (usage I or B) — an output-only field has nothing to mask.
-            if (!isInputCapableField(effectiveFieldInfo)) {
+            // user can actually type into (usage I or B) — an output-only field has nothing to mask
+            // (already excluded from the menu, but the command can still be reinvoked directly).
+            if (!inputCapable) {
                 vscode.window.showWarningMessage(inputCapableFieldWarning(node.ddsElement));
                 return;
             };
 
-            // EDTMSK requires EDTCDE or EDTWRD to be present
-            vscode.window.showInformationMessage('EDTMSK requires EDTCDE or EDTWRD. You will be asked to specify both.');
+            const existingBase = currentEditing.find(edit => edit.type === 'EDTCDE' || edit.type === 'EDTWRD');
+            let base: EditConfiguration | null = existingBase ?? null;
 
-            let baseEdit: EditConfiguration | null = null;
+            if (!base) {
+                // EDTMSK requires EDTCDE or EDTWRD to be present
+                vscode.window.showInformationMessage('EDTMSK requires EDTCDE or EDTWRD. Choose the base editing first.');
 
-            const baseEditType = await vscode.window.showQuickPick([
-                'EDTCDE - Edit Code',
-                'EDTWRD - Edit Word'
-            ], {
-                title: 'EDTMSK requires a base editing keyword. Choose base editing:',
-                placeHolder: 'Select EDTCDE or EDTWRD first'
-            });
+                const baseEditType = await vscode.window.showQuickPick([
+                    'EDTCDE - Edit Code',
+                    'EDTWRD - Edit Word'
+                ], {
+                    title: 'EDTMSK requires a base editing keyword. Choose base editing:',
+                    placeHolder: 'Select EDTCDE or EDTWRD first'
+                });
 
-            if (!baseEditType) return;
+                if (!baseEditType) return;
 
-            // Validate field is numeric for base editing
-            if (!isNumericField(effectiveFieldInfo)) {
-                vscode.window.showWarningMessage(numericFieldWarning('EDTMSK base editing', node.ddsElement, effectiveFieldInfo));
-                return;
+                // Validate field is numeric for base editing
+                if (!isNumericField(effectiveFieldInfo)) {
+                    vscode.window.showWarningMessage(numericFieldWarning('EDTMSK base editing', node.ddsElement, effectiveFieldInfo));
+                    return;
+                };
+
+                base = baseEditType.startsWith('EDTCDE')
+                    ? await collectEditCode(effectiveFieldInfo)
+                    : await collectEditWord(effectiveFieldInfo);
+
+                if (!base) return;
             };
 
-            if (baseEditType.startsWith('EDTCDE')) {
-                baseEdit = await collectEditCode(effectiveFieldInfo);
-            } else {
-                baseEdit = await collectEditWord(effectiveFieldInfo);
-            };
-
-            if (!baseEdit) return;
-
-            const editMask = await collectEditMask(baseEdit);
+            const currentEdtmsk = currentEditing.find(edit => edit.type === 'EDTMSK');
+            const editMask = await collectEditMask(base, currentEdtmsk);
             if (editMask) {
-                selectedEditing.push(baseEdit);
-                selectedEditing.push(editMask);
+                // A base that already existed is left untouched by applyOneEditingKeyword (it
+                // only replaces what's actually being changed) — only pass it along when it was
+                // just freshly collected here, so it actually gets written.
+                newEdits = existingBase ? [editMask] : [base, editMask];
             };
         };
 
-        if (selectedEditing.length === 0) {
+        if (!newEdits) {
             vscode.window.showInformationMessage('No field editing selected.');
             return;
         };
 
         // Apply the selected editing to the field
-        if (!(await addEditingToField(editor, node.ddsElement, selectedEditing))) {
+        if (!(await applyOneEditingKeyword(editor, node.ddsElement, currentEditing, newEdits))) {
             return;
         };
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
-        
 
-        const editingSummary = selectedEditing.map(edit =>
-            `${edit.type}(${edit.value}${edit.modifier ? ' ' + edit.modifier : ''})`
-        ).join(' + ');
-
+        const editingSummary = newEdits.map(formatEditConfig).join(' + ');
         vscode.window.showInformationMessage(
             `Applied field editing ${editingSummary} to ${node.ddsElement.name}.`
         );
@@ -203,6 +180,87 @@ async function handleEditingKeywordsCommand(node: DdsNode): Promise<void> {
         console.error('Error managing field editing:', error);
         vscode.window.showErrorMessage('An error occurred while managing field editing.');
     };
+};
+
+// EDITING SUMMARY MENU
+
+/** Formats an editing configuration exactly as it reads in DDS source, e.g. "EDTCDE(Z)" or "EDTWRD('   0.  ')". */
+function formatEditConfig(edit: EditConfiguration): string {
+    return `${edit.type}(${edit.value}${edit.modifier ? ' ' + edit.modifier : ''})`;
+};
+
+const EDIT_BUTTON: vscode.QuickInputButton = { iconPath: new vscode.ThemeIcon('edit'), tooltip: 'Set/change' };
+const REMOVE_BUTTON: vscode.QuickInputButton = { iconPath: new vscode.ThemeIcon('trash'), tooltip: 'Remove' };
+
+/**
+ * Builds the "editing keywords" summary menu's 3 rows (2 for an output-only field, since EDTMSK
+ * only ever applies to input-capable ones) — each showing its currently assigned value (formatted
+ * exactly as it'd read in the DDS source, e.g. "EDTCDE(Z)") or "(not set)", with an edit button
+ * (always) and a trash button (only when something's actually assigned) so both actions are
+ * explicit instead of relying on "click the row" meaning "edit".
+ * @param currentEditing - The field's current editing configuration(s)
+ * @param inputCapable - Whether the field's usage allows EDTMSK
+ */
+function buildEditingMenuItems(currentEditing: EditConfiguration[], inputCapable: boolean): EditingMenuItem[] {
+    const row = (editType: 'EDTCDE' | 'EDTWRD' | 'EDTMSK', label: string): EditingMenuItem => {
+        const current = currentEditing.find(edit => edit.type === editType);
+        return {
+            editType,
+            label,
+            description: current ? formatEditConfig(current) : '(not set)',
+            buttons: current ? [EDIT_BUTTON, REMOVE_BUTTON] : [EDIT_BUTTON]
+        };
+    };
+
+    const items: EditingMenuItem[] = [
+        row('EDTCDE', 'EDTCDE — Edit Code'),
+        row('EDTWRD', 'EDTWRD — Edit Word')
+    ];
+    if (inputCapable) {
+        items.push(row('EDTMSK', 'EDTMSK — Edit Mask'));
+    };
+    return items;
+};
+
+/**
+ * Shows the editing-keywords summary menu and resolves to what the user did: picked a row (or its
+ * edit button) to set/change (`action: 'select'`), or clicked a row's trash button to remove it
+ * (`action: 'remove'`) — undefined if dismissed. Needs the raw `createQuickPick` API rather than
+ * the simpler `showQuickPick` helper, since only it exposes per-item buttons
+ * (`onDidTriggerItemButton`).
+ * @param items - The menu's rows, from `buildEditingMenuItems`
+ * @param fieldName - The field's name, for the menu's title
+ */
+function showEditingMenu(items: EditingMenuItem[], fieldName: string): Promise<{ action: 'select' | 'remove'; editType: 'EDTCDE' | 'EDTWRD' | 'EDTMSK' } | undefined> {
+    return new Promise(resolve => {
+        const quickPick = vscode.window.createQuickPick<EditingMenuItem>();
+        quickPick.items = items;
+        quickPick.title = `Editing keywords for ${fieldName}`;
+        quickPick.placeholder = 'Select a keyword to set/change, or use its buttons';
+        quickPick.ignoreFocusOut = true;
+
+        let settled = false;
+        const finish = (result: { action: 'select' | 'remove'; editType: 'EDTCDE' | 'EDTWRD' | 'EDTMSK' } | undefined) => {
+            if (settled) return;
+            settled = true;
+            resolve(result);
+            quickPick.hide();
+        };
+
+        quickPick.onDidTriggerItemButton(event => {
+            finish({ action: event.button === REMOVE_BUTTON ? 'remove' : 'select', editType: event.item.editType });
+        });
+        quickPick.onDidAccept(() => {
+            const picked = quickPick.selectedItems[0];
+            finish(picked ? { action: 'select', editType: picked.editType } : undefined);
+        });
+        quickPick.onDidHide(() => {
+            finish(undefined);
+            quickPick.dispose();
+        });
+
+        quickPick.show();
+    });
 };
 
 // EDITING EXTRACTION FUNCTIONS
@@ -232,16 +290,18 @@ function getCurrentEditingForField(element: any): EditConfiguration[] {
             editing.push({ type: 'EDTCDE', value: code, modifier });
         };
 
-        // Check for EDTWRD
+        // Check for EDTWRD — value keeps its surrounding quotes (matching collectEditWord's own
+        // convention below), since createEditingKeywordText interpolates it as-is; without them, a
+        // "survivor" reused as-is by applyOneEditingKeyword would get written back unquoted.
         const edtwrdMatch = attr.match(/^EDTWRD\('([^']+)'\)$/);
         if (edtwrdMatch) {
-            editing.push({ type: 'EDTWRD', value: edtwrdMatch[1] });
+            editing.push({ type: 'EDTWRD', value: `'${edtwrdMatch[1]}'` });
         };
 
-        // Check for EDTMSK
+        // Check for EDTMSK — same quoting reasoning as EDTWRD above.
         const edtmskMatch = attr.match(/^EDTMSK\('([^']+)'\)$/);
         if (edtmskMatch) {
-            editing.push({ type: 'EDTMSK', value: edtmskMatch[1] });
+            editing.push({ type: 'EDTMSK', value: `'${edtmskMatch[1]}'` });
         };
     });
 
@@ -445,40 +505,35 @@ function getAvailableEditCodes(): EditCodeOption[] {
 // USER INTERACTION FUNCTIONS
 
 /**
- * Collects edit code configuration from user.
+ * Collects edit code configuration from user — a single flat list (no category grouping/separator
+ * rows, which only added scrolling noise) so typing the code letter/number and pressing Enter picks
+ * it in one shot, the same speed as typing it directly in STRSDA.
  * @param fieldInfo - Field information
  * @returns Selected edit code configuration
  */
 async function collectEditCode(fieldInfo: any): Promise<EditConfiguration | null> {
     const availableEditCodes = getAvailableEditCodes();
-    
-    // Group edit codes by category for better organization
-    const categories = ['Standard', 'Credit', 'Minus', 'Special', 'User-Defined'];
-    const editCodeItems: string[] = [];
 
-    categories.forEach(category => {
-        editCodeItems.push(`--- ${category} Edit Codes ---`);
-        const codesInCategory = availableEditCodes.filter(ec => ec.category === category);
-        codesInCategory.forEach(ec => {
-            editCodeItems.push(`${ec.code} - ${ec.description}`);
-        });
-    });
+    const items = availableEditCodes.map(ec => ({
+        label: ec.code,
+        description: ec.description,
+        code: ec.code
+    }));
 
-    const selectedItem = await vscode.window.showQuickPick(editCodeItems, {
+    const selectedItem = await vscode.window.showQuickPick(items, {
         title: `Select Edit Code for ${fieldInfo.name} (Type: ${fieldInfo.type})`,
-        placeHolder: 'Choose an edit code'
+        placeHolder: 'Type a code (e.g. J) or pick from the list'
     });
 
-    if (!selectedItem || selectedItem.startsWith('---')) return null;
+    if (!selectedItem) return null;
 
-    const selectedCode = selectedItem.split(' - ')[0];
-    const editCodeOption = availableEditCodes.find(ec => ec.code === selectedCode);
-    
+    const editCodeOption = availableEditCodes.find(ec => ec.code === selectedItem.code);
+
     if (!editCodeOption) return null;
 
     const editConfig: EditConfiguration = {
         type: 'EDTCDE',
-        value: selectedCode
+        value: editCodeOption.code
     };
 
     // Ask for modifiers if supported
@@ -495,7 +550,7 @@ async function collectEditCode(fieldInfo: any): Promise<EditConfiguration | null
         };
 
         const selectedModifier = await vscode.window.showQuickPick(modifierOptions, {
-            title: `Select modifier for EDTCDE(${selectedCode})`,
+            title: `Select modifier for EDTCDE(${editCodeOption.code})`,
             placeHolder: 'Choose a modifier (optional)'
         });
 
@@ -528,12 +583,21 @@ async function collectEditCode(fieldInfo: any): Promise<EditConfiguration | null
 /**
  * Collects edit word configuration from user.
  * @param fieldInfo - Field information
+ * @param current - The field's current EDTWRD (already quoted, e.g. "'   0.  '"), if changing one
  * @returns Selected edit word configuration
  */
-async function collectEditWord(fieldInfo: any): Promise<EditConfiguration | null> {
+async function collectEditWord(fieldInfo: any, current?: EditConfiguration): Promise<EditConfiguration | null> {
+    const fieldLength = parseInt(fieldInfo.length) || 0;
+    // Prefilled with the current word when changing one, or with a blank template already sized to
+    // the field's own digit count when starting fresh — already satisfies the "N digit positions"
+    // rule below, so the user only has to insert literal characters instead of counting blanks.
+    const defaultValue = current ? current.value : `'${' '.repeat(fieldLength)}'`;
+
     const editWordPattern = await vscode.window.showInputBox({
         title: `Edit Word for ${fieldInfo.name}`,
         prompt: `Enter edit word pattern (Field: ${fieldInfo.length} digits, ${fieldInfo.decimals || 0} decimals)`,
+        value: defaultValue,
+        valueSelection: [1, 1 + fieldLength],
         placeHolder: `Examples: '   0.  ' (decimal), '   $0.  ' (currency), '( ) -    ' (phone)`,
         validateInput: (value: string) => {
             if (!value.trim()) return 'Edit word pattern is required';
@@ -566,12 +630,14 @@ async function collectEditWord(fieldInfo: any): Promise<EditConfiguration | null
 /**
  * Collects edit mask configuration from user.
  * @param baseEdit - The base editing configuration (EDTCDE or EDTWRD)
+ * @param current - The field's current EDTMSK (already quoted), if changing one
  * @returns Selected edit mask configuration
  */
-async function collectEditMask(baseEdit: EditConfiguration): Promise<EditConfiguration | null> {
+async function collectEditMask(baseEdit: EditConfiguration, current?: EditConfiguration): Promise<EditConfiguration | null> {
     const editMaskPattern = await vscode.window.showInputBox({
         title: `Edit Mask for ${baseEdit.type}(${baseEdit.value})`,
         prompt: `Define protection: & for protected areas, blank for user input areas`,
+        value: current?.value,
         placeHolder: `Examples: '& &  & ' (phone), '  &  & ' (date), '&   .  ' (currency)`,
         validateInput: (value: string) => {
             if (!value.trim()) return 'Edit mask pattern is required';
@@ -599,6 +665,73 @@ async function collectEditMask(baseEdit: EditConfiguration): Promise<EditConfigu
 };
 
 // DDS MODIFICATION FUNCTIONS
+
+/**
+ * Applies one or two freshly-collected editing keywords to the field (EDTCDE or EDTWRD alone;
+ * EDTMSK alone if a base already exists; or both together when neither existed yet), replacing
+ * whichever existing keyword(s) they're incompatible with — EDTCDE and EDTWRD are mutually
+ * exclusive in DDS, so setting one always drops the other, but an existing EDTMSK survives (it
+ * doesn't care which of the two is its base) unless it's being explicitly replaced too. Removes
+ * everything first, then reapplies survivors + the new edit(s) together — simplest way to reuse the
+ * already-working remove/add logic for every combination (field-line vs separate attribute lines,
+ * single- vs multi-line EDTWRD...) rather than patching the existing source in place.
+ * @param editor - The active text editor
+ * @param element - The DDS field to update
+ * @param currentEditing - The field's editing configuration before this change
+ * @param newEdits - The freshly-collected edit(s) to apply
+ */
+async function applyOneEditingKeyword(
+    editor: vscode.TextEditor,
+    element: any,
+    currentEditing: EditConfiguration[],
+    newEdits: EditConfiguration[]
+): Promise<boolean> {
+    if (currentEditing.length > 0) {
+        if (!(await removeEditingFromField(editor, element))) return false;
+    };
+
+    const addingBase = newEdits.some(edit => edit.type === 'EDTCDE' || edit.type === 'EDTWRD');
+    const addingMask = newEdits.some(edit => edit.type === 'EDTMSK');
+    const toApply = [...newEdits];
+
+    if (addingMask && !addingBase) {
+        const survivingBase = currentEditing.find(edit => edit.type === 'EDTCDE' || edit.type === 'EDTWRD');
+        if (survivingBase) toApply.unshift(survivingBase);
+    };
+    if (addingBase && !addingMask) {
+        const survivingMask = currentEditing.find(edit => edit.type === 'EDTMSK');
+        if (survivingMask) toApply.push(survivingMask);
+    };
+
+    return addEditingToField(editor, element, toApply);
+};
+
+/**
+ * Removes just one editing keyword type from the field (the summary menu's trash-button action) —
+ * DDS requires EDTMSK to accompany an EDTCDE/EDTWRD, so removing the *base* takes any mask with it;
+ * removing just the mask leaves the base untouched. Same remove-everything-then-reapply-survivors
+ * approach as `applyOneEditingKeyword`.
+ * @param editor - The active text editor
+ * @param element - The DDS field to remove editing from
+ * @param editType - Which of EDTCDE/EDTWRD/EDTMSK to remove
+ */
+async function removeOneEditingType(
+    editor: vscode.TextEditor,
+    element: any,
+    editType: 'EDTCDE' | 'EDTWRD' | 'EDTMSK'
+): Promise<void> {
+    const currentEditing = getCurrentEditingForField(element);
+    const survivors = currentEditing.filter(edit => {
+        if (edit.type === editType) return false;
+        if ((editType === 'EDTCDE' || editType === 'EDTWRD') && edit.type === 'EDTMSK') return false;
+        return true;
+    });
+
+    if (!(await removeEditingFromField(editor, element))) return;
+    if (survivors.length > 0) {
+        await addEditingToField(editor, element, survivors);
+    };
+};
 
 /**
  * Adds editing configuration to a DDS field.

--- a/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
@@ -74,6 +74,18 @@ interface PreviewItem {
     /** For a resizable field: the shortest length its own type allows (decimals + 1 for a numeric field with decimals, else 1). */
     minLength?: number;
     /**
+     * True for a genuine constant literal (same gating as `isResizable` — not a system keyword)
+     * that isn't part of a subfile record. Drives whether the preview offers a *second* drag handle,
+     * on the constant's left edge, to grow/shrink its *leading* blank padding instead of its
+     * trailing one. Excluded for a subfile record: the parser stores its row/column swapped, and
+     * unlike the right handle (which never touches position), this one has to rewrite the constant's
+     * column — not worth risking writing it to the wrong raw source column without a way to verify
+     * against real STRSDA for a subfile.
+     */
+    isResizableLeft?: boolean;
+    /** For a left-resizable constant: the shortest length that doesn't eat into its own non-leading-blank text (mirrors `minLength`, from the other end). */
+    minLengthLeft?: number;
+    /**
      * A field's real DDS length/decimals, for display in the preview's selection bar — omitted
      * for constants and for a referenced field whose real length dspf-edit has no way to read
      * (see `isReferenced`), since there's nothing true to show there.
@@ -1411,7 +1423,14 @@ export class RecordPreviewPanel {
                     // stored name at all). Shrinking below its own trimmed (non-blank) text is never
                     // offered — only trailing blank padding can be added/removed.
                     isResizable: !isSystemConstant,
-                    minLength: Math.max(constant.name.replace(/\s+$/, '').length, 1)
+                    minLength: Math.max(constant.name.replace(/\s+$/, '').length, 1),
+                    // Left-edge handle: excluded for a subfile record — the parser stores its
+                    // row/column swapped (see `isSfl` above), and unlike the right handle (which
+                    // never touches position), a left-resize has to rewrite the constant's column —
+                    // not worth risking writing it to the wrong raw source column without a way to
+                    // verify against real STRSDA for a subfile. See PreviewItem.isResizableLeft.
+                    isResizableLeft: !isSystemConstant && !isSfl,
+                    minLengthLeft: Math.max(constant.name.replace(/^\s+/, '').length, 1)
                 });
             };
         };
@@ -1650,6 +1669,11 @@ export class RecordPreviewPanel {
             return;
         };
 
+        if (message?.type === 'resizeConstantLeft' && typeof message.lineIndex === 'number' && typeof message.newLength === 'number') {
+            await this.resizeConstantLeft(message.lineIndex, message.newLength);
+            return;
+        };
+
         if (message?.type === 'resize' && typeof message.newRows === 'number' && typeof message.newCols === 'number') {
             await this.resizeWindow(message.newRows, message.newCols);
             return;
@@ -1885,6 +1909,54 @@ export class RecordPreviewPanel {
         const newText = newLength >= constant.name.length
             ? constant.name + ' '.repeat(newLength - constant.name.length)
             : constant.name.slice(0, newLength);
+
+        if (!(await updateExistingConstant(editor, { lineIndex }, newText))) {
+            return;
+        };
+        this.forceReparse(editor.document);
+    };
+
+    /**
+     * Applies a drag-to-resize from the preview (dragging a constant's own LEFT-edge handle): the
+     * mirror image of `resizeConstant` — grows/shrinks the constant's *leading* blank padding
+     * instead of its trailing one. Unlike the right handle, this also has to move the constant's own
+     * start column (position spec, source columns 41-44) by the same amount its text gains/loses at
+     * the front, so its visible (non-blank) characters land on the exact same screen position as
+     * before — only the box's left edge actually moves. Applied as two separate edits — the column
+     * first, then `updateExistingConstant` for the text (same call `resizeConstant` makes, already
+     * correctly handling the constant growing past the single-line threshold into multiple lines or
+     * collapsing back) — rather than one combined atomic edit, so the (tricky, easy to get subtly
+     * wrong) multi-line continuation rewrite stays fully delegated to that already-tested logic
+     * instead of being duplicated here. Costs an extra undo step compared to the right handle; worth
+     * it for correctness on the rarer multi-line case.
+     * @param lineIndex - The constant's own source line
+     * @param newLength - The new total character count to write (already clamped in the webview)
+     */
+    private async resizeConstantLeft(lineIndex: number, newLength: number): Promise<void> {
+        const { editor } = checkForEditorAndDocument();
+        if (!editor || lineIndex >= editor.document.lineCount) {
+            return;
+        };
+
+        const constant = fieldsPerRecords.flatMap(r => r.constants).find(c => c.lineIndex === lineIndex);
+        if (!constant) {
+            return;
+        };
+
+        const delta = newLength - constant.name.length;
+        const newText = delta >= 0
+            ? ' '.repeat(delta) + constant.name
+            : constant.name.slice(-newLength);
+        const newColumn = constant.col - delta;
+        if (newColumn < 1) {
+            return;
+        };
+
+        const columnEdit = new vscode.WorkspaceEdit();
+        columnEdit.replace(editor.document.uri, new vscode.Range(lineIndex, 41, lineIndex, 44), String(newColumn).padStart(3, ' '));
+        if (!(await applyWorkspaceEdit(columnEdit, 'resize the constant'))) {
+            return;
+        };
 
         if (!(await updateExistingConstant(editor, { lineIndex }, newText))) {
             return;
@@ -2626,6 +2698,18 @@ export class RecordPreviewPanel {
         ctx.fill();
     }
 
+    // Mirror image of drawResizeHandleTriangle, for a constant's left-edge handle — fills the
+    // lower-left half of its box instead, so its outer corner sits at the box's bottom-left.
+    function drawResizeHandleTriangleLeft(boxX, boxY) {
+        ctx.fillStyle = '#ffffff';
+        ctx.beginPath();
+        ctx.moveTo(boxX, boxY);
+        ctx.lineTo(boxX + HANDLE_SIZE, boxY + HANDLE_SIZE);
+        ctx.lineTo(boxX, boxY + HANDLE_SIZE);
+        ctx.closePath();
+        ctx.fill();
+    }
+
     // Mirrors WINDOW_BORDER_* on the host: content sits 1 row inside the border top/bottom, and
     // 2 columns inside the border left/right (verified against real STRSDA output).
     const WINDOW_BORDER_TOP = 1;
@@ -2654,6 +2738,7 @@ export class RecordPreviewPanel {
     let moveWindowState = null;
     let elementResizeState = null;
     let currentElementHandleRect = null;
+    let currentElementHandleRectLeft = null;
     let selectedLineIndices = new Set();
     let currentRecordName = null;
     let placingKind = null; // null | 'constant' | 'field'
@@ -2945,14 +3030,26 @@ export class RecordPreviewPanel {
             // Field/constant resize preview: while dragging its handle, the element's own text
             // stretches/shrinks live to the currently-dragged length — nothing is actually written
             // back until the drag ends (mouseup). A field repeats its own placeholder character; a
-            // constant has no such placeholder, so it grows/shrinks its own trailing blank padding
-            // instead, same as the actual edit applied on mouseup (see resizeConstant on the host).
+            // constant has no such placeholder, so it grows/shrinks its own trailing (right handle)
+            // or leading (left handle) blank padding instead, same as the actual edit applied on
+            // mouseup (see resizeConstant/resizeConstantLeft on the host). The left handle also
+            // moves the item's own start column live, since its right edge is the one staying fixed.
             if (elementResizeState && item === elementResizeState.item) {
                 const newLength = elementResizeState.newLength;
-                const ghostText = item.kind === 'constant'
-                    ? (newLength >= item.name.length ? item.name + ' '.repeat(newLength - item.name.length) : item.name.slice(0, newLength))
-                    : (item.text.charAt(0) || ' ').repeat(newLength);
-                drawItem(Object.assign({}, item, { text: ghostText, length: newLength, isBeingResized: true }), fontFamily, moveDelta);
+                const isLeftDrag = elementResizeState.side === 'left';
+                let ghostText, ghostCol;
+                if (isLeftDrag) {
+                    ghostText = newLength >= item.name.length
+                        ? ' '.repeat(newLength - item.name.length) + item.name
+                        : item.name.slice(item.name.length - newLength);
+                    ghostCol = item.col + item.length - newLength;
+                } else {
+                    ghostText = item.kind === 'constant'
+                        ? (newLength >= item.name.length ? item.name + ' '.repeat(newLength - item.name.length) : item.name.slice(0, newLength))
+                        : (item.text.charAt(0) || ' ').repeat(newLength);
+                    ghostCol = item.col;
+                }
+                drawItem(Object.assign({}, item, { text: ghostText, length: newLength, col: ghostCol, isBeingResized: true }), fontFamily, moveDelta);
             } else {
                 drawItem(item, fontFamily, moveDelta);
             }
@@ -2960,16 +3057,24 @@ export class RecordPreviewPanel {
 
         drawGridDots(size, items, currentBackgroundItems, moveDelta, currentOuterFrame, currentWindowFrame);
 
-        // Element resize handle: shown only while exactly one resizable field/constant is selected —
+        // Element resize handles: shown only while exactly one resizable field/constant is selected —
         // a small grip just past its right edge (outside its own text, so it never overlaps it even
-        // at width 1, addressing how cramped a narrow one would otherwise feel) that drags its length.
+        // at width 1, addressing how cramped a narrow one would otherwise feel) that drags its length;
+        // a constant can also get a second, mirrored grip just before its left edge, to grow/shrink
+        // its leading padding instead (see PreviewItem.isResizableLeft). Only the handle matching the
+        // side actually being dragged is shown while a drag is in progress — the other one's position
+        // would otherwise go stale (it's computed from the item's un-dragged base length/column).
         currentElementHandleRect = null;
+        currentElementHandleRectLeft = null;
         if (selectedLineIndices.size === 1) {
             const selectedLineIndex = [...selectedLineIndices][0];
+            const isDraggingLeft = elementResizeState && elementResizeState.side === 'left';
+            const isDraggingRight = elementResizeState && elementResizeState.side !== 'left';
+
             const handleItem = items.find(i => i.lineIndex === selectedLineIndex && (i.kind === 'field' || i.kind === 'constant') && i.isResizable);
-            if (handleItem) {
+            if (handleItem && !isDraggingLeft) {
                 const { row, col } = resolveItemRowCol(handleItem, moveDelta);
-                const width = elementResizeState ? elementResizeState.newLength : Math.max(handleItem.length, handleItem.text.length, 1);
+                const width = isDraggingRight ? elementResizeState.newLength : Math.max(handleItem.length, handleItem.text.length, 1);
                 // Bottom-anchored within the row, same corner convention as the window's own handle
                 // (its outer tip sits exactly at the element's own bottom-right corner) — reads more
                 // like a familiar resize grip than one centered on the row.
@@ -2978,6 +3083,20 @@ export class RecordPreviewPanel {
                 currentElementHandleRect = { x: hx, y: hy, width: HANDLE_SIZE, height: HANDLE_SIZE, item: handleItem };
 
                 drawResizeHandleTriangle(hx, hy);
+            }
+
+            const handleItemLeft = items.find(i => i.lineIndex === selectedLineIndex && i.kind === 'constant' && i.isResizableLeft);
+            if (handleItemLeft && !isDraggingRight) {
+                const { row, col } = resolveItemRowCol(handleItemLeft, moveDelta);
+                const baseWidth = Math.max(handleItemLeft.length, handleItemLeft.text.length, 1);
+                const width = isDraggingLeft ? elementResizeState.newLength : baseWidth;
+                const rightEdgeCol = col + baseWidth - 1; // fixed anchor: unaffected by the live drag width
+                const liveStartCol = rightEdgeCol - width + 1;
+                const hx = (liveStartCol - 1) * CHAR_W;
+                const hy = row * CHAR_H - HANDLE_SIZE;
+                currentElementHandleRectLeft = { x: hx - HANDLE_SIZE, y: hy, width: HANDLE_SIZE, height: HANDLE_SIZE, item: handleItemLeft };
+
+                drawResizeHandleTriangleLeft(hx - HANDLE_SIZE, hy);
             }
         }
 
@@ -3206,6 +3325,17 @@ export class RecordPreviewPanel {
                py >= currentElementHandleRect.y && py <= currentElementHandleRect.y + currentElementHandleRect.height;
     }
 
+    function isOverElementResizeHandleLeft(ev) {
+        if (!currentElementHandleRectLeft) {
+            return false;
+        }
+        const rect = canvas.getBoundingClientRect();
+        const px = ev.clientX - rect.left;
+        const py = ev.clientY - rect.top;
+        return px >= currentElementHandleRectLeft.x && px <= currentElementHandleRectLeft.x + currentElementHandleRectLeft.width &&
+               py >= currentElementHandleRectLeft.y && py <= currentElementHandleRectLeft.y + currentElementHandleRectLeft.height;
+    }
+
     function isOverWindowFrame(ev) {
         if (!currentOuterFrame) {
             return false;
@@ -3347,7 +3477,31 @@ export class RecordPreviewPanel {
                 startLength: item.length,
                 newLength: item.length,
                 minLength: item.minLength || 1,
-                maxLength
+                maxLength,
+                side: 'right'
+            };
+            return;
+        }
+
+        if (isOverElementResizeHandleLeft(ev)) {
+            const item = currentElementHandleRectLeft.item;
+            // The element's right edge (its last character) stays fixed — only its left edge can
+            // move — so the longest it can grow to is however many columns remain to the
+            // record/window's own left edge from there (mirrors the right handle's own boundary).
+            let minLeftCol = 1;
+            if (currentWindowFrame && !item.isBackground) {
+                minLeftCol = currentWindowFrame.col;
+            }
+            const rightEdgeCol = item.col + item.length - 1;
+            const maxLength = Math.max(rightEdgeCol - minLeftCol + 1, item.minLengthLeft || 1);
+
+            elementResizeState = {
+                item,
+                startLength: item.length,
+                newLength: item.length,
+                minLength: item.minLengthLeft || 1,
+                maxLength,
+                side: 'left'
             };
             return;
         }
@@ -3468,7 +3622,11 @@ export class RecordPreviewPanel {
         if (elementResizeState) {
             const { col } = cellAt(ev);
             const item = elementResizeState.item;
-            const desiredLength = col - item.col + 1;
+            // Right handle: distance from the fixed left edge (item.col) out to the cursor. Left
+            // handle: distance from the cursor back to the fixed right edge instead.
+            const desiredLength = elementResizeState.side === 'left'
+                ? (item.col + item.length - 1) - col + 1
+                : col - item.col + 1;
             const newLength = clamp(desiredLength, elementResizeState.minLength, elementResizeState.maxLength);
 
             if (newLength !== elementResizeState.newLength) {
@@ -3505,7 +3663,7 @@ export class RecordPreviewPanel {
         if (!dragState) {
             updateWindowHoverState(ev);
 
-            if (isOverElementResizeHandle(ev)) {
+            if (isOverElementResizeHandle(ev) || isOverElementResizeHandleLeft(ev)) {
                 canvas.style.cursor = 'ew-resize';
                 canvas.title = '';
                 return;
@@ -3583,10 +3741,11 @@ export class RecordPreviewPanel {
 
     window.addEventListener('mouseup', () => {
         if (elementResizeState) {
-            const { item, newLength, startLength } = elementResizeState;
+            const { item, newLength, startLength, side } = elementResizeState;
             elementResizeState = null;
             if (newLength !== startLength) {
-                vscode.postMessage({ type: item.kind === 'constant' ? 'resizeConstant' : 'resizeField', lineIndex: item.lineIndex, newLength });
+                const messageType = side === 'left' ? 'resizeConstantLeft' : (item.kind === 'constant' ? 'resizeConstant' : 'resizeField');
+                vscode.postMessage({ type: messageType, lineIndex: item.lineIndex, newLength });
             } else {
                 draw(currentSize, currentItems, currentBackgroundItems, currentWindowFrame, currentWindowTitle, currentOuterFrame);
             }

--- a/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
@@ -2160,6 +2160,14 @@ export class RecordPreviewPanel {
      * arms `pendingCopySource` and puts the webview into its click-to-place mode (see
      * `copyElementAt`) — the same "click a spot in the preview" gesture the "+ Field"/"+ Constant"
      * buttons already use, just for a copy of an existing element instead of a brand-new one.
+     * Rename (fields)/Edit Text (constants), Indicators, and the field-only Validity Checks/
+     * Editing Keywords/Error Messages are also single-selection only — like Copy, they just
+     * delegate straight to the tree's own `dspf-edit.rename-field`/`dspf-edit.edit-constant`/
+     * `dspf-edit.add-indicators`/`dspf-edit.add-validity-check`/`dspf-edit.add-editing-keywords`/
+     * `dspf-edit.add-error-message` commands (same prompt/validation/confirmation as right-clicking
+     * the element in the tree), and indicators specifically aren't a value that makes sense shared
+     * across a group of differently-conditioned elements (same reason the multi-element branch
+     * below has no indicator prompting either).
      * @param lineIndices - Zero-based source line indices of the selected fields/constants
      */
     private async showElementMenu(lineIndices: number[]): Promise<void> {
@@ -2173,12 +2181,27 @@ export class RecordPreviewPanel {
 
         const options: (vscode.QuickPickItem & { command: string })[] = [
             { label: '$(paintcan) Add Color...', command: 'add-color' },
-            { label: '$(symbol-color) Add Attribute...', command: 'add-attribute' },
-            { label: '$(trash) Delete...', command: 'delete' }
+            { label: '$(symbol-color) Add Attribute...', command: 'add-attribute' }
         ];
         if (!isMulti) {
-            options.splice(2, 0, { label: '$(copy) Copy...', command: 'copy' });
+            const kind = nodes[0].ddsElement.kind;
+            if (kind === 'field') {
+                options.push(
+                    { label: '$(check) Validity Checks...', command: 'add-validity-check' },
+                    { label: '$(symbol-numeric) Editing Keywords...', command: 'add-editing-keywords' },
+                    { label: '$(warning) Error Messages...', command: 'add-error-message' }
+                );
+            };
+            const editOption = kind === 'field'
+                ? { label: '$(edit) Rename...', command: 'rename-field' }
+                : { label: '$(edit) Edit Text...', command: 'edit-constant' };
+            options.push(
+                editOption,
+                { label: '$(symbol-boolean) Indicators...', command: 'add-indicators' },
+                { label: '$(copy) Copy...', command: 'copy' }
+            );
         };
+        options.push({ label: '$(trash) Delete...', command: 'delete' });
 
         const singleElementName = (nodes[0].ddsElement as { name: string }).name;
         const selection = await vscode.window.showQuickPick(options, {


### PR DESCRIPTION
## [1.3.0] - 2026-09-02
### Added
- Preview: the "⋮ Actions" menu (single selection) now also offers Rename... (fields) / Edit Text... (constants), Indicators..., and — for fields — Validity Checks..., Editing Keywords..., and Error Messages..., delegating to the exact same tree commands (same prompts, validation, and confirmations as right-clicking the element in the tree). The preview now covers practically everything the tree's context menu offers for a single field or constant.
- Preview: a resizable constant now also gets a second drag handle on its *left* edge, growing/shrinking its leading blank padding (moving its start column back to keep the visible text in place) instead of only the trailing padding on the right — down to column 1, or a window's own left content edge. Not offered for a constant inside a subfile record.
- Add Editing Keywords: replaced with a single summary menu showing all three slots (EDTCDE/EDTWRD/EDTMSK) and their current value at a glance, each with its own set/change (✏️) and remove (🗑️) buttons — instead of the old "Replace/Remove, then pick a type" two-step flow. Picking EDTCDE/EDTWRD is now a flat, type-to-filter list (no more category separators). Changing an existing EDTWRD/EDTMSK pre-fills the input with its current value; starting a new EDTWRD pre-fills a blank template already sized to the field, satisfying the "N digit positions" rule from the start. Setting EDTCDE/EDTWRD automatically drops the other (they're mutually exclusive in DDS) while keeping any existing EDTMSK; removing the base takes its EDTMSK with it.
