### PR TITLE
v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
+## [1.4.0] - 2026-09-04
+### Added
+- Preview: `EDTCDE(W)`/`EDTCDE(Y)` (date-slash editing) and `EDTCDE(X)`/`EDTCDE(Z)` are now recognized and rendered correctly, confirmed against real STRSDA — previously fell back to a generic, often wrong, numeric mask.
+- Preview: the `DATE()` keyword (`*JOB`/`*SYS`, `*Y`/`*YY`) is now recognized as a system field, with or without `EDTCDE(Y)`/`EDTCDE(W)`.
+- Preview: a floating currency symbol on `EDTCDE()` (e.g. `EDTCDE(J $)`) now adds its extra display position; asterisk fill now shows as `*` in place of the leading digit instead of a plain digit.
+- Configuration: new "Date Separator" section (US `/` / European `-`) alongside Decimal Format, with "Fetch from IBM i" (reads `QDATSEP`) and reset.
+### Fixed
+- Preview: an `EDTCDE()`'s comma/sign/date/currency decoration only ever shows on an output field, confirmed against real STRSDA — an input-capable field now previews as if unedited instead of always applying the code's formatting.
+- Parser: several keywords on one physical source line (e.g. `EDTCDE(3) DSPATR(HI) COLOR(RED)`) were read as a single combined value instead of separate keywords, breaking both the preview and Remove Color/Attribute/Editing Keywords for a field or constant written that way.
+- Remove Colors / Remove Attributes / Remove Editing Keywords: removing one keyword sharing a line with others — or continued onto the next line via a trailing hyphen — could delete the sibling keywords too, or leave survivors stranded on a continuation line they no longer needed.
+
 ## [1.3.0] - 2026-09-02
 ### Added
 - Preview: the "⋮ Actions" menu (single selection) now also offers Rename... (fields) / Edit Text... (constants), Indicators..., and — for fields — Validity Checks..., Editing Keywords..., and Error Messages..., delegating to the exact same tree commands (same prompts, validation, and confirmations as right-clicking the element in the tree). The preview now covers practically everything the tree's context menu offers for a single field or constant.

