### PR TITLE
v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
+## [1.4.1] - 2026-09-05
+### Fixed
+- Preview: window title (`WDWTITLE`) and border (`WDWBORDER`) stopped rendering — a regression from 1.4.0's multi-keyword-per-line parsing fix. Its keyword tokenizer didn't handle keywords with nested parentheses, e.g. `WDWTITLE((*TEXT '...') *TOP)` or `WDWBORDER((*COLOR BLU) (*DSPATR RI))`, shredding them into fragments instead of keeping each as one attribute.
+
 ## [1.4.0] - 2026-09-04
 ### Added
 - Preview: `EDTCDE(W)`/`EDTCDE(Y)` (date-slash editing) and `EDTCDE(X)`/`EDTCDE(Z)` are now recognized and rendered correctly, confirmed against real STRSDA — previously fell back to a generic, often wrong, numeric mask.

--- a/README.md
+++ b/README.md
@@ -146,11 +146,8 @@ No known blocking issues right now. Please [open an issue](https://github.com/ch
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**1.4.0** - 2026-09-04
-- Added: Preview now correctly renders `EDTCDE(W)`, `(X)`, `(Y)` and `(Z)`, the `DATE()` keyword, floating currency symbols, and asterisk fill — all confirmed against real STRSDA.
-- Added: new "Date Separator" configuration (US `/` / European `-`), with fetch from the connected IBM i.
-- Fixed: `EDTCDE()` decoration now only applies to output fields in the preview, matching STRSDA — an input-capable field previews as if unedited.
-- Fixed: several DDS keywords sharing one source line (e.g. `EDTCDE(3) DSPATR(HI) COLOR(RED)`) are now parsed and edited correctly — removing one no longer risks deleting or corrupting the others.
+**1.4.1** - 2026-09-05
+- Fixed: window title (`WDWTITLE`) and border (`WDWBORDER`) had stopped rendering in the preview — a regression from 1.4.0, whose keyword parser didn't handle keywords with nested parentheses.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dspf-edit",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dspf-edit",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"

--- a/src/dspf-edit.parser/dspf-edit.parser.ts
+++ b/src/dspf-edit.parser/dspf-edit.parser.ts
@@ -681,11 +681,49 @@ function splitConstantValueAndKeywords(raw: string): { value: string; keywordTex
 /**
  * Splits a run of inline DDS keyword text (e.g. "EDTCDE(Y) DSPATR(HI)") into its individual keyword
  * tokens, matching the one-keyword-per-DdsAttribute convention the rest of the parser and preview
- * rely on (e.g. hasDisplayAttribute's exact-match check).
+ * rely on (e.g. hasDisplayAttribute's exact-match check). Tracks paren nesting depth (and ignores
+ * parens inside a quoted literal) rather than stopping at the first ')', so a keyword whose own
+ * parameters are themselves parenthesized — WDWTITLE((*TEXT 'title') *TOP), WDWBORDER((*COLOR BLU)
+ * (*DSPATR RI)) — comes back as one token instead of being shredded into fragments.
  * @param text - Keyword text: zero or more keywords separated by spaces
  */
 function tokenizeKeywordText(text: string): string[] {
-    return text.match(/[A-Za-z][A-Za-z0-9]*(?:\([^()]*\))?/g) ?? [];
+    const tokens: string[] = [];
+    let i = 0;
+
+    while (i < text.length) {
+        if (!/[A-Za-z]/.test(text[i])) {
+            i++;
+            continue;
+        };
+
+        const start = i;
+        while (i < text.length && /[A-Za-z0-9]/.test(text[i])) {
+            i++;
+        };
+
+        if (text[i] === '(') {
+            let depth = 0;
+            let inQuote = false;
+            for (; i < text.length; i++) {
+                const ch = text[i];
+                if (inQuote) {
+                    if (ch === "'") inQuote = false;
+                    continue;
+                };
+                if (ch === "'") { inQuote = true; continue; };
+                if (ch === '(') depth++;
+                else if (ch === ')') {
+                    depth--;
+                    if (depth === 0) { i++; break; };
+                };
+            };
+        };
+
+        tokens.push(text.slice(start, i));
+    };
+
+    return tokens;
 };
 
 /**


### PR DESCRIPTION
## [1.4.1] - 2026-09-05
### Fixed
- Preview: window title (`WDWTITLE`) and border (`WDWBORDER`) stopped rendering — a regression from 1.4.0's multi-keyword-per-line parsing fix. Its keyword tokenizer didn't handle keywords with nested parentheses, e.g. `WDWTITLE((*TEXT '...') *TOP)` or `WDWBORDER((*COLOR BLU) (*DSPATR RI))`, shredding them into fragments instead of keeping each as one attribute.
