### PR TITLE
v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - More DDS features and improvements planned.
 - Bug fixes and stability enhancements.
 
+## [1.5.0] - 2026-09-09
+### Added
+- Preview: an active `SFLMSG()` on a subfile control record (SFLCTL) is now shown on the message line during indicator simulation, the same way `ERRMSG()` already is — respecting ERRMSG's priority over SFLMSG and requiring `SFLDSP` to be in effect, per the DDS reference.
+- Preview: selecting a field with a validity check now also shows it (e.g. `VALUES(0 2 4 5 7 8)`) in the selection bar, alongside its name and position.
+- Add Validity Check: replaced with a summary menu showing all three mutually exclusive keywords (RANGE/COMP/VALUES) and whichever one is currently set, each with its own change (✏️) and remove (🗑️) button — instead of the old "Add more/Replace all/Remove all" flow, which allowed invalid DDS (e.g. a duplicate `VALUES`, or `VALUES` together with `RANGE`). Setting one now automatically replaces whichever of the three is already in effect; changing an existing one pre-fills its current value.
+- Add Error Messages: replaced with a summary menu listing every existing `ERRMSG`, each with its own change/remove buttons, plus "Add error message..." and "Remove all" — unlike validity checks, a field can legitimately carry several `ERRMSG`s, each gated by its own indicator.
+- Add Indicators: replaced the flat "Add AND/Add OR/Modify/Remove a group/Replace all/Remove all" picker with a summary menu listing every OR'd condition, each with its own modify/remove buttons, plus "Add OR condition..." and "Remove all".
+### Fixed
+- Remove/Replace All Attributes (and the equivalent commands for colors, keys, error messages, and validity checks): removing/replacing on one constant could also strip attributes off unrelated constants later in the same record — the scan used to find where an element's attributes end didn't recognize the next constant's own row/column as a boundary.
+
 ## [1.4.1] - 2026-09-05
 ### Fixed
 - Preview: window title (`WDWTITLE`) and border (`WDWBORDER`) stopped rendering — a regression from 1.4.0's multi-keyword-per-line parsing fix. Its keyword tokenizer didn't handle keywords with nested parentheses, e.g. `WDWTITLE((*TEXT '...') *TOP)` or `WDWBORDER((*COLOR BLU) (*DSPATR RI))`, shredding them into fragments instead of keeping each as one attribute.

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ DSPF-edit doesn't replace your compiler — it closes the gap between writing DD
   - Simulate indicators on/off to preview conditional fields, constants, and attributes.
   - A function-key legend (`F3`, `F12`, ...) shows every command key available to the record being previewed (file-level + record-level CAxx/CFxx); a key still shows even when its indicator condition isn't currently met (so you can see it's defined), switching to solid/inverted styling when it's actually active.
   - An active `ERRMSG()` on a window shows on the window's own reserved message line (its last content row) when the window doesn't specify `*NOMSGLIN`, matching real DDS behavior, instead of always at the bottom of the physical screen.
+  - A subfile's `SFLMSG()` also shows on the message line when its indicator is active and `SFLDSP` is in effect, the same way `ERRMSG()` does (which still takes priority over it, matching the DDS reference).
   - For files with more than one DSPSIZ format (e.g. *DS3/*DS4), switch which one is previewed — window positions/sizes and conditioned elements are resolved for the selected format. Dragging/resizing/centering a window, or adjusting a subfile's SFLPAG/SFLSIZ, only affects the size currently being previewed.
   - The "Indicators" toggle and the selected display format persist when switching which record is previewed in the same panel.
   - Stays in sync with the schema tree selection in both directions.
@@ -150,8 +151,10 @@ No known blocking issues right now. Please [open an issue](https://github.com/ch
 See the full changelog [here](./CHANGELOG.md).
 
 ### Latest
-**1.4.1** - 2026-09-05
-- Fixed: window title (`WDWTITLE`) and border (`WDWBORDER`) had stopped rendering in the preview — a regression from 1.4.0, whose keyword parser didn't handle keywords with nested parentheses.
+**1.5.0** - 2026-09-09
+- Added: subfile messages (`SFLMSG`) now show on the preview's message line during indicator simulation, the same way error messages already do.
+- Added: Validity Checks, Error Messages, and Indicators now use an editable summary menu (change/remove per item) instead of the old "Add more/Replace all/Remove all" picker.
+- Fixed: removing/replacing all attributes (and colors/keys/error messages/validity checks) on one constant could wipe out attributes on unrelated constants later in the same record.
 
 ---
 

--- a/manual/src/content/docs/guides/fields.md
+++ b/manual/src/content/docs/guides/fields.md
@@ -28,7 +28,7 @@ Right-click a record and choose **New Field**, or click **+ Field** in the [Scre
 
 ## Validity checks
 
-**Add validity checks** applies DDS field-validation keywords (e.g. range/comparison/value checks) to the field.
+**Add validity checks** applies DDS field-validation keywords (range/comparison/value checks) to the field. `RANGE`, `COMP`, and `VALUES` are mutually exclusive in DDS — a field can only have one of the three at a time — so the menu shows all three slots and whichever one is currently set; picking a different one automatically replaces it.
 
 ## Editing keywords
 
@@ -36,7 +36,7 @@ Right-click a record and choose **New Field**, or click **+ Field** in the [Scre
 
 ## Error messages
 
-**Add error messages** attaches a DDS error-message keyword (e.g. `ERRMSG()`) to the field, shown in the preview per the same message-line rules as window `ERRMSG()` — see [Screen Preview](/dspf-edit/guides/screen-preview/#windows).
+**Add error messages** attaches a DDS error-message keyword (e.g. `ERRMSG()`) to the field, shown in the preview per the same message-line rules as window `ERRMSG()` — see [Screen Preview](/dspf-edit/guides/screen-preview/#windows). Unlike validity checks, a field can carry several `ERRMSG()`s at once, each gated by its own indicator — the menu lists them all, letting you change or remove one individually, add another, or clear them all.
 
 ## Indicators
 

--- a/manual/src/content/docs/guides/indicators.md
+++ b/manual/src/content/docs/guides/indicators.md
@@ -15,7 +15,7 @@ Up to DDS's limit of **9 ANDed indicators** on a single condition is supported. 
 
 ## OR'd conditions
 
-A condition can be made of several OR'd groups, each itself an AND of up to 9 indicators (e.g. `51 AND NOT 61 AND 53  OR  52`). You can add or remove a whole OR'd group, or edit the indicators within a single group, from the same dialog.
+A condition can be made of several OR'd groups, each itself an AND of up to 9 indicators (e.g. `51 AND NOT 61 AND 53  OR  52`). The menu lists every OR'd group with its own change/remove buttons, plus an option to add another OR'd condition.
 
 ## Reading conditions in the tree
 

--- a/manual/src/content/docs/guides/screen-preview.md
+++ b/manual/src/content/docs/guides/screen-preview.md
@@ -64,7 +64,7 @@ See [Windows](/dspf-edit/guides/windows/) for the full reference.
 
 ## Subfiles
 
-`SFL`/`SFLCTL` records show every `SFLPAG` row, and automatically preview their paired header/detail record. Detail rows can't be dragged up over the header's own content. See [Subfiles](/dspf-edit/guides/subfiles/).
+`SFL`/`SFLCTL` records show every `SFLPAG` row, and automatically preview their paired header/detail record. Detail rows can't be dragged up over the header's own content. A `SFLCTL` record's `SFLMSG()` shows on the message line the same way `ERRMSG()` does (which still takes priority over it, matching the DDS reference), while `SFLDSP` is in effect. See [Subfiles](/dspf-edit/guides/subfiles/).
 
 ## Field wrapping (`CNTFLD`)
 

--- a/manual/src/content/docs/guides/subfiles.md
+++ b/manual/src/content/docs/guides/subfiles.md
@@ -23,6 +23,10 @@ If the `SFLCTL` declares its own window directly (`WINDOW(startRow startCol rows
 
 After the record is created, use **Add Constant** (or **Add Buttons**) on it to add the function-key texts.
 
+## Subfile messages
+
+A `SFLCTL` record's `SFLMSG('text' indicator)` is shown on the preview's message line when its indicator is toggled on in the [Indicators](/dspf-edit/guides/indicators/) simulation, the same way a field or record's `ERRMSG()` is — see [Error messages](/dspf-edit/guides/fields/#error-messages). Per the DDS reference, an active `ERRMSG()` always takes priority over `SFLMSG()`, and `SFLMSG()` only takes effect while `SFLDSP` is itself in effect.
+
 ## Multiple display sizes
 
 A subfile's `SFLPAG`/`SFLSIZ` can differ per `DSPSIZ` format. When previewing a file with more than one format, adjusting a subfile's page size only affects the format currently selected in the preview. See [Multiple Display Sizes](/dspf-edit/guides/display-sizes/).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dspf-edit",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dspf-edit",
-      "version": "1.4.1",
+      "version": "1.5.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.10",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://www.linkedin.com/in/christianlarsenvalverde/"
   },
   "publisher": "ChristianLarsen",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/christianlarsen/dspf-edit"

--- a/src/dspf-edit.commands/dspf-edit.add-error-messages.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-error-messages.ts
@@ -7,7 +7,7 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { isAttributeLine, findElementInsertionPointRecordFirstLine, checkForEditorAndDocument, groupConsecutiveLines, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
+import { isAttributeLine, findElementInsertionPointRecordFirstLine, checkForEditorAndDocument, groupConsecutiveLines, applyWorkspaceEdit, removeKeywordTextFromLines } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
@@ -16,6 +16,19 @@ interface ErrorMessageConfig {
     messageText: string;
     responseIndicator?: string;
     useResponseIndicator: boolean;
+    /** The keyword's own text exactly as parsed (e.g. "ERRMSG('No stock' 31)") and its line range —
+     * only set for an existing message read off the field, used to locate/remove it precisely
+     * without disturbing sibling keywords or other messages. */
+    raw?: string;
+    lineIndex?: number;
+    lastLineIndex?: number;
+};
+
+/** One row of the error-messages summary menu: an existing ERRMSG occurrence (`messageIndex` into
+ * the current list), or one of the two trailing action rows. */
+interface ErrorMessageMenuItem extends vscode.QuickPickItem {
+    messageIndex: number;
+    action?: 'addNew' | 'removeAll';
 };
 
 // COMMAND REGISTRATION