--- a/README.md
+++ b/README.md
@@ -146,10 +146,11 @@ No known blocking issues right now. Please [open an issue](https://github.com/ch
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**1.3.0** - 2026-09-02
-- Added: Preview's "⋮ Actions" menu (single selection) now also offers Rename.../Edit Text..., Indicators..., and — for fields — Validity Checks..., Editing Keywords..., and Error Messages..., the same commands the tree's context menu offers.
-- Added: a resizable constant now also gets a left-edge drag handle, growing/shrinking its leading blank padding instead of only the trailing one on the right, down to column 1 (or a window's own left edge).
-- Added: Add Editing Keywords now shows a single summary menu with EDTCDE/EDTWRD/EDTMSK and their current values, each with its own set/change and remove buttons, instead of a multi-step "Replace/Remove, then pick a type" wizard.
+**1.4.0** - 2026-09-04
+- Added: Preview now correctly renders `EDTCDE(W)`, `(X)`, `(Y)` and `(Z)`, the `DATE()` keyword, floating currency symbols, and asterisk fill — all confirmed against real STRSDA.
+- Added: new "Date Separator" configuration (US `/` / European `-`), with fetch from the connected IBM i.
+- Fixed: `EDTCDE()` decoration now only applies to output fields in the preview, matching STRSDA — an input-capable field previews as if unedited.
+- Fixed: several DDS keywords sharing one source line (e.g. `EDTCDE(3) DSPATR(HI) COLOR(RED)`) are now parsed and edited correctly — removing one no longer risks deleting or corrupting the others.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dspf-edit",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dspf-edit",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"

--- a/src/dspf-edit.commands/dspf-edit.add-attribute.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-attribute.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from './../dspf-edit.providers/dspf-edit.providers';
-import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, parseIndicatorsFromLine, groupConsecutiveLines, applyWorkspaceEdit } from './../dspf-edit.utils/dspf-edit.helper';
+import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, parseIndicatorsFromLine, applyWorkspaceEdit, removeKeywordTextFromLines, findKeywordContinuationEndLine } from './../dspf-edit.utils/dspf-edit.helper';
 import { fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
  
 // INTERFACES AND TYPES
@@ -525,92 +525,44 @@ async function removeAttributesFromElement(editor: vscode.TextEditor, element: a
     if (currentAttributes.length === 0) return true;
 
     const document = editor.document;
-    const workspaceEdit = new vscode.WorkspaceEdit();
-    const uri = document.uri;
     const isConstant = element.kind === 'constant';
 
     // Separate inline attributes from line attributes
     const inlineAttributes = currentAttributes.filter(attr => attr.isInlineAttribute);
     const lineAttributes = currentAttributes.filter(attr => !attr.isInlineAttribute);
 
-    // Handle inline attribute removal (for fields)
+    // Handle separate attribute lines removal first, from the last line to the first: DDS allows
+    // other keywords to share these lines (and their keyword area can itself continue onto further
+    // lines via a trailing hyphen), so removeKeywordTextFromLines strips just this DSPATR's own text
+    // and re-flows whatever remains back onto as few lines as it now fits in — which can itself
+    // delete or merge lines, shifting the line numbers of everything below it (but never above).
+    // Since the field's own line always comes before any of these, handling these first (latest to
+    // earliest) and the inline case last keeps every remaining entry's own line index valid.
+    for (const attr of [...lineAttributes].sort((a, b) => b.lineIndex! - a.lineIndex!)) {
+        const lineIndex = attr.lineIndex!;
+        const lineText = document.lineAt(lineIndex).text;
+        const attributeMatch = lineText.match(/DSPATR\([A-Z]{2}\)/);
+        if (!attributeMatch) {
+            continue;
+        };
+
+        const endLine = findKeywordContinuationEndLine(document, lineIndex);
+        if (!(await removeKeywordTextFromLines(editor, lineIndex, endLine, attributeMatch[0], false))) {
+            return false;
+        };
+    };
+
+    // Handle inline attribute removal (for fields) last — same reasoning as above.
     if (!isConstant && inlineAttributes.length > 0) {
-        const fieldLine = document.lineAt(element.lineIndex);
-        const fieldLineText = fieldLine.text;
-        
-        // Remove everything from position 44 onwards
-        const truncatedLine = fieldLineText.substring(0, 44).trimRight();
-        workspaceEdit.replace(uri, fieldLine.range, truncatedLine);
-    };
-
-    // Handle separate attribute lines removal
-    if (lineAttributes.length > 0) {
-        const attributeLineIndices = lineAttributes.map(attr => attr.lineIndex!);
-        const deletionRanges = calculateAttributeDeletionRanges(document, attributeLineIndices);
-        
-        // Apply deletions in reverse order to maintain offsets
-        for (let i = deletionRanges.length - 1; i >= 0; i--) {
-            const { startOffset, endOffset } = deletionRanges[i];
-            const startPos = document.positionAt(startOffset);
-            const endPos = document.positionAt(endOffset);
-            workspaceEdit.delete(uri, new vscode.Range(startPos, endPos));
-        };
-    };
-
-    return applyWorkspaceEdit(workspaceEdit, 'remove the attributes');
-};
-
-/**
- * Calculates precise deletion ranges for standalone attribute lines.
- * Handles edge cases to prevent blank lines at the end of the file.
- * @param document - The text document
- * @param attributeLines - Array of line indices containing standalone attributes
- * @returns Array of deletion ranges with start and end offsets
- */
-function calculateAttributeDeletionRanges(
-    document: vscode.TextDocument, 
-    attributeLines: number[]
-): { startOffset: number; endOffset: number }[] {
-    const docText = document.getText();
-    const docLength = docText.length;
-    const ranges: { startOffset: number; endOffset: number }[] = [];
-    
-    // Group consecutive lines for more efficient deletion
-    const lineGroups = groupConsecutiveLines(attributeLines);
-    
-    for (const group of lineGroups) {
-        const firstLine = group[0];
-        const lastLine = group[group.length - 1];
-        
-        let startOffset: number;
-        let endOffset: number;
-        
-        if (lastLine === document.lineCount - 1) {
-            // Group includes the last line of the document
-            if (firstLine === 0) {
-                // Entire document is attribute lines - delete everything
-                startOffset = 0;
-                endOffset = docLength;
-            } else {
-                // Delete from end of previous line to end of file
-                const prevLineEndPos = document.lineAt(firstLine - 1).range.end;
-                startOffset = document.offsetAt(prevLineEndPos);
-                endOffset = docLength;
+        const fieldLineText = document.lineAt(element.lineIndex).text;
+        const attributeMatch = fieldLineText.substring(44).match(/DSPATR\([A-Z]{2}\)/);
+        if (attributeMatch) {
+            const endLine = findKeywordContinuationEndLine(document, element.lineIndex);
+            if (!(await removeKeywordTextFromLines(editor, element.lineIndex, endLine, attributeMatch[0], true))) {
+                return false;
             };
-        } else {
-            // Group is in the middle or at the beginning
-            startOffset = document.offsetAt(new vscode.Position(firstLine, 0));
-            
-            // Include the line break after the last line of the group
-            const afterGroupPos = document.lineAt(lastLine).rangeIncludingLineBreak.end;
-            endOffset = document.offsetAt(afterGroupPos);
-        };
-        
-        // Validate the range
-        if (startOffset < endOffset && startOffset >= 0 && endOffset <= docLength) {
-            ranges.push({ startOffset, endOffset });
         };
     };
-    
-    return ranges;
+
+    return true;
 };

--- a/src/dspf-edit.commands/dspf-edit.add-color.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-color.ts
@@ -6,7 +6,7 @@
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, parseIndicatorsFromLine, groupConsecutiveLines, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
+import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, parseIndicatorsFromLine, applyWorkspaceEdit, removeKeywordTextFromLines, findKeywordContinuationEndLine } from '../dspf-edit.utils/dspf-edit.helper';
 import { fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
 
 // INTERFACES AND TYPES
@@ -492,92 +492,44 @@ async function removeColorsFromElement(editor: vscode.TextEditor, element: any):
     if (currentColors.length === 0) return true;
 
     const document = editor.document;
-    const workspaceEdit = new vscode.WorkspaceEdit();
-    const uri = document.uri;
     const isConstant = element.kind === 'constant';
 
     // Separate inline colors from line colors
     const inlineColors = currentColors.filter(color => color.isInlineColor);
     const lineColors = currentColors.filter(color => !color.isInlineColor);
 
-    // Handle inline color removal (for fields)
+    // Handle separate color lines removal first, from the last line to the first: DDS allows other
+    // keywords to share these lines (and their keyword area can itself continue onto further lines
+    // via a trailing hyphen), so removeKeywordTextFromLines strips just the color's own text and
+    // re-flows whatever remains back onto as few lines as it now fits in — which can itself delete
+    // or merge lines, shifting the line numbers of everything below it (but never above). Since the
+    // field's own line always comes before any of these, handling these first (latest to earliest)
+    // and the inline case last keeps every remaining entry's own line index valid when its turn comes.
+    for (const color of [...lineColors].sort((a, b) => b.lineIndex! - a.lineIndex!)) {
+        const lineIndex = color.lineIndex!;
+        const lineText = document.lineAt(lineIndex).text;
+        const colorMatch = lineText.match(/COLOR\([A-Z]{3}\)/);
+        if (!colorMatch) {
+            continue;
+        };
+
+        const endLine = findKeywordContinuationEndLine(document, lineIndex);
+        if (!(await removeKeywordTextFromLines(editor, lineIndex, endLine, colorMatch[0], false))) {
+            return false;
+        };
+    };
+
+    // Handle inline color removal (for fields) last — same reasoning as above.
     if (!isConstant && inlineColors.length > 0) {
-        const fieldLine = document.lineAt(element.lineIndex);
-        const fieldLineText = fieldLine.text;
-        
-        // Remove everything from position 44 onwards
-        const truncatedLine = fieldLineText.substring(0, 44).trimRight();
-        workspaceEdit.replace(uri, fieldLine.range, truncatedLine);
-    };
-
-    // Handle separate color lines removal
-    if (lineColors.length > 0) {
-        const colorLineIndices = lineColors.map(color => color.lineIndex!);
-        const deletionRanges = calculateColorDeletionRanges(document, colorLineIndices);
-        
-        // Apply deletions in reverse order to maintain offsets
-        for (let i = deletionRanges.length - 1; i >= 0; i--) {
-            const { startOffset, endOffset } = deletionRanges[i];
-            const startPos = document.positionAt(startOffset);
-            const endPos = document.positionAt(endOffset);
-            workspaceEdit.delete(uri, new vscode.Range(startPos, endPos));
-        };
-    };
-
-    return applyWorkspaceEdit(workspaceEdit, 'remove the colors');
-};
-
-/**
- * Calculates precise deletion ranges for standalone color lines.
- * Handles edge cases to prevent blank lines at the end of the file.
- * @param document - The text document
- * @param colorLines - Array of line indices containing standalone colors
- * @returns Array of deletion ranges with start and end offsets
- */
-function calculateColorDeletionRanges(
-    document: vscode.TextDocument, 
-    colorLines: number[]
-): { startOffset: number; endOffset: number }[] {
-    const docText = document.getText();
-    const docLength = docText.length;
-    const ranges: { startOffset: number; endOffset: number }[] = [];
-    
-    // Group consecutive lines for more efficient deletion
-    const lineGroups = groupConsecutiveLines(colorLines);
-    
-    for (const group of lineGroups) {
-        const firstLine = group[0];
-        const lastLine = group[group.length - 1];
-        
-        let startOffset: number;
-        let endOffset: number;
-        
-        if (lastLine === document.lineCount - 1) {
-            // Group includes the last line of the document
-            if (firstLine === 0) {
-                // Entire document is color lines - delete everything
-                startOffset = 0;
-                endOffset = docLength;
-            } else {
-                // Delete from end of previous line to end of file
-                const prevLineEndPos = document.lineAt(firstLine - 1).range.end;
-                startOffset = document.offsetAt(prevLineEndPos);
-                endOffset = docLength;
+        const fieldLineText = document.lineAt(element.lineIndex).text;
+        const colorMatch = fieldLineText.substring(44).match(/COLOR\([A-Z]{3}\)/);
+        if (colorMatch) {
+            const endLine = findKeywordContinuationEndLine(document, element.lineIndex);
+            if (!(await removeKeywordTextFromLines(editor, element.lineIndex, endLine, colorMatch[0], true))) {
+                return false;
             };
-        } else {
-            // Group is in the middle or at the beginning
-            startOffset = document.offsetAt(new vscode.Position(firstLine, 0));
-            
-            // Include the line break after the last line of the group
-            const afterGroupPos = document.lineAt(lastLine).rangeIncludingLineBreak.end;
-            endOffset = document.offsetAt(afterGroupPos);
-        };
-        
-        // Validate the range
-        if (startOffset < endOffset && startOffset >= 0 && endOffset <= docLength) {
-            ranges.push({ startOffset, endOffset });
         };
     };
-    
-    return ranges;
+
+    return true;
 };

--- a/src/dspf-edit.commands/dspf-edit.add-editing-keywords.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-editing-keywords.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, groupConsecutiveLines, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
+import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, applyWorkspaceEdit, removeKeywordPatternsFromLines, findKeywordContinuationEndLine } from '../dspf-edit.utils/dspf-edit.helper';
 import { getResolvedRef } from '../dspf-edit.ibmi/dspf-edit.ibmi-integration';
 
 // INTERFACES AND TYPES
@@ -502,6 +502,17 @@ function getAvailableEditCodes(): EditCodeOption[] {
     ];
 };
 
+/**
+ * Valid field lengths for EDTCDE(W) and EDTCDE(Y) — unlike the comma/sign codes, these two only
+ * work for the specific digit lengths documented in the DDS reference's Table 6/7 footnotes
+ * (confirmed against real STRSDA, which rejects any other length). Keep in sync with
+ * DATE_EDIT_CODE_DIGIT_GROUPS in dspf-edit.record-preview-panel.ts.
+ */
+const DATE_EDIT_CODE_VALID_LENGTHS: Record<'W' | 'Y', number[]> = {
+    W: [5, 6, 7, 8],
+    Y: [3, 4, 5, 6, 7, 8]
+};
+
 // USER INTERACTION FUNCTIONS
 
 /**
@@ -530,6 +541,17 @@ async function collectEditCode(fieldInfo: any): Promise<EditConfiguration | null
     const editCodeOption = availableEditCodes.find(ec => ec.code === selectedItem.code);
 
     if (!editCodeOption) return null;
+
+    if (editCodeOption.code === 'W' || editCodeOption.code === 'Y') {
+        const fieldLength = Number(fieldInfo.length) || 0;
+        const validLengths = DATE_EDIT_CODE_VALID_LENGTHS[editCodeOption.code];
+        if (!validLengths.includes(fieldLength)) {
+            vscode.window.showWarningMessage(
+                `EDTCDE(${editCodeOption.code}) is only valid for a field length of ${validLengths.join(', ')} — ${fieldInfo.name} is length ${fieldLength}.`
+            );
+            return null;
+        };
+    };
 
     const editConfig: EditConfiguration = {
         type: 'EDTCDE',
@@ -983,94 +1005,42 @@ async function removeEditingFromField(editor: vscode.TextEditor, element: any): 
     if (editingLines.length === 0) return true;
 
     const document = editor.document;
-    const workspaceEdit = new vscode.WorkspaceEdit();
-    const uri = document.uri;
 
     // Group lines by type: field line vs standalone editing lines
     const fieldLineIndex = element.lineIndex;
     const standaloneEditingLines = editingLines.filter(lineIndex => lineIndex !== fieldLineIndex);
     const hasFieldLineEditing = editingLines.includes(fieldLineIndex);
 
-    // Handle standalone editing lines
-    if (standaloneEditingLines.length > 0) {
-        const deletionRanges = calculateEditingDeletionRanges(document, standaloneEditingLines);
-        
-        // Apply deletions in reverse order to maintain offsets
-        for (let i = deletionRanges.length - 1; i >= 0; i--) {
-            const { startOffset, endOffset } = deletionRanges[i];
-            const startPos = document.positionAt(startOffset);
-            const endPos = document.positionAt(endOffset);
-            workspaceEdit.delete(uri, new vscode.Range(startPos, endPos));
+    const editingPatterns = [/EDTCDE\([^)]*\)/g, /EDTWRD\([^)]*\)/g, /EDTMSK\([^)]*\)/g];
+
+    // Handle standalone editing lines. DDS allows other keywords to share this same line (e.g.
+    // "EDTCDE(3) DSPATR(HI) COLOR(RED)"), and that shared keyword area can itself continue onto
+    // further lines via a trailing hyphen — removeKeywordPatternsFromLines strips just the
+    // EDTCDE/EDTWRD/EDTMSK text and re-flows whatever remains back onto as few lines as it now fits
+    // in. Processed from the last line to the first: each removal can itself delete or merge lines,
+    // which would shift the line numbers of everything below it (but never above), so handling later
+    // lines first keeps every remaining entry's own line index valid when its turn comes.
+    for (const lineIndex of [...standaloneEditingLines].sort((a, b) => b - a)) {
+        const endLine = findKeywordContinuationEndLine(document, lineIndex);
+        if (!(await removeKeywordPatternsFromLines(editor, lineIndex, endLine, editingPatterns, false))) {
+            return false;
         };
     };
 
-    // Handle editing on field line (just remove the editing parts)
+    // Handle editing on field line, same reasoning as above (and always last, since it's the
+    // topmost line here and unaffected by any of the standalone removals above it).
     if (hasFieldLineEditing) {
-        const line = document.lineAt(fieldLineIndex);
-        const lineText = line.text;
-        const cleanedText = lineText
-            .replace(/EDTCDE\([^)]*\)/g, '')
-            .replace(/EDTWRD\([^)]*\)/g, '')
-            .replace(/EDTMSK\([^)]*\)/g, '')
-            .trimEnd();
-        workspaceEdit.replace(uri, line.range, cleanedText);
+        const endLine = findKeywordContinuationEndLine(document, fieldLineIndex);
+        if (!(await removeKeywordPatternsFromLines(editor, fieldLineIndex, endLine, editingPatterns, true))) {
+            return false;
+        };
     };
 
-    if (!(await applyWorkspaceEdit(workspaceEdit, 'remove the field editing'))) {
-        return false;
-    };
     await vscode.commands.executeCommand('cursorRight');
     await vscode.commands.executeCommand('cursorLeft');
 
     vscode.window.showInformationMessage(`Removed field editing from ${element.name}.`);
     return true;
-};
-
-/**
- * Calculates precise deletion ranges for standalone editing lines.
- * @param document - The text document
- * @param editingLines - Array of line indices containing editing
- * @returns Array of deletion ranges with start and end offsets
- */
-function calculateEditingDeletionRanges(
-    document: vscode.TextDocument, 
-    editingLines: number[]
-): { startOffset: number; endOffset: number }[] {
-    const docText = document.getText();
-    const docLength = docText.length;
-    const ranges: { startOffset: number; endOffset: number }[] = [];
-    
-    // Group consecutive lines for more efficient deletion
-    const lineGroups = groupConsecutiveLines(editingLines);
-    
-    for (const group of lineGroups) {
-        const firstLine = group[0];
-        const lastLine = group[group.length - 1];
-        
-        let startOffset: number;
-        let endOffset: number;
-        
-        if (lastLine === document.lineCount - 1) {
-            if (firstLine === 0) {
-                startOffset = 0;
-                endOffset = docLength;
-            } else {
-                const prevLineEndPos = document.lineAt(firstLine - 1).range.end;
-                startOffset = document.offsetAt(prevLineEndPos);
-                endOffset = docLength;
-            };
-        } else {
-            startOffset = document.offsetAt(new vscode.Position(firstLine, 0));
-            const afterGroupPos = document.lineAt(lastLine).rangeIncludingLineBreak.end;
-            endOffset = document.offsetAt(afterGroupPos);
-        };
-        
-        if (startOffset < endOffset && startOffset >= 0 && endOffset <= docLength) {
-            ranges.push({ startOffset, endOffset });
-        };
-    };
-    
-    return ranges;
 };
 
 // LINE DETECTION FUNCTIONS

--- a/src/dspf-edit.commands/dspf-edit.remove-attribute.ts
+++ b/src/dspf-edit.commands/dspf-edit.remove-attribute.ts
@@ -1,41 +1,13 @@
 /*
-    Christian Larsen, 2025
+    Christian Larsen, 2026
     "RPG structure"
     dspf-edit.remove-attribute.ts
 */
 
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
-import { checkForEditorAndDocument, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
+import { checkForEditorAndDocument, removeKeywordTextFromLines } from '../dspf-edit.utils/dspf-edit.helper';
 import { fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-
-// TYPE DEFINITIONS
-
-/**
- * Information about lines to be deleted for an element and its attributes.
- */
-interface DeletionRange {
-    startLine: number;
-    endLine: number;
-    startLineWithField: boolean
-};
-
-/**
- * Complete deletion plan for an element.
- */
-interface ElementDeletionPlan {
-    range: DeletionRange;
-    totalLines: number;
-};
-
-/**
- * Boundaries information for calculating deletion offsets.
- */
-interface DeletionBoundaries {
-    startLine: number;
-    endLine: number;
-    isLastInDocument: boolean;
-};
 
 // COMMAND REGISTRATION FUNCTIONS
 
@@ -84,31 +56,22 @@ async function handleRemoveAttributeCommand(node: DdsNode): Promise<void> {
             vscode.window.showWarningMessage(`Could not determine parent field/constant or record for this attribute.`);
             return;
         };
-        
-        // Check if the start line contains a field definition
-        let startLineWithField = false;
-        if (parentInfo.parentType === 'field' && parentInfo.parentDetails.lineIndex === startLine) {
-            startLineWithField = true;
-        };
 
-        // Create deletion plan
-        const deletionPlan : ElementDeletionPlan = {
-            range: {
-                startLine,
-                endLine,
-                startLineWithField
-            },
-            totalLines: (endLine - startLine + 1)
-        };
+        // Check if the start line contains a field definition — its columns 1-44 must survive even
+        // if this attribute turns out to be the only thing in its keyword area.
+        const startLineWithField = parentInfo.parentType === 'field' && parentInfo.parentDetails.lineIndex === startLine;
 
-        // Show confirmation dialog with details
         const confirmed = await showDeletionConfirmation();
         if (!confirmed) {
             return;
         };
 
-        // Execute the deletion
-        if (!(await executeElementDeletion(editor, deletionPlan))) {
+        // DDS allows several keywords to share one physical line (e.g. "EDTCDE(3) DSPATR(HI)
+        // COLOR(RED)"), and a keyword's own text can itself continue onto the next line via a
+        // trailing hyphen — removeKeywordTextFromLines reconstructs the joined keyword text across
+        // the attribute's own line range, removes just this attribute's text, and re-paginates
+        // whatever remains, rather than deleting whole lines that might hold sibling keywords too.
+        if (!(await removeKeywordTextFromLines(editor, startLine, endLine, element.value, startLineWithField))) {
             return;
         };
         await vscode.commands.executeCommand('cursorRight');
@@ -127,9 +90,9 @@ async function handleRemoveAttributeCommand(node: DdsNode): Promise<void> {
  * @returns Promise that resolves to true if user confirms deletion, false otherwise
  */
 async function showDeletionConfirmation(): Promise<boolean> {
-    
+
     let message = `Are you sure you want to delete attribute?`;
-    
+
     // Show confirmation dialog
     const choice = await vscode.window.showWarningMessage(
         message,
@@ -139,145 +102,6 @@ async function showDeletionConfirmation(): Promise<boolean> {
     );
 
     return choice === "Delete";
-};
-
-// DELETION EXECUTION FUNCTIONS
-
-/**
- * Executes the deletion of an element and its attributes by applying workspace edits.
- * Handles special case where the first line contains a field definition that should be preserved.
- * @param editor - The active text editor
- * @param deletionPlan - The plan containing details about what lines to delete
- */
-async function executeElementDeletion(
-    editor: vscode.TextEditor,
-    deletionPlan: ElementDeletionPlan
-): Promise<boolean> {
-    const uri = editor.document.uri;
-
-    // Handle special case: first line has a field definition
-    if (deletionPlan.range.startLineWithField) {
-        // Remove only the "attributes" part of the line (columns 45-80)
-        let line = editor.document.lineAt(deletionPlan.range.startLine);
-        let lineText = line.text;
-        let before = lineText.substring(0,44); // Keep field definition part
-        let after = lineText.length > 80 ? lineText.substring(80) : ""; // Keep any text after position 80
-        let middle = " ".repeat(80 - 44); // Clear the attributes section with spaces
-        let newLine = before + middle + after;
-
-        // Replace the entire line in the document
-        const fieldLineEdit = new vscode.WorkspaceEdit();
-        fieldLineEdit.replace(uri, line.range, newLine);
-        if (!(await applyWorkspaceEdit(fieldLineEdit, 'delete the attribute'))) {
-            return false;
-        };
-
-        // If there are additional lines to delete, update the plan to start from next line
-        if (deletionPlan.range.endLine > deletionPlan.range.startLine) {
-            deletionPlan.range.startLine ++;
-
-            // Process remaining lines in the range, as a separate edit against the now-updated document
-            const remainingLinesEdit = new vscode.WorkspaceEdit();
-            await addDeletionRange(remainingLinesEdit, uri, editor, deletionPlan.range);
-            return applyWorkspaceEdit(remainingLinesEdit, 'delete the attribute');
-        } else {
-            // Only one line to process, and we've already handled it
-            return true;
-        };
-    } else {
-        // Standard case: delete entire lines
-        const workspaceEdit = new vscode.WorkspaceEdit();
-        await addDeletionRange(workspaceEdit, uri, editor, deletionPlan.range);
-        return applyWorkspaceEdit(workspaceEdit, 'delete the attribute');
-    };
-};
-
-/**
- * Adds a deletion range to the workspace edit with proper handling of line breaks and edge cases.
- * Calculates precise character offsets to ensure proper deletion without leaving orphaned line breaks.
- * @param workspaceEdit - The workspace edit to modify
- * @param uri - The document URI
- * @param editor - The text editor containing the document
- * @param range - The range of lines to delete
- */
-async function addDeletionRange(
-    workspaceEdit: vscode.WorkspaceEdit,
-    uri: vscode.Uri,
-    editor: vscode.TextEditor,
-    range: DeletionRange
-): Promise<void> {
-    const { startLine, endLine } = range;
-    const document = editor.document;
-    
-    // Validate line indices to prevent out-of-bounds errors
-    if (startLine < 0 || endLine >= document.lineCount) {
-        console.warn(`Invalid line range: ${startLine}-${endLine} for attribute`);
-        return;
-    };
-
-    // Calculate precise deletion offsets to handle edge cases
-    const { startOffset, endOffset } = calculateDeletionOffsets(document, {
-        startLine,
-        endLine,
-        isLastInDocument: endLine === document.lineCount - 1
-    });
-
-    // Convert offsets back to positions for the deletion range
-    const deleteRange = new vscode.Range(
-        document.positionAt(startOffset),
-        document.positionAt(endOffset)
-    );
-
-    workspaceEdit.delete(uri, deleteRange);
-};
-
-// UTILITY FUNCTIONS
-
-/**
- * Calculates the precise character offsets for deletion to handle edge cases properly.
- * @param document - The text document
- * @param boundaries - The deletion boundaries
- * @returns Start and end offsets for deletion
- */
-function calculateDeletionOffsets(
-    document: vscode.TextDocument, 
-    boundaries: DeletionBoundaries
-): { startOffset: number, endOffset: number } {
-    const docText = document.getText();
-    const docLength = docText.length;
-    const { startLine, endLine, isLastInDocument } = boundaries;
-
-    let startOffset: number;
-    let endOffset: number;
-
-    if (isLastInDocument && endLine === document.lineCount - 1) {
-        // Deleting the last lines in the file
-        if (startLine === 0) {
-            // Only lines in file - delete everything
-            startOffset = 0;
-            endOffset = docLength;
-        } else {
-            // Delete from end of previous line to end of file
-            const prevLineEndPos = document.lineAt(startLine - 1).range.end;
-            startOffset = document.offsetAt(prevLineEndPos);
-            endOffset = docLength;
-        };
-    } else {
-        // Deleting lines in the middle or at the beginning
-        startOffset = document.offsetAt(new vscode.Position(startLine, 0));
-        
-        // Include the line break after the last line of the range
-        if (endLine < document.lineCount - 1) {
-            const afterRangePos = document.lineAt(endLine).rangeIncludingLineBreak.end;
-            endOffset = document.offsetAt(afterRangePos);
-        } else {
-            // Last line in document (but not the only lines - shouldn't happen in this case)
-            const lastLineEndPos = document.lineAt(endLine).range.end;
-            endOffset = document.offsetAt(lastLineEndPos);
-        };
-    };
-
-    return { startOffset, endOffset };
 };
 
 /**
@@ -306,10 +130,10 @@ function findAttributeParentFromFieldsPerRecords(attributeLineIndex: number): {
                     parentDetails: field
                 };
             };
-            
+
             // Check if the attribute belongs to this field based on field's attributes
             for (const attr of field.attributes || []) {
-                if (attr.lineIndex <= attributeLineIndex && 
+                if (attr.lineIndex <= attributeLineIndex &&
                     (attr.lastLineIndex || attr.lineIndex) >= attributeLineIndex) {
                     return {
                         recordName: recordEntry.record,
@@ -320,7 +144,7 @@ function findAttributeParentFromFieldsPerRecords(attributeLineIndex: number): {
                 };
             };
         };
-        
+
         // Search within constants of the current record
         for (const constant of recordEntry.constants) {
             // Check if the attribute is within the constant's line range
@@ -333,10 +157,10 @@ function findAttributeParentFromFieldsPerRecords(attributeLineIndex: number): {
                     parentDetails: constant
                 };
             };
-            
+
             // Check if the attribute belongs to this constant based on constant's attributes
             for (const attr of constant.attributes || []) {
-                if (attr.lineIndex <= attributeLineIndex && 
+                if (attr.lineIndex <= attributeLineIndex &&
                     (attr.lastLineIndex || attr.lineIndex) >= attributeLineIndex) {
                     return {
                         recordName: recordEntry.record,
@@ -348,7 +172,7 @@ function findAttributeParentFromFieldsPerRecords(attributeLineIndex: number): {
             };
         };
     };
-    
+
     // Return null values if no parent is found
     return {
         recordName: null,

--- a/src/dspf-edit.ibmi/dspf-edit.ibmi-integration.ts
+++ b/src/dspf-edit.ibmi/dspf-edit.ibmi-integration.ts
@@ -7,6 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsAttribute, DdsElement, DdsField, attributesFileLevel } from '../dspf-edit.model/dspf-edit.model';
 import { DecimalFormat } from '../dspf-edit.utils/dspf-edit.decimal-format';
+import { DateSeparatorFormat } from '../dspf-edit.utils/dspf-edit.date-format';
 
 /**
  * Isolated from the rest of the extension on purpose: this is the only file that knows about the
@@ -229,6 +230,38 @@ export async function resolveDecimalFormatFromSystem(): Promise<DecimalFormat> {
     const mapped = QDECFMT_TO_DECIMAL_FORMAT[raw];
     if (!mapped) {
         throw new Error(`Unrecognized QDECFMT value '${raw}' on the connected IBM i.`);
+    };
+    return mapped;
+};
+
+/**
+ * Maps the IBM i QDATSEP system value's raw character to the extension's DateSeparatorFormat: '/'
+ * (the default) and '-' (common in European locales, confirmed against real STRSDA). QDATSEP also
+ * allows '.' and ',', which aren't mapped since neither format is exposed in the configuration panel.
+ */
+const QDATSEP_TO_DATE_SEPARATOR_FORMAT: Record<string, DateSeparatorFormat> = {
+    '/': 'US',
+    '-': 'European'
+};
+
+/**
+ * Reads the connected IBM i's QDATSEP system value and maps it to the extension's date separator
+ * format. Throws (no connection, unrecognized value) rather than returning a sentinel — callers show
+ * it to the user.
+ */
+export async function resolveDateSeparatorFormatFromSystem(): Promise<DateSeparatorFormat> {
+    const connection = getIBMiConnection();
+    if (!connection) {
+        throw new Error('No active IBM i connection. Connect via the Code for i extension first.');
+    };
+
+    const rows = await connection.runSQL(
+        `SELECT CURRENT_CHARACTER_VALUE FROM QSYS2.SYSTEM_VALUE_INFO WHERE SYSTEM_VALUE_NAME = 'QDATSEP'`
+    );
+    const raw = String(rows[0]?.CURRENT_CHARACTER_VALUE ?? '').trim();
+    const mapped = QDATSEP_TO_DATE_SEPARATOR_FORMAT[raw];
+    if (!mapped) {
+        throw new Error(`Unrecognized QDATSEP value '${raw}' on the connected IBM i.`);
     };
     return mapped;
 };

--- a/src/dspf-edit.parser/dspf-edit.parser.ts
+++ b/src/dspf-edit.parser/dspf-edit.parser.ts
@@ -548,8 +548,22 @@ function parseConstantElement(
     lastRecord: string
 ) {
     // Handle multi-line constants
-    const { fullValue, lastLineIndex } = extractMultiLineConstant(lines, lineIndex, trimmedLine);
-    const { attributes, nextIndex } = extractAttributes('C', lines, lastLineIndex, true, components.indicators, components.displayFormat);
+    const { fullValue: rawValue, lastLineIndex } = extractMultiLineConstant(lines, lineIndex, trimmedLine);
+    const { value: fullValue, keywordText } = splitConstantValueAndKeywords(rawValue);
+    const { attributes: continuationAttributes, nextIndex } = extractAttributes('C', lines, lastLineIndex, true, components.indicators, components.displayFormat);
+
+    // Keywords sharing the constant's own line (see splitConstantValueAndKeywords) become real
+    // attributes here directly; keywords on a separate continuation line below are instead picked
+    // up later via linkAttributesToParents, same as before this line/keyword split existed.
+    const inlineAttributes: DdsAttribute[] = tokenizeKeywordText(keywordText).map(value => ({
+        kind: 'attribute' as const,
+        lineIndex,
+        lastLineIndex,
+        value,
+        indicators: components.indicators || [],
+        displayFormat: components.displayFormat
+    }));
+    const attributes = [...inlineAttributes, ...(continuationAttributes || [])];
 
     // Check if the current record (lastRecord) is a subfile by looking at its attributes
     const currentRecordEntry = fieldsPerRecords.find(r => r.record === lastRecord);
@@ -633,6 +647,45 @@ function extractMultiLineConstant(
     };
 
     return { fullValue: fullValue.trim(), lastLineIndex: continuationIndex };
+};
+
+/**
+ * Splits a constant line's already-continuation-joined raw text into its own value (a quoted
+ * literal, or a bare system keyword/keyword-call like DATE(*Y), TIME, USER) and any further DDS
+ * keyword text sharing the same physical line. DDS allows any number of keywords to follow a
+ * constant's value on one line, same as an ordinary field definition line (e.g. "'Text' COLOR(BLU)"
+ * or "DATE(*Y) EDTCDE(Y)") — without this split, that trailing keyword text would be swallowed into
+ * the constant's own value instead of becoming a real, recognized attribute (confirmed against real
+ * STRSDA, which renders such a line exactly as if the keyword were on its own line below).
+ * @param raw - The constant's raw value text (post multi-line-continuation joining), already trimmed
+ */
+function splitConstantValueAndKeywords(raw: string): { value: string; keywordText: string } {
+    if (raw.startsWith("'")) {
+        // Find the closing quote, treating '' as an escaped quote inside the literal.
+        let i = 1;
+        while (i < raw.length) {
+            if (raw[i] === "'") {
+                if (raw[i + 1] === "'") { i += 2; continue; };
+                break;
+            };
+            i++;
+        };
+        return { value: raw.slice(0, i + 1), keywordText: raw.slice(i + 1).trim() };
+    };
+
+    // Bare word or keyword-call form (DATE(*Y), TIME, USER, SYSNAME, ...): the first token is the value.
+    const match = raw.match(/^([A-Za-z][A-Za-z0-9]*(?:\([^()]*\))?)\s*(.*)$/);
+    return match ? { value: match[1], keywordText: match[2].trim() } : { value: raw, keywordText: '' };
+};
+
+/**
+ * Splits a run of inline DDS keyword text (e.g. "EDTCDE(Y) DSPATR(HI)") into its individual keyword
+ * tokens, matching the one-keyword-per-DdsAttribute convention the rest of the parser and preview
+ * rely on (e.g. hasDisplayAttribute's exact-match check).
+ * @param text - Keyword text: zero or more keywords separated by spaces
+ */
+function tokenizeKeywordText(text: string): string[] {
+    return text.match(/[A-Za-z][A-Za-z0-9]*(?:\([^()]*\))?/g) ?? [];
 };
 
 /**
@@ -786,17 +839,31 @@ function extractAttributes(
         return { attributes: [], nextIndex: currentIndex };
     };
 
-    // Create attribute object
-    const attribute: DdsAttribute = {
-        kind: 'attribute',
+    const baseAttribute = {
+        kind: 'attribute' as const,
         lineIndex: startIndex,
         lastLineIndex: currentIndex,
-        value: lineType === 'C' ? '' : rawAttributeText,
         indicators: includeIndicators && indicators ? indicators : [],
         displayFormat: includeIndicators ? displayFormat : undefined
     };
 
-    return { attributes: [attribute], nextIndex: currentIndex };
+    if (lineType === 'C') {
+        // A constant's own further hyphen-continued keyword text (rare — reaching here means this
+        // constant's value already spanned to `currentIndex` without ending, per its own
+        // extractMultiLineConstant call) isn't split into per-keyword attributes.
+        return { attributes: [{ ...baseAttribute, value: '' }], nextIndex: currentIndex };
+    };
+
+    // DDS allows any number of keywords on one physical line (e.g. "EDTCDE(3) DSPATR(HI)
+    // COLOR(RED)") — split them into one DdsAttribute per keyword, matching the one-keyword-per-
+    // DdsAttribute convention the preview relies on (e.g. hasDisplayAttribute's exact-match check).
+    // Falls back to the whole raw text as a single attribute if it doesn't tokenize as expected,
+    // rather than silently dropping it.
+    const tokens = tokenizeKeywordText(rawAttributeText);
+    const values = tokens.length > 0 ? tokens : [rawAttributeText];
+    const attributes: DdsAttribute[] = values.map(value => ({ ...baseAttribute, value }));
+
+    return { attributes, nextIndex: currentIndex };
 };
 
 /**

--- a/src/dspf-edit.utils/dspf-edit.date-format.ts
+++ b/src/dspf-edit.utils/dspf-edit.date-format.ts
@@ -1,0 +1,69 @@
+/*
+    Christian Larsen, 2026
+    "RPG structure"
+    utils/dspf-edit.date-format.ts
+*/
+
+import { ExtensionState } from '../dspf-edit.states/state';
+
+/** The date-separator convention the preview renders EDTCDE(W)/EDTCDE(Y)-edited numeric masks with. */
+export type DateSeparatorFormat = 'US' | 'European';
+
+/** One selectable date separator, for the configuration panel. */
+export interface DateSeparatorOption {
+    value: DateSeparatorFormat;
+    label: string;
+    example: string;
+    separator: string;
+};
+
+/**
+ * The two date-separator conventions the preview supports — matching the two characters the IBM i
+ * QDATSEP system value (and the DATSEP job attribute it defaults) can hold: '/' (the system default)
+ * and '-' (common in European locales, confirmed against real STRSDA). QDATSEP also allows '.' and
+ * ',', but those aren't exposed here since neither has been reported or confirmed in practice.
+ */
+export const DATE_SEPARATOR_OPTIONS: DateSeparatorOption[] = [
+    { value: 'US', label: 'US (QDATSEP /)', example: '12/31/25', separator: '/' },
+    { value: 'European', label: 'European (QDATSEP -)', example: '31-12-25', separator: '-' }
+];
+
+const STORAGE_KEY = 'dspf-edit.dateSeparatorFormat';
+
+/** The date separator format used until the user picks or fetches their own — matches QDATSEP's own default ('/'). */
+export const DEFAULT_DATE_SEPARATOR_FORMAT: DateSeparatorFormat = 'US';
+
+/**
+ * Reads the configured date separator format — stored in the extension's own global storage
+ * (`ExtensionContext.globalState`), same as the decimal format (see dspf-edit.decimal-format.ts).
+ * Falls back to the default when unset or not a recognized value.
+ */
+export function getDateSeparatorFormat(): DateSeparatorFormat {
+    const value = ExtensionState.context.globalState.get<DateSeparatorFormat>(STORAGE_KEY);
+    return DATE_SEPARATOR_OPTIONS.some(opt => opt.value === value) ? value! : DEFAULT_DATE_SEPARATOR_FORMAT;
+};
+
+/** The separator character for the currently configured date separator format. */
+export function getDateSeparator(): string {
+    return DATE_SEPARATOR_OPTIONS.find(opt => opt.value === getDateSeparatorFormat())!.separator;
+};
+
+/**
+ * Saves the date separator format, in the extension's own global storage.
+ * @param value - The new date separator format
+ */
+export async function setDateSeparatorFormat(value: DateSeparatorFormat): Promise<void> {
+    await ExtensionState.context.globalState.update(STORAGE_KEY, value);
+};
+
+/**
+ * Resets the date separator format to its default (US).
+ * @returns Whether it actually changed (false if already at default)
+ */
+export async function resetDateSeparatorFormat(): Promise<boolean> {
+    if (getDateSeparatorFormat() === DEFAULT_DATE_SEPARATOR_FORMAT) {
+        return false;
+    };
+    await ExtensionState.context.globalState.update(STORAGE_KEY, undefined);
+    return true;
+};

--- a/src/dspf-edit.utils/dspf-edit.helper.ts
+++ b/src/dspf-edit.utils/dspf-edit.helper.ts
@@ -976,6 +976,192 @@ export async function applyWorkspaceEdit(workspaceEdit: vscode.WorkspaceEdit, co
 };
 
 /**
+ * Finds the last physical line a keyword area starting at `startLine` continues onto, by following
+ * its trailing continuation hyphen(s) — the same rule the parser itself uses (see extractAttributes
+ * in dspf-edit.parser.ts). Pass the result as removeKeywordTextFromLines's `lastLineIndex` so it can
+ * see (and, once a keyword is removed, re-flow) the whole keyword area rather than just its own
+ * first line.
+ * @param document - The text document
+ * @param startLine - The keyword area's first line
+ */
+export function findKeywordContinuationEndLine(document: vscode.TextDocument, startLine: number): number {
+    let endLine = startLine;
+    while (endLine < document.lineCount - 1) {
+        const part = document.lineAt(endLine).text.substring(44, 80);
+        if (!part.trim().endsWith('-')) {
+            break;
+        };
+        endLine++;
+    };
+    return endLine;
+};
+
+/**
+ * Removes one keyword's own text (e.g. "COLOR(RED)") from the DDS keyword area (columns 45-80) of
+ * the line(s) it occupies. Handles two things a naive "delete the whole line range" approach gets
+ * wrong: the range may span more than one physical line via a trailing continuation hyphen (e.g.
+ * "EDTCDE(3) DSPATR(HI) COLOR(RED) DSP-" continuing onto "ATR(RI)" below), and those line(s) may be
+ * shared with sibling keywords that must survive. Reconstructs the joined logical keyword text
+ * across the range, removes `value` from it, and re-paginates whatever remains back across the same
+ * starting line(s) — re-inserting a continuation hyphen only where content still doesn't fit on one
+ * line, and deleting any line(s) left over once the remainder needs fewer lines than before.
+ * @param editor - The active text editor
+ * @param lineIndex - The keyword's own first line
+ * @param lastLineIndex - The keyword's own last line (equal to lineIndex when it doesn't continue)
+ * @param value - The keyword's own text, exactly as parsed (e.g. "COLOR(RED)")
+ * @param preserveFirstLine - True when `lineIndex` is a field/constant's own definition line (whose
+ * columns 1-44 must survive even when nothing else is left in its keyword area) rather than a
+ * standalone attribute line (which can be deleted outright in that case)
+ */
+export async function removeKeywordTextFromLines(
+    editor: vscode.TextEditor,
+    lineIndex: number,
+    lastLineIndex: number,
+    value: string,
+    preserveFirstLine: boolean = false
+): Promise<boolean> {
+    return rewriteKeywordArea(editor, lineIndex, lastLineIndex, preserveFirstLine, joined => {
+        let start = joined.indexOf(value);
+        if (start === -1) {
+            vscode.window.showErrorMessage(`Could not locate the attribute's text on its source line(s).`);
+            return null;
+        };
+        let end = start + value.length;
+        if (joined[start - 1] === ' ') {
+            start -= 1;
+        } else if (joined[end] === ' ') {
+            end += 1;
+        };
+        return (joined.slice(0, start) + joined.slice(end)).replace(/\s+$/, '');
+    });
+};
+
+/**
+ * Removes every match of any of `patterns` (e.g. EDTCDE()/EDTWRD()/EDTMSK() at once) from the DDS
+ * keyword area of the line(s) it occupies, with the same continuation-aware, sibling-preserving
+ * re-pagination as removeKeywordTextFromLines — used where several *kinds* of keyword need removing
+ * together rather than one specific keyword's exact text.
+ * @param editor - The active text editor
+ * @param lineIndex - The keyword area's first line
+ * @param lastLineIndex - The keyword area's last line (equal to lineIndex when it doesn't continue)
+ * @param patterns - Regexes to remove (each applied with a global flag's worth of repeats via `replace`)
+ * @param preserveFirstLine - See removeKeywordTextFromLines
+ */
+export async function removeKeywordPatternsFromLines(
+    editor: vscode.TextEditor,
+    lineIndex: number,
+    lastLineIndex: number,
+    patterns: RegExp[],
+    preserveFirstLine: boolean = false
+): Promise<boolean> {
+    return rewriteKeywordArea(editor, lineIndex, lastLineIndex, preserveFirstLine, joined => {
+        let result = joined;
+        for (const pattern of patterns) {
+            result = result.replace(pattern, '');
+        };
+        return result.replace(/\s{2,}/g, ' ').trim();
+    });
+};
+
+/**
+ * Shared plumbing for removeKeywordTextFromLines/removeKeywordPatternsFromLines: reconstructs the
+ * joined logical keyword text across `[lineIndex, lastLineIndex]` (stripping each non-final line's
+ * continuation hyphen, matching how the parser itself reconstructs a continued value), hands it to
+ * `computeRemaining`, and re-paginates whatever comes back across the same starting line(s) —
+ * re-inserting a continuation hyphen only where content still doesn't fit on one line, and deleting
+ * any line(s) left over once the remainder needs fewer lines than before.
+ * @param computeRemaining - Returns the new joined keyword text, or null to abort (already reported
+ * to the user) when it couldn't find what it was looking for
+ */
+async function rewriteKeywordArea(
+    editor: vscode.TextEditor,
+    lineIndex: number,
+    lastLineIndex: number,
+    preserveFirstLine: boolean,
+    computeRemaining: (joined: string) => string | null
+): Promise<boolean> {
+    const document = editor.document;
+    const uri = document.uri;
+
+    const lineCount = lastLineIndex - lineIndex + 1;
+    const rawParts: string[] = [];
+    for (let i = lineIndex; i <= lastLineIndex; i++) {
+        rawParts.push(document.lineAt(i).text.substring(44, 80));
+    };
+
+    const joined = rawParts.map((part, i) => i === rawParts.length - 1 ? part : part.replace(/-$/, '')).join('');
+    const remaining = computeRemaining(joined);
+    if (remaining === null) {
+        return false;
+    };
+
+    const workspaceEdit = new vscode.WorkspaceEdit();
+
+    if (remaining.trim().length === 0) {
+        if (preserveFirstLine) {
+            const line = document.lineAt(lineIndex);
+            workspaceEdit.replace(uri, line.range, line.text.substring(0, 44).replace(/\s+$/, ''));
+            if (lastLineIndex > lineIndex) {
+                deleteLineRange(workspaceEdit, document, uri, lineIndex + 1, lastLineIndex);
+            };
+        } else {
+            deleteLineRange(workspaceEdit, document, uri, lineIndex, lastLineIndex);
+        };
+        return applyWorkspaceEdit(workspaceEdit, 'delete the attribute');
+    };
+
+    // Re-paginate the remaining text: up to 35 characters per continued line (leaving room for a
+    // trailing '-'), and up to 36 on the final line (no continuation needed).
+    const chunks: string[] = [];
+    let rest = remaining;
+    while (rest.length > 36) {
+        chunks.push(rest.substring(0, 35) + '-');
+        rest = rest.substring(35);
+    };
+    chunks.push(rest);
+
+    const prefix = document.lineAt(lineIndex).text.substring(0, 44);
+    for (let i = 0; i < chunks.length; i++) {
+        const newText = (prefix + chunks[i]).replace(/\s+$/, '');
+        workspaceEdit.replace(uri, document.lineAt(lineIndex + i).range, newText);
+    };
+
+    if (chunks.length < lineCount) {
+        deleteLineRange(workspaceEdit, document, uri, lineIndex + chunks.length, lastLineIndex);
+    };
+
+    return applyWorkspaceEdit(workspaceEdit, 'delete the attribute');
+};
+
+/** Deletes a contiguous range of whole lines (inclusive), handling end-of-document edge cases. */
+function deleteLineRange(
+    workspaceEdit: vscode.WorkspaceEdit,
+    document: vscode.TextDocument,
+    uri: vscode.Uri,
+    startLine: number,
+    endLine: number
+): void {
+    const docLength = document.getText().length;
+    let startOffset: number;
+    let endOffset: number;
+
+    if (endLine === document.lineCount - 1) {
+        if (startLine === 0) {
+            startOffset = 0;
+            endOffset = docLength;
+        } else {
+            startOffset = document.offsetAt(document.lineAt(startLine - 1).range.end);
+            endOffset = docLength;
+        };
+    } else {
+        startOffset = document.offsetAt(new vscode.Position(startLine, 0));
+        endOffset = document.offsetAt(document.lineAt(endLine).rangeIncludingLineBreak.end);
+    };
+
+    workspaceEdit.delete(uri, new vscode.Range(document.positionAt(startOffset), document.positionAt(endOffset)));
+};
+
+/**
  * Parses indicators from a DDS line at positions 8-10, 11-13, 14-16.
  * @param lineText - The DDS line text
  * @returns Array of indicator codes found

--- a/src/dspf-edit.webview/dspf-edit.preview-colors-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.preview-colors-panel.ts
@@ -7,17 +7,19 @@
 import * as vscode from 'vscode';
 import { PREVIEW_COLOR_SETTINGS, readColorSetting, resetPreviewColors, setPreviewColor } from '../dspf-edit.utils/dspf-edit.preview-colors';
 import { DECIMAL_FORMAT_OPTIONS, DecimalFormat, getDecimalFormat, resetDecimalFormat, setDecimalFormat } from '../dspf-edit.utils/dspf-edit.decimal-format';
-import { resolveDecimalFormatFromSystem } from '../dspf-edit.ibmi/dspf-edit.ibmi-integration';
+import { DATE_SEPARATOR_OPTIONS, DateSeparatorFormat, getDateSeparatorFormat, resetDateSeparatorFormat, setDateSeparatorFormat } from '../dspf-edit.utils/dspf-edit.date-format';
+import { resolveDecimalFormatFromSystem, resolveDateSeparatorFormatFromSystem } from '../dspf-edit.ibmi/dspf-edit.ibmi-integration';
 import { RecordPreviewPanel } from './dspf-edit.record-preview-panel';
 
 /**
  * The extension's "⚙ Configuration" webview panel. Lets the user pick the record preview's colors
  * visually — a native OS/browser color picker per swatch (`<input type="color">`) instead of
  * typing hex codes by hand — and choose the decimal/thousands-separator convention (US/European)
- * used when previewing EDTCDE()-edited numeric fields, either manually or fetched from the
- * connected IBM i's QDECFMT system value. Reads and writes straight to the extension's own
- * stored settings (see dspf-edit.utils/dspf-edit.preview-colors.ts and
- * dspf-edit.utils/dspf-edit.decimal-format.ts), so there's no separate state of its own: closing
+ * and the date-separator convention (US '/' / European '-') used when previewing EDTCDE()-edited
+ * numeric fields, either manually or fetched from the connected IBM i's QDECFMT/QDATSEP system
+ * values. Reads and writes straight to the extension's own stored settings (see
+ * dspf-edit.utils/dspf-edit.preview-colors.ts, dspf-edit.utils/dspf-edit.decimal-format.ts and
+ * dspf-edit.utils/dspf-edit.date-format.ts), so there's no separate state of its own: closing
  * this panel loses nothing, since every change was already saved the moment it was made — and it
  * pushes each change straight to an open record preview panel, if any.
  */
@@ -73,6 +75,11 @@ export class PreviewColorsPanel {
         this.panel.webview.postMessage({ type: 'updateDecimalFormat', value: getDecimalFormat() });
     };
 
+    /** Same as updateDecimalFormatRadio, for the date separator's radios. */
+    private updateDateSeparatorRadio(): void {
+        this.panel.webview.postMessage({ type: 'updateDateSeparator', value: getDateSeparatorFormat() });
+    };
+
     private async onDidReceiveMessage(message: any): Promise<void> {
         switch (message?.type) {
             case 'setColor':
@@ -115,6 +122,32 @@ export class PreviewColorsPanel {
                     vscode.window.showErrorMessage(error instanceof Error ? error.message : 'Could not read QDECFMT from the connected IBM i.');
                 };
                 break;
+            case 'setDateSeparator':
+                await setDateSeparatorFormat(message.value as DateSeparatorFormat);
+                RecordPreviewPanel.refreshTheme();
+                break;
+            case 'resetDateSeparator': {
+                const changed = await resetDateSeparatorFormat();
+                this.updateDateSeparatorRadio();
+                RecordPreviewPanel.refreshTheme();
+                vscode.window.showInformationMessage(
+                    changed
+                        ? 'DSPF Edit: date separator reset to default (US).'
+                        : 'DSPF Edit: date separator was already at its default (US).'
+                );
+                break;
+            };
+            case 'fetchDateSeparatorFromIBMi':
+                try {
+                    const format = await resolveDateSeparatorFormatFromSystem();
+                    await setDateSeparatorFormat(format);
+                    this.updateDateSeparatorRadio();
+                    RecordPreviewPanel.refreshTheme();
+                    vscode.window.showInformationMessage(`DSPF Edit: date separator set to '${format}' from the connected IBM i (QDATSEP).`);
+                } catch (error) {
+                    vscode.window.showErrorMessage(error instanceof Error ? error.message : 'Could not read QDATSEP from the connected IBM i.');
+                };
+                break;
         };
     };
 
@@ -135,6 +168,15 @@ export class PreviewColorsPanel {
     <div class="row">
         <label class="radio-label">
             <input type="radio" name="decimalFormat" value="${opt.value}" ${opt.value === currentDecimalFormat ? 'checked' : ''}>
+            ${opt.label} — <span class="hex">${opt.example}</span>
+        </label>
+    </div>`).join('');
+
+        const currentDateSeparator = getDateSeparatorFormat();
+        const dateSeparatorRows = DATE_SEPARATOR_OPTIONS.map(opt => `
+    <div class="row">
+        <label class="radio-label">
+            <input type="radio" name="dateSeparator" value="${opt.value}" ${opt.value === currentDateSeparator ? 'checked' : ''}>
             ${opt.label} — <span class="hex">${opt.example}</span>
         </label>
     </div>`).join('');
@@ -239,6 +281,16 @@ ${decimalFormatRows}
     <button id="fetchDecimalFormat" class="btn-secondary" style="margin-top: 0;">Fetch from IBM i</button>
     <button id="resetDecimalFormat" class="btn-secondary" style="margin-top: 0;">Reset to Default</button>
 </div>
+
+<hr class="section">
+
+<h2>Date Separator</h2>
+<p class="hint">Separator used when previewing EDTCDE(W)/EDTCDE(Y)-edited numeric fields.</p>
+${dateSeparatorRows}
+<div class="row" style="gap: 8px; margin-top: 8px;">
+    <button id="fetchDateSeparator" class="btn-secondary" style="margin-top: 0;">Fetch from IBM i</button>
+    <button id="resetDateSeparator" class="btn-secondary" style="margin-top: 0;">Reset to Default</button>
+</div>
 <script>
     const vscode = acquireVsCodeApi();
 
@@ -279,12 +331,31 @@ ${decimalFormatRows}
         vscode.postMessage({ type: 'resetDecimalFormat' });
     });
 
+    document.querySelectorAll('input[name="dateSeparator"]').forEach(input => {
+        input.addEventListener('change', () => {
+            vscode.postMessage({ type: 'setDateSeparator', value: input.value });
+        });
+    });
+
+    document.getElementById('fetchDateSeparator').addEventListener('click', () => {
+        vscode.postMessage({ type: 'fetchDateSeparatorFromIBMi' });
+    });
+
+    document.getElementById('resetDateSeparator').addEventListener('click', () => {
+        vscode.postMessage({ type: 'resetDateSeparator' });
+    });
+
     // Reset/Fetch don't reload the panel's html (see updateDecimalFormatRadio's comment on the
     // extension side for why) — they instead send this message so the already-live radios get
     // updated directly, without depending on a reload happening at all.
     window.addEventListener('message', event => {
         if (event.data?.type === 'updateDecimalFormat') {
             document.querySelectorAll('input[name="decimalFormat"]').forEach(input => {
+                input.checked = input.value === event.data.value;
+            });
+        };
+        if (event.data?.type === 'updateDateSeparator') {
+            document.querySelectorAll('input[name="dateSeparator"]').forEach(input => {
                 input.checked = input.value === event.data.value;
             });
         };

--- a/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
@@ -9,6 +9,7 @@ import { FieldsPerRecord, DdsSize, DdsAttribute, AttributeWithIndicators, DdsInd
 import { checkForEditorAndDocument, updateTreeProvider, applyWorkspaceEdit, applyDisplayFormatSplitEdit } from '../dspf-edit.utils/dspf-edit.helper';
 import { getBackgroundColor, getDdsColorMap, getReferencedFieldColor } from '../dspf-edit.utils/dspf-edit.preview-colors';
 import { getDecimalSeparators } from '../dspf-edit.utils/dspf-edit.decimal-format';
+import { getDateSeparator } from '../dspf-edit.utils/dspf-edit.date-format';
 import { DdsTreeProvider, DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { ExtensionState } from '../dspf-edit.states/state';
 import { getResolvedRef } from '../dspf-edit.ibmi/dspf-edit.ibmi-integration';
@@ -217,8 +218,9 @@ const EDIT_CODE_INFO: Record<string, { comma: boolean; sign: '' | '-' | 'CR'; si
 };
 
 /**
- * Extracts a field's EDTCDE() code, if it carries one (its optional modifier — asterisk fill or a
- * currency symbol — doesn't affect the preview mask, so it's not extracted here).
+ * Extracts a field's EDTCDE() code, if it carries one. Recognizes every IBM i edit code: 1-4, A-D,
+ * J-Q (the comma/decimal/sign codes), W and Y (the date-slash codes), and X and Z (see
+ * getEditingMask for their masks, confirmed against real STRSDA).
  * @param attributes - The element's DDS attributes
  */
 function getEditCode(attributes: AttributeWithIndicators[] | undefined): string | null {
@@ -227,7 +229,88 @@ function getEditCode(attributes: AttributeWithIndicators[] | undefined): string 
         return null;
     };
 
-    return attr.value.match(/^EDTCDE\(\s*([1-4A-DJ-Q])/i)?.[1]?.toUpperCase() ?? null;
+    return attr.value.match(/^EDTCDE\(\s*([1-4A-DJ-QWXYZ])/i)?.[1]?.toUpperCase() ?? null;
+};
+
+/**
+ * Extracts a field's EDTCDE() floating currency symbol modifier, if it carries one — confirmed
+ * against real STRSDA to add one extra display position (prefixed, to the left of the first digit),
+ * unlike the asterisk-fill modifier which only substitutes a leading suppressed-zero digit without
+ * changing the field's width at all. Only 1-4, A-D and J-Q support either modifier (see
+ * getAvailableEditCodes in dspf-edit.add-editing-keywords.ts).
+ * @param attributes - The element's DDS attributes
+ */
+function getEditCodeCurrencySymbol(attributes: AttributeWithIndicators[] | undefined): string | null {
+    const attr = attributes?.find(a => /^EDTCDE\(/i.test(a.value));
+    if (!attr) {
+        return null;
+    };
+
+    const modifier = attr.value.match(/^EDTCDE\(\s*[1-4A-DJ-Q]\s+(\S)\s*\)/i)?.[1];
+    return modifier && modifier !== '*' ? modifier : null;
+};
+
+/** True when a field's EDTCDE() carries the asterisk-fill modifier (see getEditCodeCurrencySymbol). */
+function hasEditCodeAsteriskFill(attributes: AttributeWithIndicators[] | undefined): boolean {
+    const attr = attributes?.find(a => /^EDTCDE\(/i.test(a.value));
+    return Boolean(attr && /^EDTCDE\(\s*[1-4A-DJ-Q]\s+\*\s*\)/i.test(attr.value));
+};
+
+/**
+ * Digit-group sizes for EDTCDE(W) and EDTCDE(Y), keyed by the field's total digit length — per the
+ * DDS reference's Table 6/7 footnotes, confirmed against real STRSDA. Unlike the comma/decimal codes
+ * above, W/Y ignore decimal positions entirely: the grouping is based purely on total length, and a
+ * '/' (or the configured date separator) is inserted between groups instead of a decimal point.
+ * Lengths outside this table have no documented pattern and aren't previewed with a mask.
+ */
+const DATE_EDIT_CODE_DIGIT_GROUPS: Record<'W' | 'Y', Record<number, number[]>> = {
+    W: { 5: [2, 3], 6: [4, 2], 7: [4, 3], 8: [4, 2, 2] },
+    Y: { 3: [2, 1], 4: [2, 2], 5: [2, 2, 1], 6: [2, 2, 2], 7: [3, 2, 2], 8: [2, 2, 4] }
+};
+
+/**
+ * Builds the slash-grouped mask for a field carrying EDTCDE(W) or EDTCDE(Y) — e.g. "  -  -  " for a
+ * 6-digit field, matching STRSDA's "66-66-66" for EDTCDE(Y) and "6666-66" for EDTCDE(W).
+ * @param length - The field's total digit length (decimals aren't used — see DATE_EDIT_CODE_DIGIT_GROUPS)
+ * @param code - 'W' or 'Y'
+ */
+function getDateEditCodeMask(length: number, code: 'W' | 'Y'): string | null {
+    const groups = DATE_EDIT_CODE_DIGIT_GROUPS[code][length];
+    if (!groups) {
+        return null;
+    };
+
+    return groups.map(size => ' '.repeat(size)).join(getDateSeparator());
+};
+
+/**
+ * Resolves what a constant should render as, for the two forms of a DDS system keyword coded bare,
+ * unquoted, in a constant's position: the plain word (DATE, TIME, USER, SYSNAME — via
+ * SYSTEM_FIELD_PLACEHOLDER) and DATE's own parenthesized keyword-call form
+ * (DATE([*JOB|*SYS] [*Y|*YY])). Confirmed against real STRSDA: unlike the plain word, DATE(...)
+ * shows no separators by itself — "DDDDDD" for the default 2-digit year (*Y), "DDDDDDDD" for
+ * *YY — only gaining them when the constant also carries EDTCDE(Y) or EDTCDE(W) on its own
+ * attribute line, exactly like a numeric field's edit code (see getEditCodeMask). Returns
+ * undefined when `name` is neither form, so the caller falls back to the literal constant text.
+ * @param name - The constant's stored name/text (already quote-stripped)
+ * @param attributes - The constant's own DDS attributes (for a possible EDTCDE)
+ */
+function getSystemConstantText(name: string, attributes: AttributeWithIndicators[] | undefined): string | undefined {
+    const upper = name.trim().toUpperCase();
+    const bare = SYSTEM_FIELD_PLACEHOLDER[upper];
+    if (bare) {
+        return bare;
+    };
+
+    const dateMatch = upper.match(/^DATE\(([^)]*)\)$/);
+    if (!dateMatch) {
+        return undefined;
+    };
+
+    const length = /\*YY\b/.test(dateMatch[1]) ? 8 : 6;
+    const code = getEditCode(attributes);
+    const mask = code ? getEditCodeMask(length, 0, code) : null;
+    return (mask ?? ' '.repeat(length)).split('').map(ch => ch === ' ' ? 'D' : ch).join('');
 };
 
 /**
@@ -236,9 +319,13 @@ function getEditCode(attributes: AttributeWithIndicators[] | undefined): string 
  * width (commas, decimal point, sign) SDA/RDi reserve when previewing an edited numeric field.
  * @param length - The field's digit length
  * @param decimals - The field's decimal positions
- * @param code - The EDTCDE code (1-4, A-D, J-Q)
+ * @param code - The EDTCDE code (1-4, A-D, J-Q, W, Y)
  */
 function getEditCodeMask(length: number, decimals: number, code: string): string | null {
+    if (code === 'W' || code === 'Y') {
+        return getDateEditCodeMask(length, code);
+    };
+
     const info = EDIT_CODE_INFO[code];
     if (!info) {
         return null;
@@ -324,7 +411,35 @@ function getEditingMask(attributes: AttributeWithIndicators[] | undefined, type:
 
     const code = getEditCode(attributes);
     if (code) {
-        return getEditCodeMask(length, decimals, code);
+        // Confirmed against real STRSDA: an EDTCDE's comma/sign/date-slash/currency decoration only
+        // ever shows on an output field — an input-capable (I/B) field always previews exactly as if
+        // it carried no EDTCDE at all, under the Y (numeric-only) shift EDTCDE forces on a blank
+        // Type (a decimal point reserved only when it actually has decimals; see
+        // getUneditedNumericMask). This holds for every code, including W/Y/X/Z.
+        const usageCode = (usage || '').trim().toUpperCase() || 'O';
+        if (usageCode === 'I' || usageCode === 'B') {
+            return getUneditedNumericMask('Y', usage, length, rawDecimals);
+        };
+
+        if (code === 'W' || code === 'Y') {
+            return getDateEditCodeMask(length, code);
+        };
+        // X's own output display is identical to an unedited field (no comma/sign, ever) — it only
+        // ever mattered for forcing the Y shift above. Z's own output display, confirmed against
+        // real STRSDA, has no comma or decimal point regardless of decimals (unlike every other
+        // code) and reserves no extra position either — it only changes the field's stored sign
+        // representation (hex F), never its display.
+        if (code === 'X' || code === 'Z') {
+            return null;
+        };
+
+        const baseMask = getEditCodeMask(length, decimals, code);
+        // Asterisk fill (confirmed against real STRSDA) substitutes the leading suppressed-zero
+        // digit with a literal '*' rather than adding width — replacing the mask's first blank
+        // (its first digit position, skipping past any fixed leading sign character) does that.
+        const withAsterisk = baseMask && hasEditCodeAsteriskFill(attributes) ? baseMask.replace(' ', '*') : baseMask;
+        const currency = getEditCodeCurrencySymbol(attributes);
+        return currency && withAsterisk ? currency + withAsterisk : withAsterisk;
     };
 
     return getUneditedNumericMask(type, usage, length, rawDecimals);
@@ -1395,8 +1510,9 @@ export class RecordPreviewPanel {
                 const activeAttrs = this.getActiveAttributes(constant.attributes, useLiveIndicators);
                 // Same reasoning as the field loop above: a bare system keyword (DATE, USER...)
                 // renders at its own fixed width, not the raw constant text's length.
-                const isSystemConstant = Boolean(SYSTEM_FIELD_PLACEHOLDER[constant.name.trim().toUpperCase()]);
-                const text = isSystemConstant ? SYSTEM_FIELD_PLACEHOLDER[constant.name.trim().toUpperCase()] : constant.name;
+                const systemConstantText = getSystemConstantText(constant.name, activeAttrs);
+                const isSystemConstant = systemConstantText !== undefined;
+                const text = systemConstantText ?? constant.name;
                 items.push({
                     kind: 'constant',
                     name: constant.name,


### PR DESCRIPTION
## [1.4.0] - 2026-09-04
### Added
- Preview: `EDTCDE(W)`/`EDTCDE(Y)` (date-slash editing) and `EDTCDE(X)`/`EDTCDE(Z)` are now recognized and rendered correctly, confirmed against real STRSDA — previously fell back to a generic, often wrong, numeric mask.
- Preview: the `DATE()` keyword (`*JOB`/`*SYS`, `*Y`/`*YY`) is now recognized as a system field, with or without `EDTCDE(Y)`/`EDTCDE(W)`.
- Preview: a floating currency symbol on `EDTCDE()` (e.g. `EDTCDE(J $)`) now adds its extra display position; asterisk fill now shows as `*` in place of the leading digit instead of a plain digit.
- Configuration: new "Date Separator" section (US `/` / European `-`) alongside Decimal Format, with "Fetch from IBM i" (reads `QDATSEP`) and reset.
### Fixed
- Preview: an `EDTCDE()`'s comma/sign/date/currency decoration only ever shows on an output field, confirmed against real STRSDA — an input-capable field now previews as if unedited instead of always applying the code's formatting.
- Parser: several keywords on one physical source line (e.g. `EDTCDE(3) DSPATR(HI) COLOR(RED)`) were read as a single combined value instead of separate keywords, breaking both the preview and Remove Color/Attribute/Editing Keywords for a field or constant written that way.
- Remove Colors / Remove Attributes / Remove Editing Keywords: removing one keyword sharing a line with others — or continued onto the next line via a trailing hyphen — could delete the sibling keywords too, or leave survivors stranded on a continuation line they no longer needed.