@@ -67,23 +80,16 @@ async function handleAddErrorMessageCommand(node: DdsNode): Promise<void> {
         // Get current error messages from the field
         const currentErrorMessages = getCurrentErrorMessages(field);
 
-        // Show current error messages if any exist
+        // Show a summary menu — one row per existing message, editable/removable individually —
+        // instead of the old "Add more/Replace all/Remove all" 3-choice picker. Unlike RANGE/COMP/
+        // VALUES, ERRMSG can legitimately be coded more than once on the same field (the manual is
+        // explicit: "You can specify ERRMSG ... more than once for a single field"), each with its
+        // own trigger indicator, so a real list — not a mutually-exclusive set — is the right shape.
         if (currentErrorMessages.length > 0) {
-            const currentMessagesList = currentErrorMessages.map(msg =>
-                `${msg.indicator}: "${msg.messageText}"${msg.responseIndicator ? ` (Response: ${msg.responseIndicator})` : ''}`
-            ).join('; ');
+            const choice = await showErrorMessageMenu(buildErrorMessageMenuItems(currentErrorMessages), field.name);
+            if (!choice) return;
 
-            const action = await vscode.window.showQuickPick(
-                ['Add more error messages', 'Replace all error messages', 'Remove all error messages'],
-                {
-                    title: `Current error messages: ${currentMessagesList}`,
-                    placeHolder: 'Choose how to manage error messages'
-                }
-            );
-
-            if (!action) return;
-
-            if (action === 'Remove all error messages') {
+            if (choice.action === 'removeAll') {
                 if (!(await removeErrorMessagesFromField(editor, field))) {
                     return;
                 };
@@ -94,12 +100,27 @@ async function handleAddErrorMessageCommand(node: DdsNode): Promise<void> {
                 return;
             };
 
-            if (action === 'Replace all error messages') {
-                if (!(await removeErrorMessagesFromField(editor, field))) {
-                    return;
-                };
+            if (choice.action === 'remove') {
+                await removeOneErrorMessage(editor, field, currentErrorMessages[choice.messageIndex]);
+                return;
             };
-            // If "Add more error messages", continue with current logic
+
+            if (choice.action === 'edit') {
+                const existing = currentErrorMessages[choice.messageIndex];
+                const updated = await collectOneErrorMessage(existing);
+                if (!updated) return;
+
+                if (!(await removeOneErrorMessage(editor, field, existing, true))) return;
+                if (!(await addErrorMessagesToField(editor, field, [updated]))) return;
+                await vscode.commands.executeCommand('cursorRight');
+                await vscode.commands.executeCommand('cursorLeft');
+
+                vscode.window.showInformationMessage(
+                    `Updated error message (indicator ${updated.indicator}) on field '${field.name}'.`
+                );
+                return;
+            };
+            // choice.action === 'addNew' falls through to the add flow below
         };
 
         // Collect new error messages to add
@@ -178,12 +199,147 @@ function getCurrentErrorMessages(field: any): ErrorMessageConfig[] {
                     messageText: errmsgMatch[1],
                     responseIndicator: errmsgMatch[2],
                     useResponseIndicator: !!errmsgMatch[2],
+                    raw: attribute,
+                    lineIndex: attrObj.lineIndex,
+                    lastLineIndex: attrObj.lastLineIndex
                 });
             };
         });
     };
 
     return errorMessages;
+};
+
+// ERROR MESSAGES SUMMARY MENU
+
+const EDIT_BUTTON: vscode.QuickInputButton = { iconPath: new vscode.ThemeIcon('edit'), tooltip: 'Change' };
+const REMOVE_BUTTON: vscode.QuickInputButton = { iconPath: new vscode.ThemeIcon('trash'), tooltip: 'Remove' };
+
+/**
+ * Builds the error-messages summary menu's rows: one per existing ERRMSG occurrence (its trigger
+ * indicator + text, with edit + trash buttons), plus an "Add error message..." row, plus a
+ * "Remove all" row when there's more than one message (with just one, its own trash button already
+ * does the same thing).
+ * @param currentMessages - The field's current error messages, from `getCurrentErrorMessages`
+ */
+function buildErrorMessageMenuItems(currentMessages: ErrorMessageConfig[]): ErrorMessageMenuItem[] {
+    const items: ErrorMessageMenuItem[] = currentMessages.map((msg, index) => ({
+        messageIndex: index,
+        label: `IND ${msg.indicator} — "${msg.messageText}"`,
+        description: msg.responseIndicator ? `Response: ${msg.responseIndicator}` : undefined,
+        buttons: [EDIT_BUTTON, REMOVE_BUTTON]
+    }));
+
+    items.push({ messageIndex: -1, action: 'addNew', label: '$(add) Add error message...' });
+
+    if (currentMessages.length > 1) {
+        items.push({ messageIndex: -1, action: 'removeAll', label: '$(trash) Remove all error messages' });
+    };
+
+    return items;
+};
+
+/**
+ * Shows the error-messages summary menu and resolves to what the user did: picked a row (or its
+ * edit button) to change it (`action: 'edit'`), clicked a row's trash button to remove just that
+ * one (`action: 'remove'`), or picked one of the trailing action rows (`'addNew'`/`'removeAll'`) —
+ * undefined if dismissed. Needs the raw `createQuickPick` API rather than the simpler `showQuickPick`
+ * helper, since only it exposes per-item buttons (`onDidTriggerItemButton`).
+ * @param items - The menu's rows, from `buildErrorMessageMenuItems`
+ * @param fieldName - The field's name, for the menu's title
+ */
+function showErrorMessageMenu(
+    items: ErrorMessageMenuItem[],
+    fieldName: string
+): Promise<{ action: 'edit' | 'remove' | 'addNew' | 'removeAll'; messageIndex: number } | undefined> {
+    return new Promise(resolve => {
+        const quickPick = vscode.window.createQuickPick<ErrorMessageMenuItem>();
+        quickPick.items = items;
+        quickPick.title = `Error messages for ${fieldName}`;
+        quickPick.placeholder = 'Select a message to change, use its buttons, or add a new one';
+        quickPick.ignoreFocusOut = true;
+
+        let settled = false;
+        const finish = (result: { action: 'edit' | 'remove' | 'addNew' | 'removeAll'; messageIndex: number } | undefined) => {
+            if (settled) return;
+            settled = true;
+            resolve(result);
+            quickPick.hide();
+        };
+
+        quickPick.onDidTriggerItemButton(event => {
+            finish({ action: event.button === REMOVE_BUTTON ? 'remove' : 'edit', messageIndex: event.item.messageIndex });
+        });
+        quickPick.onDidAccept(() => {
+            const picked = quickPick.selectedItems[0];
+            if (!picked) { finish(undefined); return; };
+            finish({ action: picked.action ?? 'edit', messageIndex: picked.messageIndex });
+        });
+        quickPick.onDidHide(() => {
+            finish(undefined);
+            quickPick.dispose();
+        });
+
+        quickPick.show();
+    });
+};
+
+/**
+ * Removes just one existing error message (the summary menu's trash-button action, or the first
+ * step of editing one), using the same precise keyword-text removal as single-attribute deletion —
+ * only this message's own text is stripped from its line(s), leaving sibling keywords and other
+ * messages untouched.
+ * @param editor - The active text editor
+ * @param field - The DDS field the message belongs to
+ * @param message - The existing message to remove (must carry `raw`/`lineIndex`/`lastLineIndex`)
+ * @param silent - Suppresses the cursor nudge + confirmation message (used when immediately
+ * re-adding a replacement as part of "edit")
+ */
+async function removeOneErrorMessage(
+    editor: vscode.TextEditor,
+    field: any,
+    message: ErrorMessageConfig,
+    silent: boolean = false
+): Promise<boolean> {
+    if (message.raw === undefined || message.lineIndex === undefined || message.lastLineIndex === undefined) {
+        return false;
+    };
+
+    const preserveFirstLine = message.lineIndex === field.lineIndex;
+    if (!(await removeKeywordTextFromLines(editor, message.lineIndex, message.lastLineIndex, message.raw, preserveFirstLine))) {
+        return false;
+    };
+
+    if (!silent) {
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
+        vscode.window.showInformationMessage(`Removed error message (indicator ${message.indicator}) from field '${field.name}'.`);
+    };
+    return true;
+};
+
+/**
+ * Collects a changed error message, prefilled with its current indicator/text/response indicator.
+ * @param current - The message's current value
+ */
+async function collectOneErrorMessage(current: ErrorMessageConfig): Promise<ErrorMessageConfig | null> {
+    const indicator = await collectIndicatorForErrorMessage(current.indicator);
+    if (!indicator) return null;
+
+    const messageText = await collectErrorMessageText(current.messageText);
+    if (!messageText) return null;
+
+    const useResponseIndicator = await askUseResponseIndicator(current.useResponseIndicator);
+    if (useResponseIndicator === undefined) return null;
+
+    let responseIndicator: string | undefined | null;
+    if (useResponseIndicator) {
+        responseIndicator = await collectResponseIndicator(indicator, current.responseIndicator);
+        if (!responseIndicator) return null;
+    };
+    if (responseIndicator === null) responseIndicator = undefined;
+
+    return { indicator, messageText, responseIndicator, useResponseIndicator };
 };
 
 // USER INTERACTION FUNCTIONS
@@ -240,12 +396,14 @@ async function collectErrorMessagesFromUser(): Promise<ErrorMessageConfig[]> {
 
 /**
  * Collects conditioning indicator for an error message.
+ * @param current - The message's current indicator, when changing an existing one
  * @returns Selected indicator or null if cancelled
  */
-async function collectIndicatorForErrorMessage(): Promise<string | null> {
+async function collectIndicatorForErrorMessage(current?: string): Promise<string | null> {
     const indicator = await vscode.window.showInputBox({
         title: 'Error Message Indicator',
         prompt: 'Enter the indicator that will trigger this error message (01-99)',
+        value: current,
         placeHolder: '31',
         validateInput: (value: string) => {
             if (!value.trim()) return 'Indicator is required';
@@ -265,12 +423,14 @@ async function collectIndicatorForErrorMessage(): Promise<string | null> {
 
 /**
  * Collects error message text from user.
+ * @param current - The message's current text, when changing an existing one
  * @returns Message text or null if cancelled
  */
-async function collectErrorMessageText(): Promise<string | null> {
+async function collectErrorMessageText(current?: string): Promise<string | null> {
     const messageText = await vscode.window.showInputBox({
         title: 'Error Message Text',
         prompt: 'Enter the error message text to display',
+        value: current,
         placeHolder: 'No stock available',
         validateInput: validateErrorMessageText
     });
@@ -305,9 +465,10 @@ function validateErrorMessageText(value: string): string | null {
 
 /**
  * Asks user if they want to use a response indicator.
+ * @param current - Whether the message currently uses one, when changing an existing message
  * @returns true if yes, false if no, undefined if cancelled
  */
-async function askUseResponseIndicator(): Promise<boolean | undefined> {
+async function askUseResponseIndicator(current?: boolean): Promise<boolean | undefined> {
     const choice = await vscode.window.showQuickPick(
         [
             {
@@ -322,7 +483,7 @@ async function askUseResponseIndicator(): Promise<boolean | undefined> {
             }
         ],
         {
-            title: 'Response Indicator',
+            title: current !== undefined ? `Response Indicator (current: ${current ? 'used' : 'not used'})` : 'Response Indicator',
             placeHolder: 'Choose whether to use a response indicator'
         }
     );
@@ -334,13 +495,14 @@ async function askUseResponseIndicator(): Promise<boolean | undefined> {
 /**
  * Collects response indicator from user.
  * @param optionIndicator - The option indicator for reference
+ * @param current - The message's current response indicator, when changing an existing one
  * @returns Response indicator or null if cancelled
  */
-async function collectResponseIndicator(optionIndicator: string): Promise<string | null> {
+async function collectResponseIndicator(optionIndicator: string, current?: string): Promise<string | null> {
     const responseIndicator = await vscode.window.showInputBox({
         title: 'Response Indicator',
         prompt: `Enter response indicator (typically same as option indicator: ${optionIndicator})`,
-        value: optionIndicator, // Default to same as option indicator
+        value: current ?? optionIndicator, // Default to same as option indicator
         placeHolder: optionIndicator,
         validateInput: (value: string) => {
             if (!value.trim()) return 'Response indicator is required';

--- a/src/dspf-edit.commands/dspf-edit.add-indicators.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-indicators.ts
@@ -29,6 +29,13 @@ interface IndicatorLineSpec {
     marker: ' ' | 'O';
 };
 
+/** One row of the indicators summary menu: an existing OR'd AND-group (`groupIndex` into the
+ * current condition), or one of the two trailing action rows. */
+interface IndicatorMenuItem extends vscode.QuickPickItem {
+    groupIndex: number;
+    action?: 'addOr' | 'removeAll';
+};
+
 // CONSTANTS
 
 /** DDS indicator slots per line (positions 8-16: three 3-character slots). */
@@ -104,22 +111,14 @@ async function handleAddIndicatorsCommand(node: DdsNode): Promise<void> {
         // Read the element's full condition: every OR'd AND-group, including continuation lines
         const { groups } = findIndicatorConditionBlock(editor, node.ddsElement.lineIndex);
 
-        let action: string | undefined;
+        // Show a summary menu — one row per existing OR'd condition, editable/removable
+        // individually — instead of the old flat "Add AND/Add OR/Modify/Remove a group/Replace
+        // all/Remove all" 6-choice picker.
         if (groups.length > 0) {
-            const options = ['Add AND indicator', 'Add OR condition', 'Modify existing indicators'];
-            if (groups.length > 1) {
-                options.push('Remove a group');
-            };
-            options.push('Replace all indicators', 'Remove all indicators');
+            const choice = await showIndicatorMenu(buildIndicatorMenuItems(groups), elementName);
+            if (!choice) return;
 
-            action = await vscode.window.showQuickPick(options, {
-                title: `Current condition: ${formatGroupsSummary(groups)}`,
-                placeHolder: 'Choose how to manage indicators'
-            });
-
-            if (!action) return;
-
-            if (action === 'Remove all indicators') {
+            if (choice.action === 'removeAll') {
                 if (!(await applyGroupsToElement(editor, node.ddsElement, []))) {
                     return;
                 };
@@ -128,11 +127,8 @@ async function handleAddIndicatorsCommand(node: DdsNode): Promise<void> {
                 return;
             };
 
-            if (action === 'Remove a group') {
-                const groupToRemove = await pickGroupIndex(groups, 'Select the OR condition to remove');
-                if (groupToRemove === undefined) return;
-
-                const remaining = groups.filter((_, i) => i !== groupToRemove);
+            if (choice.action === 'remove') {
+                const remaining = groups.filter((_, i) => i !== choice.groupIndex);
                 if (!(await applyGroupsToElement(editor, node.ddsElement, remaining))) {
                     return;
                 };
@@ -141,59 +137,33 @@ async function handleAddIndicatorsCommand(node: DdsNode): Promise<void> {
                 return;
             };
 
-            if (action === 'Modify existing indicators') {
-                if (!(await modifyExistingIndicators(editor, node.ddsElement, groups))) {
+            if (choice.action === 'edit') {
+                if (!(await modifyGroup(editor, node.ddsElement, groups, choice.groupIndex))) {
                     return;
                 };
                 await refreshEditorView();
                 return;
             };
 
-            if (action === 'Add OR condition') {
-                if (groups.length >= MAX_OR_CONDITIONS) {
-                    vscode.window.showWarningMessage(`Maximum of ${MAX_OR_CONDITIONS} OR'd conditions reached (DDS limit).`);
-                    return;
-                };
-                const newGroup = await collectIndicatorsFromUser(MAX_AND_INDICATORS);
-                if (newGroup.length === 0) {
-                    vscode.window.showInformationMessage('No indicators selected.');
-                    return;
-                };
-                if (!(await applyGroupsToElement(editor, node.ddsElement, [...groups, newGroup]))) {
-                    return;
-                };
-                await refreshEditorView();
-                vscode.window.showInformationMessage(`Added OR condition (${formatIndicatorsSummary(newGroup)}) to ${elementName}.`);
+            // choice.action === 'addOr'
+            if (groups.length >= MAX_OR_CONDITIONS) {
+                vscode.window.showWarningMessage(`Maximum of ${MAX_OR_CONDITIONS} OR'd conditions reached (DDS limit).`);
                 return;
             };
-
-            if (action === 'Add AND indicator') {
-                const groupIndex = groups.length === 1 ? 0 : await pickGroupIndex(groups, 'Add to which OR condition?');
-                if (groupIndex === undefined) return;
-
-                if (groups[groupIndex].length >= MAX_AND_INDICATORS) {
-                    vscode.window.showWarningMessage(`Maximum of ${MAX_AND_INDICATORS} ANDed indicators reached (DDS limit).`);
-                    return;
-                };
-                const newIndicators = await collectIndicatorsFromUser(MAX_AND_INDICATORS - groups[groupIndex].length);
-                if (newIndicators.length === 0) {
-                    vscode.window.showInformationMessage('No indicators selected.');
-                    return;
-                };
-                const updatedGroups = groups.map((g, i) => i === groupIndex ? [...g, ...newIndicators] : g);
-                if (!(await applyGroupsToElement(editor, node.ddsElement, updatedGroups))) {
-                    return;
-                };
-                await refreshEditorView();
-                vscode.window.showInformationMessage(`Added indicators (${formatIndicatorsSummary(newIndicators)}) to ${elementName}.`);
+            const newGroup = await collectIndicatorsFromUser(MAX_AND_INDICATORS);
+            if (newGroup.length === 0) {
+                vscode.window.showInformationMessage('No indicators selected.');
                 return;
             };
-
-            // action === 'Replace all indicators': falls through to collect a fresh condition below,
-            // replacing whatever was there in a single edit (nothing is touched until it's confirmed).
+            if (!(await applyGroupsToElement(editor, node.ddsElement, [...groups, newGroup]))) {
+                return;
+            };
+            await refreshEditorView();
+            vscode.window.showInformationMessage(`Added OR condition (${formatIndicatorsSummary(newGroup)}) to ${elementName}.`);
+            return;
         };
 
-        // No condition yet, or replacing: collect a single fresh AND group.
+        // No condition yet: collect a single fresh AND group.
         const newGroup = await collectIndicatorsFromUser(MAX_AND_INDICATORS);
         if (newGroup.length === 0) {
             vscode.window.showInformationMessage('No indicators selected.');
@@ -225,19 +195,78 @@ function elementDisplayName(element: any): string {
     return (element.kind === 'constant' || element.kind === 'field') ? element.name : 'attribute';
 };
 
+// INDICATORS SUMMARY MENU
+
+const EDIT_BUTTON: vscode.QuickInputButton = { iconPath: new vscode.ThemeIcon('edit'), tooltip: 'Modify' };
+const REMOVE_BUTTON: vscode.QuickInputButton = { iconPath: new vscode.ThemeIcon('trash'), tooltip: 'Remove' };
+
 /**
- * Asks the user to pick one of an element's OR'd AND-groups.
- * @param groups - The element's current OR'd AND-groups
- * @param title - QuickPick title
- * @returns The chosen group's index, or undefined if cancelled
+ * Builds the indicators summary menu's rows: one per existing OR'd AND-group (formatted as e.g.
+ * "51, N61, 53", with edit + trash buttons), plus an "Add OR condition..." row, plus a "Remove all"
+ * row when there's more than one group (with just one, its own trash button already does the same
+ * thing).
+ * @param groups - The element's current OR'd AND-groups, from `findIndicatorConditionBlock`
  */
-async function pickGroupIndex(groups: IndicatorAssignment[][], title: string): Promise<number | undefined> {
-    const items = groups.map((group, index) => ({
-        label: `Condition ${index + 1}: ${formatIndicatorsSummary(group)}`,
-        index
+function buildIndicatorMenuItems(groups: IndicatorAssignment[][]): IndicatorMenuItem[] {
+    const items: IndicatorMenuItem[] = groups.map((group, index) => ({
+        groupIndex: index,
+        label: groups.length > 1 ? `Condition ${index + 1}: ${formatIndicatorsSummary(group)}` : formatIndicatorsSummary(group),
+        buttons: [EDIT_BUTTON, REMOVE_BUTTON]
     }));
-    const picked = await vscode.window.showQuickPick(items, { title, placeHolder: 'Choose a condition' });
-    return picked?.index;
+
+    items.push({ groupIndex: -1, action: 'addOr', label: '$(add) Add OR condition...' });
+
+    if (groups.length > 1) {
+        items.push({ groupIndex: -1, action: 'removeAll', label: '$(trash) Remove all indicators' });
+    };
+
+    return items;
+};
+
+/**
+ * Shows the indicators summary menu and resolves to what the user did: picked a row (or its edit
+ * button) to modify that OR'd condition (`action: 'edit'`), clicked a row's trash button to remove
+ * just that one (`action: 'remove'`), or picked one of the trailing action rows
+ * (`'addOr'`/`'removeAll'`) — undefined if dismissed. Needs the raw `createQuickPick` API rather
+ * than the simpler `showQuickPick` helper, since only it exposes per-item buttons
+ * (`onDidTriggerItemButton`).
+ * @param items - The menu's rows, from `buildIndicatorMenuItems`
+ * @param elementName - The element's name, for the menu's title
+ */
+function showIndicatorMenu(
+    items: IndicatorMenuItem[],
+    elementName: string
+): Promise<{ action: 'edit' | 'remove' | 'addOr' | 'removeAll'; groupIndex: number } | undefined> {
+    return new Promise(resolve => {
+        const quickPick = vscode.window.createQuickPick<IndicatorMenuItem>();
+        quickPick.items = items;
+        quickPick.title = `Indicators for ${elementName}`;
+        quickPick.placeholder = 'Select a condition to modify, use its buttons, or add an OR condition';
+        quickPick.ignoreFocusOut = true;
+
+        let settled = false;
+        const finish = (result: { action: 'edit' | 'remove' | 'addOr' | 'removeAll'; groupIndex: number } | undefined) => {
+            if (settled) return;
+            settled = true;
+            resolve(result);
+            quickPick.hide();
+        };
+
+        quickPick.onDidTriggerItemButton(event => {
+            finish({ action: event.button === REMOVE_BUTTON ? 'remove' : 'edit', groupIndex: event.item.groupIndex });
+        });
+        quickPick.onDidAccept(() => {
+            const picked = quickPick.selectedItems[0];
+            if (!picked) { finish(undefined); return; };
+            finish({ action: picked.action ?? 'edit', groupIndex: picked.groupIndex });
+        });
+        quickPick.onDidHide(() => {
+            finish(undefined);
+            quickPick.dispose();
+        });
+
+        quickPick.show();
+    });
 };
 
 // INLINE ATTRIBUTE HANDLING
@@ -489,17 +518,6 @@ function formatIndicatorsSummary(indicators: IndicatorAssignment[]): string {
     return indicators.map(ind => `${ind.isNegated ? 'N' : ''}${ind.value}`).join(', ');
 };
 
-/**
- * Formats a full condition — one or more OR'd AND-groups — into a readable summary string.
- * @param groups - The element's OR'd AND-groups
- * @returns Formatted summary string, e.g. "51, N61, 53  OR  52  OR  81, 82"
- */
-function formatGroupsSummary(groups: IndicatorAssignment[][]): string {
-    if (groups.length === 0) return 'None';
-
-    return groups.map(formatIndicatorsSummary).join('  OR  ');
-};
-
 // USER INTERACTION FUNCTIONS
 
 /**
@@ -560,21 +578,20 @@ async function collectIndicatorsFromUser(maxIndicators: number = MAX_AND_INDICAT
 };
 
 /**
- * Modifies an element's existing indicator condition. When it spans more than one OR'd group, asks
- * which one to work on first; a single group (the common case) skips straight to the per-indicator
- * flow below, unchanged from before OR support existed.
+ * Modifies one of an element's OR'd AND-groups — which one is already chosen (its summary menu
+ * row), so this goes straight to the per-indicator flow: add a new indicator, change or remove an
+ * existing one, or clear the whole group and start over.
  * @param editor - The active text editor
  * @param element - The DDS element
  * @param groups - The element's current OR'd AND-groups
+ * @param groupIndex - Which group to modify
  */
-async function modifyExistingIndicators(
+async function modifyGroup(
     editor: vscode.TextEditor,
     element: any,
-    groups: IndicatorAssignment[][]
+    groups: IndicatorAssignment[][],
+    groupIndex: number
 ): Promise<boolean> {
-    const groupIndex = groups.length === 1 ? 0 : await pickGroupIndex(groups, 'Which OR condition do you want to modify?');
-    if (groupIndex === undefined) return true;
-
     const currentIndicators = groups[groupIndex];
     const indicatorChoices = currentIndicators.map((indicator, index) =>
         `Position ${index + 1}: ${indicator.isNegated ? 'N' : ''}${indicator.value}`

--- a/src/dspf-edit.commands/dspf-edit.add-validity-check.ts
+++ b/src/dspf-edit.commands/dspf-edit.add-validity-check.ts
@@ -7,13 +7,19 @@
 import * as vscode from 'vscode';
 import { DdsNode } from '../dspf-edit.providers/dspf-edit.providers';
 import { fieldsPerRecords } from '../dspf-edit.model/dspf-edit.model';
-import { isAttributeLine, findElementInsertionPoint, checkForEditorAndDocument, groupConsecutiveLines, applyWorkspaceEdit } from '../dspf-edit.utils/dspf-edit.helper';
+import { findElementInsertionPoint, checkForEditorAndDocument, applyWorkspaceEdit, removeKeywordTextFromLines } from '../dspf-edit.utils/dspf-edit.helper';
 
 // INTERFACES AND TYPES
 
 interface ValidityCheck {
     type: 'RANGE' | 'COMP' | 'VALUES';
     parameters: string[];
+    /** The keyword's own text exactly as parsed (e.g. "VALUES(1 2 3)") and its line range — only
+     * set for an existing check read off the field, used to locate/remove it precisely without
+     * disturbing sibling keywords. */
+    raw?: string;
+    lineIndex?: number;
+    lastLineIndex?: number;
 };
 
 interface CompParameters {
@@ -21,11 +27,16 @@ interface CompParameters {
     value: string;
 };
 
+/** One row of the validity-check summary menu — one of the 3 mutually exclusive check types. */
+interface ValidityCheckMenuItem extends vscode.QuickPickItem {
+    checkType: 'RANGE' | 'COMP' | 'VALUES';
+};
+
 // COMMAND REGISTRATION
 
 /**
  * Registers the add validity check command for DDS fields.
- * Allows users to interactively manage validity checks for fields.
+ * Allows users to interactively manage the validity check for fields.
  * @param context - The VS Code extension context
  */
 export function addValidityCheck(context: vscode.ExtensionContext): void {
@@ -39,8 +50,14 @@ export function addValidityCheck(context: vscode.ExtensionContext): void {
 // COMMAND HANDLER
 
 /**
- * Handles the add validity check command for a DDS field.
- * Manages existing validity checks and allows adding/removing checks.
+ * Handles the add validity check command for a DDS field. RANGE, COMP and VALUES are mutually
+ * exclusive in DDS — the manual is explicit that COMP allows "only one COMP keyword for a field",
+ * and lists COMP/RANGE/VALUES as unable to coexist with each other or with a CHECK(VN/VNE/...)
+ * keyword — so a field has at most one validity check at a time, never several to manage as a list.
+ * Shows a 3-row summary menu (RANGE/COMP/VALUES) with whichever one is currently set, letting the
+ * user jump straight to setting/changing it or removing it directly via its own trash button;
+ * setting a different type than the one currently in effect replaces it, the same way EDTCDE and
+ * EDTWRD replace each other in the editing-keywords command.
  * @param node - The DDS node containing the field
  */
 async function handleAddValidityCheckCommand(node: DdsNode): Promise<void> {
@@ -63,39 +80,6 @@ async function handleAddValidityCheckCommand(node: DdsNode): Promise<void> {
             return;
         };
 
-        // Get current validity checks from the field
-        const currentValidityChecks = getCurrentValidityChecksForField(node.ddsElement);
-
-        // Show current validity checks if any exist
-        if (currentValidityChecks.length > 0) {
-            const currentChecksList = currentValidityChecks.map(vc =>
-                `${vc.type}(${vc.parameters.join(' ')})`
-            ).join(', ');
-
-            const action = await vscode.window.showQuickPick(
-                ['Add more validity checks', 'Replace all validity checks', 'Remove all validity checks'],
-                {
-                    title: `Current validity checks: ${currentChecksList}`,
-                    placeHolder: 'Choose how to manage validity checks'
-                }
-            );
-
-            if (!action) return;
-
-            if (action === 'Remove all validity checks') {
-                await removeValidityChecksFromField(editor, node.ddsElement);
-                return;
-            };
-
-            if (action === 'Replace all validity checks') {
-                if (!(await removeValidityChecksFromField(editor, node.ddsElement))) {
-                    return;
-                };
-                // Continue to add new validity checks
-            };
-            // If "Add more validity checks", continue with current logic
-        };
-
         // Get field information to determine valid options
         const fieldInfo = getFieldInfo(node.ddsElement);
         if (!fieldInfo) {
@@ -103,27 +87,48 @@ async function handleAddValidityCheckCommand(node: DdsNode): Promise<void> {
             return;
         };
 
-        // Collect new validity checks to add
-        const selectedValidityChecks = await collectValidityChecksFromUser(fieldInfo);
+        // A field can have at most one of RANGE/COMP/VALUES — if the source somehow has more than
+        // one (invalid DDS), only the first one found is treated as "current".
+        const current = getCurrentValidityCheckForField(node.ddsElement);
 
-        if (selectedValidityChecks.length === 0) {
-            vscode.window.showInformationMessage('No validity checks selected.');
-            return;
+        let checkType: ValidityCheck['type'];
+
+        if (current) {
+            const choice = await showValidityCheckMenu(buildValidityCheckMenuItems(current), node.ddsElement.name);
+            if (!choice) return;
+
+            if (choice.action === 'remove') {
+                await removeOneValidityCheck(editor, node.ddsElement, current);
+                return;
+            };
+            checkType = choice.checkType;
+        } else {
+            const selectedType = await vscode.window.showQuickPick(
+                ['RANGE - Validation range', 'COMP - Value comparison', 'VALUES - Valid values list'],
+                {
+                    title: `Add Validity Check for ${node.ddsElement.name}`,
+                    placeHolder: 'Select validity check type'
+                }
+            );
+            if (!selectedType) return;
+            checkType = selectedType.split(' - ')[0] as ValidityCheck['type'];
         };
 
-        // Apply the selected validity checks to the field
-        if (!(await addValidityChecksToField(editor, node.ddsElement, selectedValidityChecks))) {
-            return;
+        // Collect the check's parameters, prefilled with the current value when the user picked
+        // the same type that's already set (i.e. they're changing it, not switching types).
+        const newCheck = await collectOneValidityCheck(checkType, fieldInfo, current?.type === checkType ? current : undefined);
+        if (!newCheck) return;
+
+        // Replace whatever check currently exists (of any of the 3 types) with the new one.
+        if (current) {
+            if (!(await removeOneValidityCheck(editor, node.ddsElement, current, true))) return;
         };
+        if (!(await addValidityCheckToField(editor, node.ddsElement, newCheck))) return;
         await vscode.commands.executeCommand('cursorRight');
         await vscode.commands.executeCommand('cursorLeft');
 
-        const checksSummary = selectedValidityChecks.map(vc =>
-            `${vc.type}(${vc.parameters.join(' ')})`
-        ).join(', ');
-
         vscode.window.showInformationMessage(
-            `Added validity checks ${checksSummary} to ${node.ddsElement.name}.`
+            `Set validity check ${formatValidityCheck(newCheck)} on ${node.ddsElement.name}.`
         );
 
     } catch (error) {
@@ -132,58 +137,162 @@ async function handleAddValidityCheckCommand(node: DdsNode): Promise<void> {
     };
 };
 
-// VALIDITY CHECKS EXTRACTION FUNCTIONS
+// VALIDITY CHECK EXTRACTION FUNCTIONS
 
 /**
- * Extracts current validity checks from a DDS field.
+ * Extracts the field's current validity check, if any — RANGE, COMP and VALUES are mutually
+ * exclusive in DDS, so at most one of them is ever in effect.
  * @param element - The DDS field element
- * @returns Array of current validity checks
+ * @returns The current validity check, or undefined if none is set
  */
-function getCurrentValidityChecksForField(element: any): ValidityCheck[] {
+function getCurrentValidityCheckForField(element: any): ValidityCheck | undefined {
     // Find the field in the fieldsPerRecords data
     const recordInfo = fieldsPerRecords.find(r => r.record === element.recordname);
-    if (!recordInfo) return [];
+    if (!recordInfo) return undefined;
 
     const fieldInfo = recordInfo.fields.find(field => field.name === element.name);
-    if (!fieldInfo || !fieldInfo.attributes) return [];
+    if (!fieldInfo || !fieldInfo.attributes) return undefined;
 
-    // Extract validity check attributes
-    const validityChecks: ValidityCheck[] = [];
-    
-    fieldInfo.attributes.forEach(attrObj => {
+    for (const attrObj of fieldInfo.attributes) {
         const attr = attrObj.value;
-        // Check for RANGE
-        const rangeMatch = attr.match(/^RANGE\(([^)]+)\)$/);
-        if (rangeMatch) {
-            const params = rangeMatch[1].split(' ').filter(p => p.trim());
-            validityChecks.push({
-                type: 'RANGE',
-                parameters: params
-            });
+        const match = attr.match(/^(RANGE|COMP|VALUES)\(([^)]+)\)$/);
+        if (!match) continue;
+
+        return {
+            type: match[1] as ValidityCheck['type'],
+            parameters: match[2].split(' ').filter(p => p.trim()),
+            raw: attr,
+            lineIndex: attrObj.lineIndex,
+            lastLineIndex: attrObj.lastLineIndex
+        };
+    };
+
+    return undefined;
+};
+
+// VALIDITY CHECK SUMMARY MENU
+
+/** Formats a validity check exactly as it reads in DDS source, e.g. "VALUES(0 1 2)". */
+function formatValidityCheck(vc: ValidityCheck): string {
+    return `${vc.type}(${vc.parameters.join(' ')})`;
+};
+
+const EDIT_BUTTON: vscode.QuickInputButton = { iconPath: new vscode.ThemeIcon('edit'), tooltip: 'Set/change' };
+const REMOVE_BUTTON: vscode.QuickInputButton = { iconPath: new vscode.ThemeIcon('trash'), tooltip: 'Remove' };
+
+/**
+ * Builds the validity-check summary menu's 3 rows (RANGE/COMP/VALUES), each showing its currently
+ * assigned value (formatted exactly as it'd read in the DDS source, e.g. "VALUES(0 1 2)") or
+ * "(not set)" for the other two — mirroring the editing-keywords command's summary menu for another
+ * mutually exclusive keyword group (EDTCDE/EDTWRD).
+ * @param current - The field's current validity check
+ */
+function buildValidityCheckMenuItems(current: ValidityCheck): ValidityCheckMenuItem[] {
+    const row = (type: ValidityCheck['type'], label: string): ValidityCheckMenuItem => {
+        const isCurrent = current.type === type;
+        return {
+            checkType: type,
+            label,
+            description: isCurrent ? formatValidityCheck(current) : '(not set)',
+            buttons: isCurrent ? [EDIT_BUTTON, REMOVE_BUTTON] : [EDIT_BUTTON]
+        };
+    };
+
+    return [
+        row('RANGE', 'RANGE — Validation range'),
+        row('COMP', 'COMP — Value comparison'),
+        row('VALUES', 'VALUES — Valid values list')
+    ];
+};
+
+/**
+ * Shows the validity-check summary menu and resolves to what the user did: picked a row (or its
+ * edit button) to set/change it (`action: 'select'`), or clicked the current row's trash button to
+ * remove it (`action: 'remove'`) — undefined if dismissed. Needs the raw `createQuickPick` API
+ * rather than the simpler `showQuickPick` helper, since only it exposes per-item buttons
+ * (`onDidTriggerItemButton`).
+ * @param items - The menu's rows, from `buildValidityCheckMenuItems`
+ * @param fieldName - The field's name, for the menu's title
+ */
+function showValidityCheckMenu(
+    items: ValidityCheckMenuItem[],
+    fieldName: string
+): Promise<{ action: 'select' | 'remove'; checkType: ValidityCheck['type'] } | undefined> {
+    return new Promise(resolve => {
+        const quickPick = vscode.window.createQuickPick<ValidityCheckMenuItem>();
+        quickPick.items = items;
+        quickPick.title = `Validity check for ${fieldName}`;
+        quickPick.placeholder = 'RANGE, COMP and VALUES are mutually exclusive — setting one replaces any other';
+        quickPick.ignoreFocusOut = true;
+
+        let settled = false;
+        const finish = (result: { action: 'select' | 'remove'; checkType: ValidityCheck['type'] } | undefined) => {
+            if (settled) return;
+            settled = true;
+            resolve(result);
+            quickPick.hide();
         };
 
-        // Check for COMP
-        const compMatch = attr.match(/^COMP\(([^)]+)\)$/);
-        if (compMatch) {
-            const params = compMatch[1].split(' ').filter(p => p.trim());
-            validityChecks.push({
-                type: 'COMP',
-                parameters: params
-            });
-        };
+        quickPick.onDidTriggerItemButton(event => {
+            finish({ action: event.button === REMOVE_BUTTON ? 'remove' : 'select', checkType: event.item.checkType });
+        });
+        quickPick.onDidAccept(() => {
+            const picked = quickPick.selectedItems[0];
+            finish(picked ? { action: 'select', checkType: picked.checkType } : undefined);
+        });
+        quickPick.onDidHide(() => {
+            finish(undefined);
+            quickPick.dispose();
+        });
 
-        // Check for VALUES
-        const valuesMatch = attr.match(/^VALUES\(([^)]+)\)$/);
-        if (valuesMatch) {
-            const params = valuesMatch[1].split(' ').filter(p => p.trim());
-            validityChecks.push({
-                type: 'VALUES',
-                parameters: params
-            });
-        };
+        quickPick.show();
     });
+};
 
-    return validityChecks;
+/**
+ * Removes the field's current validity check (the summary menu's trash-button action, or the first
+ * step of changing it), using the same precise keyword-text removal as single-attribute deletion —
+ * only this check's own text is stripped from its line(s), leaving sibling keywords untouched.
+ * @param editor - The active text editor
+ * @param element - The DDS field the check belongs to
+ * @param check - The existing check to remove (must carry `raw`/`lineIndex`/`lastLineIndex`)
+ * @param silent - Suppresses the cursor nudge + confirmation message (used when immediately
+ * re-adding a replacement as part of "change")
+ */
+async function removeOneValidityCheck(
+    editor: vscode.TextEditor,
+    element: any,
+    check: ValidityCheck,
+    silent: boolean = false
+): Promise<boolean> {
+    if (check.raw === undefined || check.lineIndex === undefined || check.lastLineIndex === undefined) {
+        return false;
+    };
+
+    const preserveFirstLine = check.lineIndex === element.lineIndex;
+    if (!(await removeKeywordTextFromLines(editor, check.lineIndex, check.lastLineIndex, check.raw, preserveFirstLine))) {
+        return false;
+    };
+
+    if (!silent) {
+        await vscode.commands.executeCommand('cursorRight');
+        await vscode.commands.executeCommand('cursorLeft');
+        vscode.window.showInformationMessage(`Removed validity check ${formatValidityCheck(check)} from ${element.name}.`);
+    };
+    return true;
+};
+
+/**
+ * Collects a single validity check of a given type, prefilled with its current value when changing
+ * an existing one of the same type.
+ * @param type - Which validity check type to collect
+ * @param fieldInfo - Field information to determine valid options
+ * @param current - The check's current value, when changing an existing one of this same type
+ */
+async function collectOneValidityCheck(type: ValidityCheck['type'], fieldInfo: any, current?: ValidityCheck): Promise<ValidityCheck | null> {
+    if (type === 'RANGE') return collectRangeParameters(fieldInfo, current);
+    if (type === 'COMP') return collectCompParameters(fieldInfo, current);
+    return collectValuesParameters(fieldInfo, current);
 };
 
 /**
@@ -201,56 +310,19 @@ function getFieldInfo(element: any): any {
 // USER INTERACTION FUNCTIONS
 
 /**
- * Collects validity checks from user through interactive selection.
- * @param fieldInfo - Field information to determine valid options
- * @returns Array of selected validity checks 
- */
-async function collectValidityChecksFromUser(fieldInfo: any): Promise<ValidityCheck[]> {
-    const selectedValidityChecks: ValidityCheck[] = [];
-
-    while (true) {
-        const availableOptions = ['RANGE - Validation range', 'COMP - Value comparison', 'VALUES - Valid values list', 'Finish adding checks'];
-        
-        const selectedOption = await vscode.window.showQuickPick(
-            availableOptions,
-            {
-                title: `Add Validity Check (${selectedValidityChecks.length} selected)`,
-                placeHolder: 'Select validity check type'
-            }
-        );
-
-        if (!selectedOption || selectedOption === 'Finish adding checks') break;
-
-        let validityCheck: ValidityCheck | null = null;
-
-        if (selectedOption.startsWith('RANGE')) {
-            validityCheck = await collectRangeParameters(fieldInfo);
-        } else if (selectedOption.startsWith('COMP')) {
-            validityCheck = await collectCompParameters(fieldInfo);
-        } else if (selectedOption.startsWith('VALUES')) {
-            validityCheck = await collectValuesParameters(fieldInfo);
-        };
-
-        if (validityCheck) {
-            selectedValidityChecks.push(validityCheck);
-        };
-    };
-
-    return selectedValidityChecks;
-};
-
-/**
  * Collects RANGE parameters from user.
  * @param fieldInfo - Field information
+ * @param current - The check's current from/to values, when changing an existing RANGE
  * @returns RANGE validity check or null if cancelled
  */
-async function collectRangeParameters(fieldInfo: any): Promise<ValidityCheck | null> {
+async function collectRangeParameters(fieldInfo: any, current?: ValidityCheck): Promise<ValidityCheck | null> {
     const fieldType = fieldInfo.type || 'A';
     const isNumeric = ['P', 'S', 'B', 'F', 'I'].includes(fieldType);
 
     const fromValue = await vscode.window.showInputBox({
         title: 'RANGE - From Value',
         prompt: `Enter the starting value for the range (Field type: ${fieldType})`,
+        value: current?.parameters[0],
         placeHolder: isNumeric ? 'e.g., 0, -100' : 'e.g., A, AA',
         validateInput: (value: string) => {
             if (!value.trim()) return 'From value is required';
@@ -263,6 +335,7 @@ async function collectRangeParameters(fieldInfo: any): Promise<ValidityCheck | n
     const toValue = await vscode.window.showInputBox({
         title: 'RANGE - To Value',
         prompt: `Enter the ending value for the range (Field type: ${fieldType})`,
+        value: current?.parameters[1],
         placeHolder: isNumeric ? 'e.g., 1000, 999' : 'e.g., Z, ZZ',
         validateInput: (value: string) => {
             if (!value.trim()) return 'To value is required';
@@ -281,9 +354,10 @@ async function collectRangeParameters(fieldInfo: any): Promise<ValidityCheck | n
 /**
  * Collects COMP parameters from user.
  * @param fieldInfo - Field information
+ * @param current - The check's current operator/value, when changing an existing COMP
  * @returns COMP validity check or null if cancelled
  */
-async function collectCompParameters(fieldInfo: any): Promise<ValidityCheck | null> {
+async function collectCompParameters(fieldInfo: any, current?: ValidityCheck): Promise<ValidityCheck | null> {
     const operators = [
         'EQ - Equal to',
         'NE - Not equal to',
@@ -298,7 +372,7 @@ async function collectCompParameters(fieldInfo: any): Promise<ValidityCheck | nu
     const selectedOperator = await vscode.window.showQuickPick(
         operators,
         {
-            title: 'COMP - Select Operator',
+            title: current ? `COMP - Select Operator (current: ${current.parameters[0]})` : 'COMP - Select Operator',
             placeHolder: 'Choose comparison operator'
         }
     );
@@ -310,6 +384,7 @@ async function collectCompParameters(fieldInfo: any): Promise<ValidityCheck | nu
     const value = await vscode.window.showInputBox({
         title: `COMP - Comparison Value (${operator})`,
         prompt: `Enter the value to compare against (Field type: ${fieldInfo.type || 'A'})`,
+        value: current?.parameters[1],
         placeHolder: 'e.g., 0, 100, A',
         validateInput: (value: string) => {
             if (!value.trim()) return 'Comparison value is required';
@@ -328,12 +403,14 @@ async function collectCompParameters(fieldInfo: any): Promise<ValidityCheck | nu
 /**
  * Collects VALUES parameters from user.
  * @param fieldInfo - Field information
+ * @param current - The check's current values list, when changing an existing VALUES
  * @returns VALUES validity check or null if cancelled
  */
-async function collectValuesParameters(fieldInfo: any): Promise<ValidityCheck | null> {
+async function collectValuesParameters(fieldInfo: any, current?: ValidityCheck): Promise<ValidityCheck | null> {
     const values = await vscode.window.showInputBox({
         title: 'VALUES - Valid Values List',
         prompt: `Enter valid values separated by spaces (Field type: ${fieldInfo.type || 'A'})`,
+        value: current?.parameters.join(' '),
         placeHolder: 'e.g., 0 1 2 or A B C',
         validateInput: (value: string) => {
             if (!value.trim()) return 'At least one valid value is required';
@@ -356,40 +433,35 @@ async function collectValuesParameters(fieldInfo: any): Promise<ValidityCheck | 
 // DDS MODIFICATION FUNCTIONS
 
 /**
- * Adds validity checks to a DDS field by inserting validity check lines after the field.
+ * Adds a validity check to a DDS field by inserting a validity check line after the field.
  * @param editor - The active text editor
- * @param element - The DDS field to add validity checks to
- * @param validityChecks - Array of validity checks to add
+ * @param element - The DDS field to add the validity check to
+ * @param validityCheck - The validity check to add
  */
-async function addValidityChecksToField(
+async function addValidityCheckToField(
     editor: vscode.TextEditor,
     element: any,
-    validityChecks: ValidityCheck[]
+    validityCheck: ValidityCheck
 ): Promise<boolean> {
     const insertionPoint = findElementInsertionPoint(editor, element);
     if (insertionPoint === -1) {
-        throw new Error('Could not find insertion point for validity checks');
+        throw new Error('Could not find insertion point for the validity check');
     };
 
     const workspaceEdit = new vscode.WorkspaceEdit();
     const uri = editor.document.uri;
 
-    // Insert each validity check line
-    let crInserted: boolean = false;
-    for (let i = 0; i < validityChecks.length; i++) {
-        const validityCheckLine = createValidityCheckLine(validityChecks[i]);
-        const insertPos = new vscode.Position(insertionPoint, 0);
-        if (!crInserted && insertPos.line >= editor.document.lineCount) {
-            workspaceEdit.insert(uri, insertPos, '\n');
-            crInserted = true;
-        };
-        workspaceEdit.insert(uri, insertPos, validityCheckLine);
-        if (i < validityChecks.length - 1 || insertPos.line < editor.document.lineCount) {
-            workspaceEdit.insert(uri, insertPos, '\n');
-        };
+    const validityCheckLine = createValidityCheckLine(validityCheck);
+    const insertPos = new vscode.Position(insertionPoint, 0);
+    if (insertPos.line >= editor.document.lineCount) {
+        workspaceEdit.insert(uri, insertPos, '\n');
+    };
+    workspaceEdit.insert(uri, insertPos, validityCheckLine);
+    if (insertPos.line < editor.document.lineCount) {
+        workspaceEdit.insert(uri, insertPos, '\n');
     };
 
-    return applyWorkspaceEdit(workspaceEdit, 'add the validity checks');
+    return applyWorkspaceEdit(workspaceEdit, 'add the validity check');
 };
 
 /**
@@ -408,140 +480,4 @@ function createValidityCheckLine(validityCheck: ValidityCheck): string {
     line += `${validityCheck.type}(${validityCheck.parameters.join(' ')})`;
 
     return line;
-};
-
-/**
- * Removes existing validity checks from a DDS field using precise character offsets.
- * Handles edge cases properly to avoid leaving blank lines at the end of the file.
- * @param editor - The active text editor
- * @param element - The DDS field to remove validity checks from
- */
-async function removeValidityChecksFromField(editor: vscode.TextEditor, element: any): Promise<boolean> {
-    const validityCheckLines = findExistingValidityCheckLines(editor, element);
-    if (validityCheckLines.length === 0) return true;
-
-    const document = editor.document;
-    const workspaceEdit = new vscode.WorkspaceEdit();
-    const uri = document.uri;
-
-    // Group lines by type: field line vs standalone validity check lines
-    const fieldLineIndex = element.lineIndex;
-    const standaloneValidityCheckLines = validityCheckLines.filter(lineIndex => lineIndex !== fieldLineIndex);
-    const hasFieldLineValidityCheck = validityCheckLines.includes(fieldLineIndex);
-
-    // Handle standalone validity check lines using precise offsets
-    if (standaloneValidityCheckLines.length > 0) {
-        const deletionRanges = calculateValidityCheckDeletionRanges(document, standaloneValidityCheckLines);
-        
-        // Apply deletions in reverse order to maintain offsets
-        for (let i = deletionRanges.length - 1; i >= 0; i--) {
-            const { startOffset, endOffset } = deletionRanges[i];
-            const startPos = document.positionAt(startOffset);
-            const endPos = document.positionAt(endOffset);
-            workspaceEdit.delete(uri, new vscode.Range(startPos, endPos));
-        };
-    };
-
-    // Handle validity check on field line (just remove the validity check part)
-    if (hasFieldLineValidityCheck) {
-        const line = document.lineAt(fieldLineIndex);
-        // Remove validity check keywords from the end of the line
-        const lineText = line.text;
-        const cleanedText = lineText.replace(/(RANGE|COMP|VALUES)\([^)]*\)/g, '').trimEnd();
-        workspaceEdit.replace(uri, line.range, cleanedText);
-    };
-
-    return applyWorkspaceEdit(workspaceEdit, 'remove the validity checks');
-};
-
-/**
- * Calculates precise deletion ranges for standalone validity check lines.
- * Handles edge cases to prevent blank lines at the end of the file.
- * @param document - The text document
- * @param validityCheckLines - Array of line indices containing standalone validity checks
- * @returns Array of deletion ranges with start and end offsets
- */
-function calculateValidityCheckDeletionRanges(
-    document: vscode.TextDocument, 
-    validityCheckLines: number[]
-): { startOffset: number; endOffset: number }[] {
-    const docText = document.getText();
-    const docLength = docText.length;
-    const ranges: { startOffset: number; endOffset: number }[] = [];
-    
-    // Group consecutive lines for more efficient deletion
-    const lineGroups = groupConsecutiveLines(validityCheckLines);
-    
-    for (const group of lineGroups) {
-        const firstLine = group[0];
-        const lastLine = group[group.length - 1];
-        
-        let startOffset: number;
-        let endOffset: number;
-        
-        if (lastLine === document.lineCount - 1) {
-            // Group includes the last line of the document
-            if (firstLine === 0) {
-                // Entire document is validity check lines - delete everything
-                startOffset = 0;
-                endOffset = docLength;
-            } else {
-                // Delete from end of previous line to end of file
-                const prevLineEndPos = document.lineAt(firstLine - 1).range.end;
-                startOffset = document.offsetAt(prevLineEndPos);
-                endOffset = docLength;
-            };
-        } else {
-            // Group is in the middle or at the beginning
-            startOffset = document.offsetAt(new vscode.Position(firstLine, 0));
-            
-            // Include the line break after the last line of the group
-            const afterGroupPos = document.lineAt(lastLine).rangeIncludingLineBreak.end;
-            endOffset = document.offsetAt(afterGroupPos);
-        };
-        
-        // Validate the range
-        if (startOffset < endOffset && startOffset >= 0 && endOffset <= docLength) {
-            ranges.push({ startOffset, endOffset });
-        };
-    };
-    
-    return ranges;
-};
-
-// LINE CREATION AND DETECTION FUNCTIONS
-
-/**
- * Finds existing validity check lines for a field.
- * @param editor - The active text editor
- * @param element - The DDS field
- * @returns Array of line indices containing validity checks
- */
-function findExistingValidityCheckLines(editor: vscode.TextEditor, element: any): number[] {
-    const validityCheckLines: number[] = [];
-    const startLine = element.lineIndex;
-
-    // Look for validity check lines after the field
-    for (let i = startLine; i < editor.document.lineCount; i++) {
-        const lineText = editor.document.lineAt(i).text;
-
-        // Special case: first line of a field can have validity checks
-        if (i === element.lineIndex) {
-            if (lineText.match(/(RANGE|COMP|VALUES)\(/)) {
-                validityCheckLines.push(i);
-            };
-            continue;
-        };
-
-        if (!lineText.trim().startsWith('A ') || !isAttributeLine(lineText)) {
-            break;
-        };
-
-        // Check if this is a validity check attribute
-        if (lineText.match(/(RANGE|COMP|VALUES)\(/)) {
-            validityCheckLines.push(i);
-        };
-    };
-
-    return validityCheckLines;
 };

--- a/src/dspf-edit.utils/dspf-edit.helper.ts
+++ b/src/dspf-edit.utils/dspf-edit.helper.ts
@@ -276,9 +276,13 @@ export function isAttributeLine(line: string): boolean {
     if (line.length > 16 && line[16] === 'R') {
         return false;
     };
-    // If there is a field, returns false    
+    // If there is a field, returns false
     const fieldName = line.substring(18, 27).trim();
     if (fieldName !== '') {
+        return false;
+    };
+    // If the line has its own row/col position, it starts a new constant, not a continuation
+    if (line.length > 43 && line.charAt(40) !== ' ' && line.charAt(43) !== ' ') {
         return false;
     };
 

--- a/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
@@ -1658,7 +1658,10 @@ export class RecordPreviewPanel {
      * Finds the record's currently-active ERRMSG() message, if any: an ERRMSG keyword (record-level,
      * or on one of the record's own fields/constants) whose own conditioning indicator is satisfied
      * by the indicator simulation — same gating already used for COLOR()/DSPATR() via isItemDisplayed.
-     * Shown on the display's message line (the bottom row) like a real 5250 error, in white.
+     * Falls back to the SFLCTL record's own SFLMSG() (a subfile message) when no ERRMSG is active,
+     * matching the DDS manual's stated priority (ERRMSG over SFLMSG) and its requirement that SFLDSP
+     * be in effect for SFLMSG to be processed. Shown on the display's message line (the bottom row)
+     * like a real 5250 error/subfile message, in white.
      */
     private resolveErrorMessage(recordInfo: FieldsPerRecord): { text: string } | null {
         const candidates: { value: string; indicators?: DdsIndicator[]; displayFormat?: string }[] = [
@@ -1667,14 +1670,25 @@ export class RecordPreviewPanel {
             ...recordInfo.constants.flatMap(constant => constant.attributes)
         ];
 
-        const forFormat = filterForActiveFormat(candidates, this.activeDisplayFormat);
-        for (const attr of forFormat) {
-            if (!this.isItemDisplayed(attr.indicators, this.indicatorsEnabled)) {
-                continue;
-            };
+        const displayed = filterForActiveFormat(candidates, this.activeDisplayFormat)
+            .filter(attr => this.isItemDisplayed(attr.indicators, this.indicatorsEnabled));
+
+        for (const attr of displayed) {
             const errmsgMatch = attr.value.match(/^ERRMSG\('([^']+)'\s*(\d{2})?\)$/);
             if (errmsgMatch) {
                 return { text: errmsgMatch[1] };
+            };
+        };
+
+        const recordAttrs = filterForActiveFormat(recordInfo.attributes ?? [], this.activeDisplayFormat);
+        const sflDsp = recordAttrs.find(attr => attr.value === 'SFLDSP');
+        const sflDspActive = sflDsp ? this.isItemDisplayed(sflDsp.indicators, this.indicatorsEnabled) : false;
+        if (sflDspActive) {
+            for (const attr of displayed) {
+                const sflmsgMatch = attr.value.match(/^SFLMSG\('([^']+)'\s*(\d{2})?\)$/);
+                if (sflmsgMatch) {
+                    return { text: sflmsgMatch[1] };
+                };
             };
         };
         return null;

--- a/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
+++ b/src/dspf-edit.webview/dspf-edit.record-preview-panel.ts
@@ -93,6 +93,10 @@ interface PreviewItem {
      */
     dataLength?: number;
     decimals?: number;
+    /** A field's RANGE()/COMP()/VALUES() validity checks, formatted as they read in DDS source
+     * (e.g. "VALUES(0 2 4 5 7 8)"), for display in the preview's selection bar. Undefined when the
+     * field has none, or for a constant. */
+    validityChecks?: string;
 };
 
 /** A rectangle in the coordinates of the canvas being drawn (the full display size). */
@@ -1428,7 +1432,8 @@ export class RecordPreviewPanel {
                     isResizable,
                     minLength,
                     dataLength: isReferenced ? undefined : effectiveLength,
-                    decimals: isReferenced ? undefined : effectiveDecimals
+                    decimals: isReferenced ? undefined : effectiveDecimals,
+                    validityChecks: this.formatValidityChecksForField(field.attributes)
                 };
 
                 // CNTFLD(n) wraps a field too long for one line across multiple rows, n characters
@@ -1642,6 +1647,22 @@ export class RecordPreviewPanel {
         };
 
         return result.sort((a, b) => parseInt(a.key.slice(1), 10) - parseInt(b.key.slice(1), 10));
+    };
+
+    /**
+     * Formats a field's RANGE()/COMP()/VALUES() validity checks for the preview's selection bar,
+     * exactly as they read in DDS source (e.g. "VALUES(0 2 4 5 7 8)"), joined with ", " when more
+     * than one is coded. Shown unconditionally (not gated by indicators, unlike DSPATR/COLOR/ERRMSG
+     * elsewhere in this file) since a validity check's own indicator only controls whether the check
+     * is *enforced*, not something the 5250 ever visibly toggles — the point here is just letting the
+     * user see what values the field accepts.
+     */
+    private formatValidityChecksForField(attributes: AttributeWithIndicators[]): string | undefined {
+        const checks = filterForActiveFormat(attributes, this.activeDisplayFormat)
+            .map(attr => attr.value)
+            .filter(value => /^(RANGE|COMP|VALUES)\([^)]+\)$/.test(value));
+
+        return checks.length > 0 ? checks.join(', ') : undefined;
     };
 
     /**
@@ -3380,6 +3401,9 @@ export class RecordPreviewPanel {
                 label = '1 constant selected — Pos= ' + item.row + ', ' + item.col + ', width ' + item.length;
             } else {
                 label = '1 field selected — Pos= ' + item.row + ', ' + item.col;
+            }
+            if (item.kind === 'field' && item.validityChecks) {
+                label += ' — ' + item.validityChecks;
             }
             selectionLabel.textContent = label;
         }


### PR DESCRIPTION
## [1.5.0] - 2026-09-09
### Added
- Preview: an active `SFLMSG()` on a subfile control record (SFLCTL) is now shown on the message line during indicator simulation, the same way `ERRMSG()` already is — respecting ERRMSG's priority over SFLMSG and requiring `SFLDSP` to be in effect, per the DDS reference.
- Preview: selecting a field with a validity check now also shows it (e.g. `VALUES(0 2 4 5 7 8)`) in the selection bar, alongside its name and position.
- Add Validity Check: replaced with a summary menu showing all three mutually exclusive keywords (RANGE/COMP/VALUES) and whichever one is currently set, each with its own change (✏️) and remove (🗑️) button — instead of the old "Add more/Replace all/Remove all" flow, which allowed invalid DDS (e.g. a duplicate `VALUES`, or `VALUES` together with `RANGE`). Setting one now automatically replaces whichever of the three is already in effect; changing an existing one pre-fills its current value.
- Add Error Messages: replaced with a summary menu listing every existing `ERRMSG`, each with its own change/remove buttons, plus "Add error message..." and "Remove all" — unlike validity checks, a field can legitimately carry several `ERRMSG`s, each gated by its own indicator.
- Add Indicators: replaced the flat "Add AND/Add OR/Modify/Remove a group/Replace all/Remove all" picker with a summary menu listing every OR'd condition, each with its own modify/remove buttons, plus "Add OR condition..." and "Remove all".
### Fixed
- Remove/Replace All Attributes (and the equivalent commands for colors, keys, error messages, and validity checks): removing/replacing on one constant could also strip attributes off unrelated constants later in the same record — the scan used to find where an element's attributes end didn't recognize the next constant's own row/column as a boundary.
